### PR TITLE
Modify simpoint flow 1 and its simulation based on SPEC

### DIFF
--- a/common/Dockerfile.common
+++ b/common/Dockerfile.common
@@ -78,5 +78,8 @@ RUN cd $tmpdir/ && \
     make -C SimPoint.3.2 && \
     ln -s SimPoint.3.2/bin/simpoint ./simpoint
 
+# disable ASLR
+RUN echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
+
 ENV DOCKER_BUILDKIT 1
 ENV COMPOSE_DOCKER_CLI_BUILD 1

--- a/run_clustering.sh
+++ b/run_clustering.sh
@@ -4,14 +4,21 @@ source /usr/local/bin/utilities.sh
 
 FPFILE=$1
 OUTDIR=$2
-
+# if specified, maxk will use the user provided value;
+# if not specified, maxk will be calculated as the square root of the number of segments
+USERK=${3:-0}
 cd $OUTDIR
 mkdir -p simpoints
 
-lines=($(wc -l $FPFILE))
-# intended to round to nearest int
-# but in fact it is just rouding down
-maxK=$(echo "(sqrt($lines)+0.5)/1" | bc)
+if [ "$USERK" == "0" ]; then
+    lines=($(wc -l $FPFILE))
+    # intended to round to nearest int
+    # but in fact it is just rouding down
+    maxK=$(echo "(sqrt($lines)+0.5)/1" | bc)
+else
+    maxK=$USERK
+fi
+
 echo "fingerprint size: $lines, maxk: $maxK"
 # binary search with maxK
 spCmd="$tmpdir/simpoint -maxK $maxK -fixedLength off -numInitSeeds 10 -loadFVFile $FPFILE -saveSimpoints $OUTDIR/simpoints/opt.p -saveSimpointWeights $OUTDIR/simpoints/opt.w -saveVectorWeights $OUTDIR/simpoints/vector.w -saveLabels $OUTDIR/simpoints/opt.l -coveragePct .99 &> $OUTDIR/simpoints/simp.opt.log"

--- a/run_exp_using_descriptor.py
+++ b/run_exp_using_descriptor.py
@@ -67,6 +67,9 @@ def run_experiment():
             if args.application_name == "allbench" or args.application_name == "isca2024":
                 if workload in ["602.gcc_s", "clang", "gcc", "mongodb", "mysql", "postgres", "verilator", "xgboost"]:
                     use_traces_simp = "1"
+                elif workload in ["500.perlbench_r", "502.gcc_r", "505.mcf_r", "520.omnetpp_r", "523.xalancbmk_r", "525.x264_r", "531.deepsjeng_r", "541.leela_r", "548.exchange2_r", "557.xz_r",
+                                "503.bwaves_r", "507.cactuBSSN_r", "508.namd_r", "510.parest_r", "511.povray_r", "519.lbm_r", "521.wrf_r", "526.blender_r", "527.cam4_r", "538.imagick_r", "544.nab_r", "549.fotonik3d_r", "554.roms_r"]:
+                    use_traces_simp = "2"
                 else:
                     use_traces_simp = "0"
                 command = 'run_scarab_allbench.sh "' + workload + '" "' + args.application_group_name + '" "" "' + experiment + '/' + config_key + '" "' + config_value + '" "' + args.scarab_mode + '" "' + architecture + '" "' + use_traces_simp + '"'

--- a/run_scarab_allbench.sh
+++ b/run_scarab_allbench.sh
@@ -131,6 +131,9 @@ if [ "$SCARABMODE" == "4" ]; then
   if [ "$TRACESSIMP" == "1" ]; then
     MODULESDIR=/simpoint_traces/$APPNAME/traces_simp/bin
     TRACEFILE=/simpoint_traces/$APPNAME/traces_simp/trace
+  elif [ "$TRACESSIMP" == "2" ]; then
+    MODULESDIR=/simpoint_traces/$APPNAME/traces_simp/
+    TRACEFILE=/simpoint_traces/$APPNAME/traces_simp/
   fi
 
   SIMHOME=$HOME/simpoint_flow/simulations/$APPNAME

--- a/run_scarab_mode_4_allbench.sh
+++ b/run_scarab_mode_4_allbench.sh
@@ -13,13 +13,13 @@ OUTDIR=$7
 WARMUPORG=$8
 SCARABARCH=$9
 
-# if TRACESSIMP is 1,
+# if TRACESSIMP is 1 or 2,
 # TRACEFILE is supposed to be traces_simp FOLDER
 TRACESSIMP=${10}
 
-if [ "$TRACESSIMP" == "1" ]; then
+if [ "$TRACESSIMP" == "1" ] || [ "$TRACESSIMP" == "2" ]; then
     if [ ! -d $TRACEFILE ]; then
-        echo "TRACEFILE is supposed to be traces_simp FOLDER"
+        echo "TRACEFILE is supposed to be a FOLDER"
         exit
     fi
 fi
@@ -65,7 +65,7 @@ do
 
     instLimit=$(( $roiEnd - $roiStart + 1 ))
 
-    if [ "$TRACESSIMP" != "1" ]; then
+    if [ "$TRACESSIMP" == "0" ]; then
         scarabCmd="$SCARABHOME/src/scarab \
         --frontend memtrace \
         --cbp_trace_r0=$TRACEFILE \
@@ -78,7 +78,7 @@ do
         $SCARABPARAMS \
         &> sim.log"
     elif [ "$TRACESSIMP" == "1" ]; then
-        # with TRACESSIMP
+        # with TRACESSIMP == 1
         # simultion uses the specific trace file
         # the roiStart is the second chunk, which is assumed to be segment size
         #### if chunk zero chunk is part of the simulation, the roiStart is the first chunk
@@ -111,7 +111,19 @@ do
             $SCARABPARAMS \
             &> sim.log"
         fi
-
+    elif [ "$TRACESSIMP" == "2" ]; then
+        # with TRACESSIMP == 2
+        # simultion always uses the specific trace file with no skip
+        # do not use fetch count
+        scarabCmd="$SCARABHOME/src/scarab \
+        --frontend memtrace \
+        --cbp_trace_r0=$TRACEFILE/$segID/trace/$segID.zip \
+        --memtrace_modules_log=$MODULESDIR/$segID/raw \
+        --inst_limit=$instLimit \
+        --full_warmup=$WARMUP \
+        --use_fetched_count=0 \
+        $SCARABPARAMS \
+        &> sim.log"
     fi
 
     echo "simulating clusterID ${clusterID}, segment $segID..."

--- a/setup_apps.sh
+++ b/setup_apps.sh
@@ -34,8 +34,8 @@ case $APPNAME in
     echo "solr"
     APP_GROUPNAME="solr"
     ;;
-  600.perlbench_s | 602.gcc_s | 605.mcf_s | 620.omnetpp_s | 623.xalancbmk_s | 625.x264_s | 631.deepsjeng_s | 641.leela_s | 648.exchange2_s | 657.xz_s | \
-  603.bwaves_s | 607.cactuBSSN_s | 619.lbm_s | 621.wrf_s | 627.cam4_s | 628.pop2_s | 638.imagick_s | 644.nab_s | 649.fotonik3d_s | 654.roms_s | \
+  500.perlbench_r | 502.gcc_r | 505.mcf_r | 520.omnetpp_r | 523.xalancbmk_r | 525.x264_r | 531.deepsjeng_r | 541.leela_r | 548.exchange2_r | 557.xz_r | \
+  503.bwaves_r | 507.cactuBSSN_r | 508.namd_r | 510.parest_r | 511.povray_r | 519.lbm_r | 521.wrf_r | 526.blender_r | 527.cam4_r | 538.imagick_r | 544.nab_r | 549.fotonik3d_r | 554.roms_r | \
   clang | gcc)
     echo "spec2017"
     APP_GROUPNAME="spec2017"
@@ -166,8 +166,8 @@ case $APPNAME in
   solr)
     BINCMD="java -server -Xms14g -Xmx14g -XX:+UseG1GC -XX:+PerfDisableSharedMem -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=250 -XX:+UseLargePages -XX:+AlwaysPreTouch -XX:+ExplicitGCInvokesConcurrent -Xlog:gc\*:file=/usr/src/solr-9.1.1/server/logs/solr_gc.log:time\,uptime:filecount=9\,filesize=20M -Dsolr.jetty.inetaccess.includes= -Dsolr.jetty.inetaccess.excludes= -DzkClientTimeout=30000 -DzkRun -Dsolr.log.dir=/usr/src/solr-9.1.1/server/logs -Djetty.port=8983 -DSTOP.PORT=7983 -DSTOP.KEY=solrrocks -Duser.timezone=UTC -XX:-OmitStackTraceInFastThrow -XX:OnOutOfMemoryError=/usr/src/solr-9.1.1/bin/oom_solr.sh\ 8983\ /usr/src/solr-9.1.1/server/logs -Djetty.home=/usr/src/solr-9.1.1/server -Dsolr.solr.home=/usr/src/solr_cores -Dsolr.data.home= -Dsolr.install.dir=/usr/src/solr-9.1.1 -Dsolr.default.confdir=/usr/src/solr-9.1.1/server/solr/configsets/_default/conf -Dsolr.jetty.host=0.0.0.0 -Xss256k -XX:CompileCommand=exclude\,com.github.benmanes.caffeine.cache.BoundedLocalCache::put -Djava.security.manager -Djava.security.policy=/usr/src/solr-9.1.1/server/etc/security.policy -Djava.security.properties=/usr/src/solr-9.1.1/server/etc/security.properties -Dsolr.internal.network.permission=\* -DdisableAdminUI=false -jar /usr/src/solr-9.1.1/server/start.jar --module=http --module=requestlog --module=gzip"
     ;;
-  600.perlbench_s | 602.gcc_s | 605.mcf_s | 620.omnetpp_s | 623.xalancbmk_s | 625.x264_s | 631.deepsjeng_s | 641.leela_s | 648.exchange2_s | 657.xz_s | \
-  603.bwaves_s | 607.cactuBSSN_s | 619.lbm_s | 621.wrf_s | 627.cam4_s | 628.pop2_s | 638.imagick_s | 644.nab_s | 649.fotonik3d_s | 654.roms_s)
+  500.perlbench_r | 502.gcc_r | 505.mcf_r | 520.omnetpp_r | 523.xalancbmk_r | 525.x264_r | 531.deepsjeng_r | 541.leela_r | 548.exchange2_r | 557.xz_r | \
+  503.bwaves_r | 507.cactuBSSN_r | 508.namd_r | 510.parest_r | 511.povray_r | 519.lbm_r | 521.wrf_r | 526.blender_r | 527.cam4_r | 538.imagick_r | 544.nab_r | 549.fotonik3d_r | 554.roms_r)
     BINCMD="placeholder"
     ;;
   xgboost)

--- a/spec2017/install.sh
+++ b/spec2017/install.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -x
 
-mkdir -p /home/$username/cpu2017
-cd $tmpdir/cpu2017_install && echo "yes" | ./install.sh -d /home/$username/cpu2017
+if [ ! -d "/home/$username/cpu2017" ]; then
+    mkdir /home/$username/cpu2017
+    cd $tmpdir/cpu2017_install && echo "yes" | ./install.sh -d /home/$username/cpu2017
 
-cp $tmpdir/memtrace.cfg /home/$username/cpu2017/config/memtrace.cfg
-cp $tmpdir/compile-538-clang.sh /home/$username/cpu2017/benchspec/CPU
+    cp $tmpdir/memtrace.cfg /home/$username/cpu2017/config/memtrace.cfg
+    cp $tmpdir/compile-538-clang.sh /home/$username/cpu2017/benchspec/CPU
+else
+    echo "cpu2017 exists. skip installation."
+fi


### PR DESCRIPTION
## Notes
Flow 2 does the following:
1. Traces the application. The output is one big trace
2. Processes the big trace, generates the fingerprints, and runs the clustering. The output is the simpoints.
3. Extracts the simpoint traces from the one big trace. The output is the simpoint traces

Flow 2 relies on a DynamoRIO feature that it internally divides the one big trace into smaller chunks with a given size. By setting the chunk size to the simpoint size, the fingerprint generations can be done in parallel where each task targets a single chunk. And later we can easily separate the simpoints traces from the big trace.

It is important that the fingerprint generation (as well as scarab simulation) uses the same way of counting instructions as how DynamoRIO does it while generating chunks, which is counting only **fetched instructions**.

> In DynamoRIO traces, a rep instruction is duplicated by the number of times it is executed to aid simulators. However, only the first instance is counted towards fetched instruction. 

---

Flow 1 does the following:
1. Instruments the application, generates the fingerprints, and runs the clustering. The output is the simpoints.
2. Traces only the simpoints. The output is the simpoint traces

Flow 1 relies on a DynamoRIO feature that it can start tracing after a specified amount of instruction (skipping unwanted instructions). So we get to trace only the simpoint, skipping preceding instructions.

Likewise, it is important that the fingerprint generation (as well as scarab simulation) uses the same way of counting instructions as how DynamoRIO does it while skipping instructions, which is counting also **non-fetched instructions**

> So this time, all instances of a rep instruction are counted towards the total number of instructions.

---

The inconsistency of how DynamoRIO counts instructions across different features complicates the two simpoint flows. For example, when flow 2 simulates the traces, it uses `--use_fetched_count=1` while the flow 2 uses `--use_fetched_count=0 `. Users need to be aware of the nuances but in general, as long as they follow the scripts, it should be fine.

---

Another difference between these two flow is that, even though the ultimate outputs are both simpoint traces, they have different composition:
1. Flow 2 simpoint traces are extracted from the one big trace. The first chunk of the big trace contains meta information about the trace, so it is copied into every simpoint trace.
2. Flow 1 simpoint traces are independently generated. So they really only contains the simpoint.

This affects how scarab read in the trace:
1. For flow 2, scarab will almost always skip the first chunk unless it is originally part of the simpoint: `--memtrace_roi_begin=$(( $SEGSIZE + 1))`
2. For flow 1, scarab does not skip anything

---

## SPEC SimPoints
The simpoint clustering accepts a parameter `maxK` as the upper-bound of the resulting number of clusters. To aid the selection of the `maxK` to be used, we swept from 20 to 200 with the step size of 20.

To compare the result of each `maxK`, we estimated the fingerprint of the entire application using the fingerprints of the simpoints and calculated the estimation error, which is defined as the L1 distance between the estimation and the actual fingerprint.

The following two tables summarizes the resulting number of clusters and estimation error of different `maxK`:

|      bench      | #cluster1 |   err  | #cluster2 |   err  | #cluster3 |   err  | #cluster4 |   err  | #cluster5 |   err  |
|:---------------:|:---------:|:------:|:---------:|:------:|:---------:|:------:|:---------:|:------:|:---------:|:------:|
| 500.perlbench_r |     13    |  1.79% |     17    |  1.58% |     21    |  1.44% |     30    |  1.36% |     33    |  1.53% |
|    502.gcc_r    |     8     | 33.60% |     13    | 28.64% |     18    | 26.12% |     20    | 29.40% |     25    | 24.64% |
|   503.bwaves_r  |     14    |  2.91% |     26    |  2.87% |     34    |  1.47% |     43    |  1.00% |     44    |  1.02% |
|    505.mcf_r    |     11    |  3.00% |     25    |  2.74% |     25    |  2.74% |     44    |  2.11% |     55    |  2.06% |
| 507.cactuBSSN_r |     11    |  4.58% |     16    |  1.13% |     18    |  1.06% |     17    |  1.18% |     19    |  1.06% |
|    508.namd_r   |     18    | 15.00% |     36    |  2.86% |     42    |  0.85% |     49    |  1.45% |     60    |  1.35% |
|   510.parest_r  |     12    | 13.33% |     23    | 10.67% |     34    |  8.09% |     45    |  5.28% |     55    |  5.38% |
|   511.povray_r  |     12    |  2.57% |     24    |  1.88% |     31    |  2.26% |     39    |  1.83% |     46    |  1.27% |
|    519.lbm_r    |     7     |  0.83% |     7     |  0.83% |     7     |  0.83% |     8     |  0.83% |     11    |  0.84% |
|  520.omnetpp_r  |     11    |  1.27% |     23    |  1.12% |     36    |  0.67% |     22    |  1.10% |     38    |  0.67% |
|    521.wrf_r    |     17    | 69.04% |     32    | 35.66% |     47    | 26.51% |     66    | 15.60% |     79    | 10.87% |
| 523.xalancbmk_r |     13    |  3.11% |     23    |  1.79% |     29    |  1.46% |     35    |  1.84% |     43    |  1.66% |
|    525.x264_r   |     13    |  4.03% |     23    |  3.61% |     36    |  2.86% |     46    |  2.15% |     63    |  2.20% |
|  526.blender_r  |     16    |  3.51% |     16    |  5.02% |     33    |  3.71% |     27    |  4.26% |     33    |  3.71% |
|    527.cam4_r   |     15    | 12.20% |     25    |  8.35% |     36    |  7.59% |     38    |  6.08% |     61    |  4.89% |
| 531.deepsjeng_r |     5     |  5.53% |     9     |  7.74% |     12    |  3.64% |     15    |  4.39% |     18    |  3.89% |
|  538.imagick_r  |     5     |  0.83% |     5     |  0.83% |     5     |  0.83% |     5     |  0.83% |     5     |  0.83% |
|   541.leela_r   |     13    |  1.66% |     24    |  1.76% |     31    |  1.25% |     39    |  1.60% |     44    |  1.38% |
|    544.nab_r    |     8     |  1.56% |     11    |  1.56% |     14    |  1.57% |     12    |  1.64% |     12    |  1.64% |
| 548.exchange2_r |     12    |  1.55% |     20    |  2.72% |     28    |  2.35% |     34    |  1.93% |     39    |  1.81% |
| 549.fotonik3d_r |     14    |  7.08% |     21    |  3.26% |     28    |  2.60% |     37    |  2.22% |     48    |  1.50% |
|    554.roms_r   |     18    | 38.15% |     27    | 22.27% |     42    |  8.13% |     51    |  6.36% |     69    |  4.32% |
|     557.xz_r    |     11    |  3.16% |     23    |  3.01% |     28    |  2.91% |     34    |  2.13% |     44    |  2.21% |

|      bench      | #cluster6 |   err  | #cluster7 |   err  | #cluster8 |   err  | #cluster9 |   err  | #cluster10 |   err  |
|:---------------:|:---------:|:------:|:---------:|:------:|:---------:|:------:|:---------:|:------:|:----------:|:------:|
| 500.perlbench_r |     25    |  1.72% |     27    |  1.50% |     46    |  0.54% |     52    |  0.56% |     52     |  0.86% |
|    502.gcc_r    |     25    | 24.87% |     31    | 24.47% |     38    | 24.50% |     58    | 20.09% |     59     | 19.63% |
|   503.bwaves_r  |     46    |  1.40% |     46    |  1.21% |     49    |  1.02% |     49    |  1.04% |     58     |  1.26% |
|    505.mcf_r    |     44    |  2.24% |     51    |  2.09% |     70    |  1.96% |     85    |  1.63% |     74     |  1.62% |
| 507.cactuBSSN_r |     19    |  1.06% |     18    |  1.20% |     20    |  1.01% |     19    |  1.06% |     20     |  1.04% |
|    508.namd_r   |     63    |  1.36% |     75    |  1.37% |     69    |  0.97% |     75    |  1.11% |     81     |  1.30% |
|   510.parest_r  |     65    |  5.23% |     77    |  4.17% |     90    |  5.67% |     97    |  3.21% |     106    |  2.87% |
|   511.povray_r  |     51    |  1.45% |     59    |  1.30% |     66    |  1.31% |     75    |  1.23% |     82     |  1.40% |
|    519.lbm_r    |     11    |  0.84% |     11    |  0.84% |     59    |  0.07% |     41    |  0.07% |     87     |  0.05% |
|  520.omnetpp_r  |     95    |  0.67% |     94    |  0.65% |     90    |  0.62% |    101    |  0.64% |     163    |  0.64% |
|    521.wrf_r    |     97    |  9.30% |    110    |  8.96% |    126    |  6.03% |    129    |  5.99% |     143    |  5.56% |
| 523.xalancbmk_r |     49    |  1.75% |     56    |  1.84% |     60    |  1.69% |     68    |  1.79% |     76     |  1.79% |
|    525.x264_r   |     62    |  2.14% |     75    |  2.02% |     77    |  2.26% |     96    |  1.79% |     102    |  1.64% |
|  526.blender_r  |     34    |  3.65% |     39    |  3.75% |     43    |  3.15% |     76    |  2.39% |     55     |  3.13% |
|    527.cam4_r   |     61    |  4.89% |     69    |  4.79% |     81    |  4.06% |     82    |  4.05% |     86     |  3.86% |
| 531.deepsjeng_r |     21    |  3.29% |     23    |  3.58% |     25    |  3.63% |     27    |  3.73% |     30     |  3.16% |
|  538.imagick_r  |     29    |  1.01% |     29    |  1.01% |     55    |  0.89% |     64    |  0.89% |     71     |  0.89% |
|   541.leela_r   |     56    |  1.18% |     65    |  1.31% |     61    |  1.17% |     75    |  1.30% |     83     |  1.12% |
|    544.nab_r    |     16    |  1.57% |     16    |  1.57% |     12    |  1.64% |     16    |  1.57% |     14     |  1.55% |
| 548.exchange2_r |     47    |  2.10% |     52    |  1.30% |     60    |  1.13% |     65    |  0.91% |     71     |  0.96% |
| 549.fotonik3d_r |     48    |  1.50% |     51    |  1.47% |     57    |  1.07% |     56    |  1.07% |     60     |  1.35% |
|    554.roms_r   |     82    |  4.20% |     95    |  3.10% |    110    |  3.05% |    124    |  2.94% |     129    |  2.72% |
|     557.xz_r    |     47    |  2.04% |     50    |  1.19% |     52    |  2.06% |     57    |  1.67% |     64     |  1.37% |

For every application, we select the smallest `maxK` such that the error is below `5%`. For `502` and `521`, there is no satisfying `maxK` so we just used `200` for them. The following table summarizes the `maxK` for each application:

|      bench      |   maxK  | #cluster |     err    |
|:---------------:|:-------:|:--------:|:----------:|
| 500.perlbench_r |    20   |    13    |    1.79%   |
|    502.gcc_r    | **200** |  **59**  | **19.63%** |
|   503.bwaves_r  |    20   |    14    |    2.91%   |
|    505.mcf_r    |    20   |    11    |    3.00%   |
| 507.cactuBSSN_r |    20   |    11    |    4.58%   |
|    508.namd_r   |    40   |    36    |    2.86%   |
|   510.parest_r  |   140   |    77    |    4.17%   |
|   511.povray_r  |    20   |    12    |    2.57%   |
|    519.lbm_r    |    20   |     7    |    0.83%   |
|  520.omnetpp_r  |    20   |    11    |    1.27%   |
|    521.wrf_r    | **200** |  **143** |  **5.56%** |
| 523.xalancbmk_r |    20   |    13    |    3.11%   |
|    525.x264_r   |    20   |    13    |    4.03%   |
|  526.blender_r  |    20   |    16    |    3.51%   |
|    527.cam4_r   |   100   |    61    |    4.89%   |
| 531.deepsjeng_r |    60   |    12    |    3.64%   |
|  538.imagick_r  |    20   |     5    |    0.83%   |
|   541.leela_r   |    20   |    13    |    1.66%   |
|    544.nab_r    |    20   |     8    |    1.56%   |
| 548.exchange2_r |    20   |    12    |    1.55%   |
| 549.fotonik3d_r |    40   |    21    |    3.26%   |
|    554.roms_r   |   100   |    69    |    4.32%   |
|     557.xz_r    |    20   |    11    |    3.16%   | 

## Simulating SPEC apps
SPEC apps are ready to use. Add wanted spec app names to the JSON file and the rest is the same.
```
        "500.perlbench_r",
        "502.gcc_r",
        "505.mcf_r",
        "520.omnetpp_r",
        "523.xalancbmk_r",
        "525.x264_r",
        "531.deepsjeng_r",
        "541.leela_r",
        "548.exchange2_r",
        "557.xz_r",
        
        "503.bwaves_r",
        "507.cactuBSSN_r",
        "508.namd_r",
        "510.parest_r",
        "511.povray_r",
        "519.lbm_r",
        "521.wrf_r",
        "526.blender_r",
        "527.cam4_r",
        "538.imagick_r",
        "544.nab_r",
        "549.fotonik3d_r",
        "554.roms_r",
```