### PR TITLE
Fix typo from the autoware trace commit

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -328,7 +328,7 @@ def generate_single_trace_run_command(user, workload, image_name, trace_name, bi
     command = ""
     if simpoint_mode == "cluster_then_trace":
         mode = 1
-    elif simpoint_mode == "trace_then_cluster":
+    elif simpoint_mode == "trace_then_post_process":
         mode = 2
     elif simpoint_mode == "iterative_trace":
         mode = 3


### PR DESCRIPTION
Hi, @5surim 

I realized I had a typo at "trace_then_clustering"  logic at the previous iterative trace commit.
I checked the normal working with "trace_then_clustering" & "iterative" with this correction.

Thanks.
Best regards