### PR TITLE
Changed derive stat to weight simpoints at derive time by default

### DIFF
--- a/scarab_stats/README.md
+++ b/scarab_stats/README.md
@@ -246,12 +246,13 @@ aggregation_level = "Config": f"{config} {statistic}"
 - simpoints: For aggregation level "Simpoint", optionally provide which simpoints you want data from. Default is all
 
 #### derive_stat
-Arguments: (equation:str, overwrite:bool=True)
+Arguments: (equation:str, overwrite:bool=True, agg_first:bool=True)
 
 Creates a new stat column using the given equation. Format should be similar to `new_stat_name = stat_name + stat_name_2 * 42`. Format strings can be used to insert variables
 
 - equation: The equation to be used to derive a new statistic. + - * / all work, with column names or number literals.
 - overwrite: If set to false, will error if user attempts to overwrite the value of an existing stat. When enabled (default), it will replace the value of the stat if it exists. Cannot be used on stats collected directly from scarab.
+- agg_first: If set to false, do not carry out simpoint weighting during stat creation. When set to true (default), it will aggregate/weight simpoints during the data retrival step while deriving your stat.
 
 #### to_csv
 Arguments: (path: str)


### PR DESCRIPTION
Changed `derive_stat` to weight and aggregate simpoints before computing `equation`. This can be disabled by setting the `agg_first` optional argument to false. Since data is stored internally as a pandas dataframe with a column per simpoint, each simpoint's entry contains the same (duplicated) values for their respective workload. This means that all simpoints for a given workload&config will have the same value. Using graphing functions which aggregate simpoints is not an issue, since weights sum to zero.
Example:
| Workload Config Simpoint | Value of derived stat | weight |
| -------- | ------- | ------- | 
| Mysql Baseline 4 | 300 | 70% |
| Mysql Baseline 10 | 300 | 30% |

When graphing derived stat: 300\*0.7 + 300\*0.3 = 300