### PR TITLE
remove disabling ASLR from docker build as it faults

### DIFF
--- a/README.LitzLab.md
+++ b/README.LitzLab.md
@@ -28,14 +28,14 @@ Usage: ./run.sh [ -h | --help ]
 !! Modify 'apps.list' and '<experiment_name>.json' to specify the apps to build and Scarab parameters before run !!
 The entire process of simulating a data center workload is the following.
 1) application setup by building a docker image (each directory represents an application group)
-2) collect traces with different simpoint workflows for trace-based simulation
+2) collect traces with different simpoint workflows for trace-based simulation; **this will turn off ASLR; the user needs to recover the ASLR setting afterwards manually by running on host**: `echo 2 | sudo tee /proc/sys/kernel/randomize_va_space`
 3) run Scarab simulation in different modes
 To perform the later step, the previous steps must be performed first, meaning all the necessary options should be set at the same time. However, you can only run earlier step(s) by unsetting the later steps for debugging purposes.
 Options:
 h     Print this Help.
 o     Absolute path to the directory for scarab repo, pin, traces, simpoints, and simulation results. scarab and pin will be installed if they don't exist in the given path. The directory will be mounted as home directory of a container e.g) -o /soe/user/testbench_container_home
 b     Build a docker image with application setup. 0: Run a container of existing docker image 1: Build cached image and run a container of the cached image, 2: Build a new image from the beginning and overwrite whatever image with the same name. e.g) -b 2
-t     Collect traces with different SimPoint workflows. 0: Do not collect traces, 1: Only collect traces without simpoint clustering, 2: Collect traces based on SimPoint workflow - post-processing (trace, collect fingerprints, do simpoint clustering). e.g) -t 2
+t     Collect traces with different SimPoint workflows. 0: Do not collect traces, 1: Collect traces based on SimPoint workflow - collect fingerprints, do simpoint clustering, trace, 2: Collect traces based on SimPoint post-processing workflow - trace, collect fingerprints, do simpoint clustering, 3: Only collect traces without simpoint clustering. e.g) -t 2
 s     Scarab simulation mode. 0: No simulation 1: execution-driven simulation w/o SimPoint 2: trace-based simulation w/o SimPoint (-t should be 1 if no traces exist already in the container). 3: execution-driven simulation w/ SimPoint 4: trace-based simulation w/ SimPoint e.g) -s 4
 e     Experiment name. e.g.) -e exp2
 c     Clean up all the containers/volumes after run. 0: No clean up 2: Clean up e.g) -c 1

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Usage: ./run.sh [ -h | --help ]
 !! Modify 'apps.list' and '<experiment_name>.json' to specify the apps to build and Scarab parameters before run !!
 The entire process of simulating a data center workload is the following.
 1) application setup by building a docker image (each directory represents an application group)
-2) collect traces with different simpoint workflows for trace-based simulation
+2) collect traces with different simpoint workflows for trace-based simulation; **this will turn off ASLR; the user needs to recover the ASLR setting afterwards manually by running on host**: `echo 2 | sudo tee /proc/sys/kernel/randomize_va_space`
 3) run Scarab simulation in different modes
 To perform the later step, the previous steps must be performed first, meaning all the necessary options should be set at the same time. However, you can only run earlier step(s) by unsetting the later steps for debugging purposes.
 Options:
 h     Print this Help.
 o     Absolute path to the directory for scarab repo, pin, traces, simpoints, and simulation results. scarab and pin will be installed if they don't exist in the given path. The directory will be mounted as home directory of a container e.g) -o /soe/user/testbench_container_home
 b     Build a docker image with application setup. 0: Run a container of existing docker image 1: Build cached image and run a container of the cached image, 2: Build a new image from the beginning and overwrite whatever image with the same name. e.g) -b 2
-t     Collect traces with different SimPoint workflows. 0: Do not collect traces, 1: Only collect traces without simpoint clustering, 2: Collect traces based on SimPoint workflow - post-processing (trace, collect fingerprints, do simpoint clustering). e.g) -t 2
+t     Collect traces with different SimPoint workflows. 0: Do not collect traces, 1: Collect traces based on SimPoint workflow - collect fingerprints, do simpoint clustering, trace, 2: Collect traces based on SimPoint post-processing workflow - trace, collect fingerprints, do simpoint clustering, 3: Only collect traces without simpoint clustering. e.g) -t 2
 s     Scarab simulation mode. 0: No simulation 1: execution-driven simulation w/o SimPoint 2: trace-based simulation w/o SimPoint (-t should be 1 if no traces exist already in the container). 3: execution-driven simulation w/ SimPoint 4: trace-based simulation w/ SimPoint e.g) -s 4
 e     Experiment name. e.g.) -e exp2
 c     Clean up all the containers/volumes after run. 0: No clean up 2: Clean up e.g) -c 1

--- a/common/Dockerfile.common
+++ b/common/Dockerfile.common
@@ -78,8 +78,5 @@ RUN cd $tmpdir/ && \
     make -C SimPoint.3.2 && \
     ln -s SimPoint.3.2/bin/simpoint ./simpoint
 
-# disable ASLR
-RUN echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
-
 ENV DOCKER_BUILDKIT 1
 ENV COMPOSE_DOCKER_CLI_BUILD 1

--- a/run.sh
+++ b/run.sh
@@ -18,7 +18,7 @@ help()
   echo "!! Modify 'apps.list' and '<experiment_name>.json' to specify the apps to build and Scarab parameters before run !!"
   echo "The entire process of simulating a data center workload is the following."
   echo "1) application setup by building a docker image (each directory represents an application group)"
-  echo "2) collect traces with different simpoint workflows for trace-based simulation"
+  echo "2) collect traces with different simpoint workflows for trace-based simulation; **this will turn off ASLR; the user needs to recover the ASLR setting afterwards manually by running on host**: `echo 2 | sudo tee /proc/sys/kernel/randomize_va_space`"
   echo "3) run Scarab simulation in different modes"
   echo "To perform the later step, the previous steps must be performed first, meaning all the necessary options should be set at the same time. However, you can only run earlier step(s) by unsetting the later steps for debugging purposes."
 
@@ -26,7 +26,7 @@ help()
   echo "h     Print this Help."
   echo "o     Absolute path to the directory for scarab repo, pin, traces, simpoints, and simulation results. scarab and pin will be installed if they don't exist in the given path. The directory will be mounted as home directory of a container e.g) -o /soe/user/testbench_container_home"
   echo "b     Build a docker image with application setup. 0: Run a container of existing docker image 1: Build cached image and run a container of the cached image, 2: Build a new image from the beginning and overwrite whatever image with the same name. e.g) -b 2"
-  echo "t     Collect traces with different SimPoint workflows. 0: Do not collect traces, 1: Only collect traces without simpoint clustering, 2: Collect traces based on SimPoint workflow - post-processing (trace, collect fingerprints, do simpoint clustering). e.g) -t 2"
+  echo "t     Collect traces with different SimPoint workflows. 0: Do not collect traces, 1: Collect traces based on SimPoint workflow - collect fingerprints, do simpoint clustering, trace, 2: Collect traces based on SimPoint post-processing workflow - trace, collect fingerprints, do simpoint clustering, 3: Only collect traces without simpoint clustering. e.g) -t 2"
   echo "s     Scarab simulation mode. 0: No simulation 1: execution-driven simulation w/o SimPoint 2: trace-based simulation w/o SimPoint (-t should be 1 if no traces exist already in the container). 3: execution-driven simulation w/ SimPoint 4: trace-based simulation w/ SimPoint. 5: trace-based simulation w/o SimPoint with pt e.g) -s 4"
   echo "e     Experiment name. e.g.) -e exp2"
   echo "c     Clean up all the containers/volumes after run. 0: No clean up 2: Clean up e.g) -c 1"
@@ -127,6 +127,10 @@ while read APPNAME ;do
 
     # update the script
     docker cp ./run_simpoint_trace.sh $APP_GROUPNAME\_$USER:/usr/local/bin
+    # disable ASLR;
+    # the user needs to recover the ASLR setting afterwards manually by running on host:
+    # echo 2 | sudo tee /proc/sys/kernel/randomize_va_space
+    docker exec --privileged $APP_GROUPNAME\_$USER /bin/bash -c "echo 0 | sudo tee /proc/sys/kernel/randomize_va_space"
     docker exec $ENVVARS --user $USER --workdir /home/$USER --privileged $APP_GROUPNAME\_$USER run_simpoint_trace.sh "$APPNAME" "$APP_GROUPNAME" "$BINCMD" "$SIMPOINT" "$DRIO_ARGS" &
     sleep 2
     while read -r line ;do


### PR DESCRIPTION
Disabling ASLR while building an image is not possible; containers share the setting with the host: https://stackoverflow.com/questions/54845095/cannot-run-sysctl-command-in-dockerfile

This commit turns off ASLR before running the simpoint script; the user needs to recover the setting afterwards manually.