### PR TITLE
No need to use g++-9

### DIFF
--- a/common/Dockerfile.common
+++ b/common/Dockerfile.common
@@ -13,8 +13,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     zlib1g-dev \
     libsnappy-dev \
     liblz4-dev \
-    g++-9 \
-    g++-9-multilib \
     doxygen \
     libconfig++-dev \
     libboost-dev \
@@ -22,9 +20,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     bc \
     unzip \
     gosu
-
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 1
-
 
 # Copy workflow simpoint/no_simpoint script
 COPY ./scripts/utilities.sh /usr/local/bin/utilities.sh


### PR DESCRIPTION
- The public scarab is now buildable with g++-11