### PR TITLE
Append 'source /usr/local/bin/user_entrypoint.sh' to .bashrc only for the interactive shell

### DIFF
--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -395,5 +395,3 @@ def run_tracing(user, descriptor_data, workload_db_path, suite_db_path, infra_di
 
         print("Recover the ASLR setting with sudo. Provide password..")
         os.system("echo 2 | sudo tee /proc/sys/kernel/randomize_va_space")
-
-        subprocess.run(["sed", "-i", "/source \\/usr\\/local\\/bin\\/user_entrypoint.sh/d", f"{docker_home}/.bashrc"], check=True, capture_output=True, text=True)

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -115,11 +115,21 @@ def open_interactive_shell(user, descriptor_data, workloads_data, suite_data, in
         # currently open it on local
 
         docker_prefix = get_image_name(workloads_data, suite_data, descriptor_data['simulations'][0])
+        docker_home = descriptor_data['root_dir']
+
+        # Set the env for simulation again (already set in Dockerfile.common) in case user's bashrc overwrite the existing ones when the home directory is mounted
+        bashrc_path = f"{docker_home}/.bashrc"
+        entry = "source /usr/local/bin/user_entrypoint.sh"
+        with open(bashrc_path, "a+") as f:
+            f.seek(0)
+            if entry not in f.read():
+                f.write(f"\n{entry}\n")
+
         # Generate commands for executing in users docker and sbatching to nodes with containers
         scarab_githash = prepare_simulation(user,
                                             scarab_path,
                                             descriptor_data['scarab_build'],
-                                            descriptor_data['root_dir'],
+                                            docker_home,
                                             experiment_name,
                                             descriptor_data['architecture'],
                                             docker_prefix,

--- a/scripts/run_trace.py
+++ b/scripts/run_trace.py
@@ -124,6 +124,15 @@ def open_interactive_shell(user, descriptor_data, infra_dir, dbg_lvl = 1):
         trace_scenario = descriptor_data["trace_configurations"][0]
         docker_prefix = trace_scenario["image_name"]
         workload = trace_scenario["workload"]
+
+        # Set the env for simulation again (already set in Dockerfile.common) in case user's bashrc overwrite the existing ones when the home directory is mounted
+        bashrc_path = f"{docker_home}/.bashrc"
+        entry = "source /usr/local/bin/user_entrypoint.sh"
+        with open(bashrc_path, "a+") as f:
+            f.seek(0)
+            if entry not in f.read():
+                f.write(f"\n{entry}\n")
+
         prepare_trace(user, scarab_path, scarab_build, docker_home, trace_name, infra_dir, docker_prefix, githash, True, dbg_lvl)
         if trace_scenario["env_vars"] != None:
             env_vars = trace_scenario["env_vars"].split()

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -562,5 +562,3 @@ def run_tracing(user, descriptor_data, workload_db_path, suite_db_path, infra_di
 
         print("Recover the ASLR setting with sudo. Provide password..")
         os.system("echo 2 | sudo tee /proc/sys/kernel/randomize_va_space")
-
-        subprocess.run(["sed", "-i", "/source \\/usr\\/local\\/bin\\/user_entrypoint.sh/d", f"{docker_home}/.bashrc"], check=True, capture_output=True, text=True)


### PR DESCRIPTION
- Directly execute it within the command for non-interactive tracing/simulation
- Remove bashrc modification from non-interactive tracing/simulation
- Only an interactive shell needs to modify bashrc