### PR TITLE
Fix folder renaming timing for iterative tracing

### DIFF
--- a/workloads/autoware/workload_user_entrypoint.sh
+++ b/workloads/autoware/workload_user_entrypoint.sh
@@ -1,6 +1,7 @@
 source /opt/ros/$ROS_DISTRO/setup.sh
 source $tmpdir/autoware/install/setup.bash
 nohup /opt/ros/humble/bin/ros2 bag play $tmpdir/driving_log_replayer_data/yabloc/sample/input_bag --topics /sensing/camera/traffic_light/image_raw/compressed -p &
+sleep 5
 cd $tmpdir/autoware/ && /opt/ros/humble/bin/ros2 launch tier4_map_launch map.launch.xml pointcloud_map_path:=/tmp_home/autoware_map/nishishinjuku_autoware_map/pointcloud_map.pcd pointcloud_map_metadata_path:='""' lanelet2_map_path:=/tmp_home/autoware_map/nishishinjuku_autoware_map/lanelet2_map.osm map_projector_info_path:='""' pointcloud_map_loader_param_path:=src/universe/autoware.universe/map/autoware_map_loader/config/pointcloud_map_loader.param.yaml lanelet2_map_loader_param_path:=src/universe/autoware.universe/map/autoware_map_loader/config/lanelet2_map_loader.param.yaml map_tf_generator_param_path:=src/universe/autoware.universe/map/autoware_map_tf_generator/config/map_tf_generator.param.yaml map_projection_loader_param_path:=/tmp_home/autoware/src/universe/autoware.universe/map/autoware_map_projection_loader/config/map_projection_loader.param.yaml &
 sleep 10
 source $tmpdir/autoware/image_republisher/install/setup.bash && /opt/ros/humble/bin/ros2 run image_republisher image_republisher &

--- a/workloads/workloads_db.json
+++ b/workloads/workloads_db.json
@@ -5688,3002 +5688,3002 @@
       {
         "cluster_id":1,
         "segment_id":0,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":2,
         "segment_id":1,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":3,
         "segment_id":2,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":4,
         "segment_id":3,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":5,
         "segment_id":4,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":6,
         "segment_id":5,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":7,
         "segment_id":6,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":8,
         "segment_id":7,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":9,
         "segment_id":8,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":10,
         "segment_id":9,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":11,
         "segment_id":10,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":12,
         "segment_id":11,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":13,
         "segment_id":12,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":14,
         "segment_id":13,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":15,
         "segment_id":14,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":16,
         "segment_id":15,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":17,
         "segment_id":16,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":18,
         "segment_id":17,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":19,
         "segment_id":18,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":20,
         "segment_id":19,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":21,
         "segment_id":20,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":22,
         "segment_id":21,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":23,
         "segment_id":22,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":24,
         "segment_id":23,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":25,
         "segment_id":24,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":26,
         "segment_id":25,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":27,
         "segment_id":26,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":28,
         "segment_id":27,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":29,
         "segment_id":28,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":30,
         "segment_id":29,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":31,
         "segment_id":30,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":32,
         "segment_id":31,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":33,
         "segment_id":32,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":34,
         "segment_id":33,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":35,
         "segment_id":34,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":36,
         "segment_id":35,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":37,
         "segment_id":36,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":38,
         "segment_id":37,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":39,
         "segment_id":38,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":40,
         "segment_id":39,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":41,
         "segment_id":40,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":42,
         "segment_id":41,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":43,
         "segment_id":42,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":44,
         "segment_id":43,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":45,
         "segment_id":44,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":46,
         "segment_id":45,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":47,
         "segment_id":46,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":48,
         "segment_id":47,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":49,
         "segment_id":48,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":50,
         "segment_id":49,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":51,
         "segment_id":50,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":52,
         "segment_id":51,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":53,
         "segment_id":52,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":54,
         "segment_id":53,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":55,
         "segment_id":54,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":56,
         "segment_id":55,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":57,
         "segment_id":56,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":58,
         "segment_id":57,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":59,
         "segment_id":58,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":60,
         "segment_id":59,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":61,
         "segment_id":60,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":62,
         "segment_id":61,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":63,
         "segment_id":62,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":64,
         "segment_id":63,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":65,
         "segment_id":64,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":66,
         "segment_id":65,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":67,
         "segment_id":66,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":68,
         "segment_id":67,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":69,
         "segment_id":68,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":70,
         "segment_id":69,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":71,
         "segment_id":70,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":72,
         "segment_id":71,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":73,
         "segment_id":72,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":74,
         "segment_id":73,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":75,
         "segment_id":74,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":76,
         "segment_id":75,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":77,
         "segment_id":76,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":78,
         "segment_id":77,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":79,
         "segment_id":78,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":80,
         "segment_id":79,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":81,
         "segment_id":80,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":82,
         "segment_id":81,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":83,
         "segment_id":82,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":84,
         "segment_id":83,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":85,
         "segment_id":84,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":86,
         "segment_id":85,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":87,
         "segment_id":86,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":88,
         "segment_id":87,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":89,
         "segment_id":88,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":90,
         "segment_id":89,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":91,
         "segment_id":90,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":92,
         "segment_id":91,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":93,
         "segment_id":92,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":94,
         "segment_id":93,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":95,
         "segment_id":94,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":96,
         "segment_id":95,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":97,
         "segment_id":96,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":98,
         "segment_id":97,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":99,
         "segment_id":98,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":100,
         "segment_id":99,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":101,
         "segment_id":100,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":102,
         "segment_id":101,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":103,
         "segment_id":102,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":104,
         "segment_id":103,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":105,
         "segment_id":104,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":106,
         "segment_id":105,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":107,
         "segment_id":106,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":108,
         "segment_id":107,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":109,
         "segment_id":108,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":110,
         "segment_id":109,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":111,
         "segment_id":110,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":112,
         "segment_id":111,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":113,
         "segment_id":112,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":114,
         "segment_id":113,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":115,
         "segment_id":114,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":116,
         "segment_id":115,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":117,
         "segment_id":116,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":118,
         "segment_id":117,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":119,
         "segment_id":118,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":120,
         "segment_id":119,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":121,
         "segment_id":120,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":122,
         "segment_id":121,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":123,
         "segment_id":122,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":124,
         "segment_id":123,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":125,
         "segment_id":124,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":126,
         "segment_id":125,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":127,
         "segment_id":126,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":128,
         "segment_id":127,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":129,
         "segment_id":128,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":130,
         "segment_id":129,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":131,
         "segment_id":130,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":132,
         "segment_id":131,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":133,
         "segment_id":132,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":134,
         "segment_id":133,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":135,
         "segment_id":134,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":136,
         "segment_id":135,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":137,
         "segment_id":136,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":138,
         "segment_id":137,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":139,
         "segment_id":138,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":140,
         "segment_id":139,
-        "weight":0.001394
+        "weight":0.001527
       },
       {
         "cluster_id":141,
         "segment_id":140,
-        "weight":0.001394
+        "weight":0.001696
       },
       {
         "cluster_id":142,
         "segment_id":141,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":143,
         "segment_id":142,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":144,
         "segment_id":143,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":145,
         "segment_id":144,
-        "weight":0.001394
+        "weight":0.001527
       },
       {
         "cluster_id":146,
         "segment_id":145,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":147,
         "segment_id":146,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":148,
         "segment_id":147,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":149,
         "segment_id":148,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":150,
         "segment_id":149,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":151,
         "segment_id":150,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":152,
         "segment_id":151,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":153,
         "segment_id":152,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":154,
         "segment_id":153,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":155,
         "segment_id":154,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":156,
         "segment_id":155,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":157,
         "segment_id":156,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":158,
         "segment_id":157,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":159,
         "segment_id":158,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":160,
         "segment_id":159,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":161,
         "segment_id":160,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":162,
         "segment_id":161,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":163,
         "segment_id":162,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":164,
         "segment_id":163,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":165,
         "segment_id":164,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":166,
         "segment_id":165,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":167,
         "segment_id":166,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":168,
         "segment_id":167,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":169,
         "segment_id":168,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":170,
         "segment_id":169,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":171,
         "segment_id":170,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":172,
         "segment_id":171,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":173,
         "segment_id":172,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":174,
         "segment_id":173,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":175,
         "segment_id":174,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":176,
         "segment_id":175,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":177,
         "segment_id":176,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":178,
         "segment_id":177,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":179,
         "segment_id":178,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":180,
         "segment_id":179,
-        "weight":0.001394
+        "weight":0.001696
       },
       {
         "cluster_id":181,
         "segment_id":180,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":182,
         "segment_id":181,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":183,
         "segment_id":182,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":184,
         "segment_id":183,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":185,
         "segment_id":184,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":186,
         "segment_id":185,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":187,
         "segment_id":186,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":188,
         "segment_id":187,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":189,
         "segment_id":188,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":190,
         "segment_id":189,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":191,
         "segment_id":190,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":192,
         "segment_id":191,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":193,
         "segment_id":192,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":194,
         "segment_id":193,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":195,
         "segment_id":194,
-        "weight":0.001394
+        "weight":0.001696
       },
       {
         "cluster_id":196,
         "segment_id":195,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":197,
         "segment_id":196,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":198,
         "segment_id":197,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":199,
         "segment_id":198,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":200,
         "segment_id":199,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":201,
         "segment_id":200,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":202,
         "segment_id":201,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":203,
         "segment_id":202,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":204,
         "segment_id":203,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":205,
         "segment_id":204,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":206,
         "segment_id":205,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":207,
         "segment_id":206,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":208,
         "segment_id":207,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":209,
         "segment_id":208,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":210,
         "segment_id":209,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":211,
         "segment_id":210,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":212,
         "segment_id":211,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":213,
         "segment_id":212,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":214,
         "segment_id":213,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":215,
         "segment_id":214,
-        "weight":0.001394
+        "weight":0.001527
       },
       {
         "cluster_id":216,
         "segment_id":215,
-        "weight":0.001394
+        "weight":0.001696
       },
       {
         "cluster_id":217,
         "segment_id":216,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":218,
         "segment_id":217,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":219,
         "segment_id":218,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":220,
         "segment_id":219,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":221,
         "segment_id":220,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":222,
         "segment_id":221,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":223,
         "segment_id":222,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":224,
         "segment_id":223,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":225,
         "segment_id":224,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":226,
         "segment_id":225,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":227,
         "segment_id":226,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":228,
         "segment_id":227,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":229,
         "segment_id":228,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":230,
         "segment_id":229,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":231,
         "segment_id":230,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":232,
         "segment_id":231,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":233,
         "segment_id":232,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":234,
         "segment_id":233,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":235,
         "segment_id":234,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":236,
         "segment_id":235,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":237,
         "segment_id":236,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":238,
         "segment_id":237,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":239,
         "segment_id":238,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":240,
         "segment_id":239,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":241,
         "segment_id":240,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":242,
         "segment_id":241,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":243,
         "segment_id":242,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":244,
         "segment_id":243,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":245,
         "segment_id":244,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":246,
         "segment_id":245,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":247,
         "segment_id":246,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":248,
         "segment_id":247,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":249,
         "segment_id":248,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":250,
         "segment_id":249,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":251,
         "segment_id":250,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":252,
         "segment_id":251,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":253,
         "segment_id":252,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":254,
         "segment_id":253,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":255,
         "segment_id":254,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":256,
         "segment_id":255,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":257,
         "segment_id":256,
-        "weight":0.001394
+        "weight":0.001527
       },
       {
         "cluster_id":258,
         "segment_id":257,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":259,
         "segment_id":258,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":260,
         "segment_id":259,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":261,
         "segment_id":260,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":262,
         "segment_id":261,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":263,
         "segment_id":262,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":264,
         "segment_id":263,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":265,
         "segment_id":264,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":266,
         "segment_id":265,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":267,
         "segment_id":266,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":268,
         "segment_id":267,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":269,
         "segment_id":268,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":270,
         "segment_id":269,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":271,
         "segment_id":270,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":272,
         "segment_id":271,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":273,
         "segment_id":272,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":274,
         "segment_id":273,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":275,
         "segment_id":274,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":276,
         "segment_id":275,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":277,
         "segment_id":276,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":278,
         "segment_id":277,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":279,
         "segment_id":278,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":280,
         "segment_id":279,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":281,
         "segment_id":280,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":282,
         "segment_id":281,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":283,
         "segment_id":282,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":284,
         "segment_id":283,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":285,
         "segment_id":284,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":286,
         "segment_id":285,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":287,
         "segment_id":286,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":288,
         "segment_id":287,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":289,
         "segment_id":288,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":290,
         "segment_id":289,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":291,
         "segment_id":290,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":292,
         "segment_id":291,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":293,
         "segment_id":292,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":294,
         "segment_id":293,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":295,
         "segment_id":294,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":296,
         "segment_id":295,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":297,
         "segment_id":296,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":298,
         "segment_id":297,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":299,
         "segment_id":298,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":300,
         "segment_id":299,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":301,
         "segment_id":300,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":302,
         "segment_id":301,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":303,
         "segment_id":302,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":304,
         "segment_id":303,
-        "weight":0.001394
+        "weight":0.001696
       },
       {
         "cluster_id":305,
         "segment_id":304,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":306,
         "segment_id":305,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":307,
         "segment_id":306,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":308,
         "segment_id":307,
-        "weight":0.001394
+        "weight":0.001696
       },
       {
         "cluster_id":309,
         "segment_id":308,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":310,
         "segment_id":309,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":311,
         "segment_id":310,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":312,
         "segment_id":311,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":313,
         "segment_id":312,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":314,
         "segment_id":313,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":315,
         "segment_id":314,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":316,
         "segment_id":315,
-        "weight":0.001394
+        "weight":0.001696
       },
       {
         "cluster_id":317,
         "segment_id":316,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":318,
         "segment_id":317,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":319,
         "segment_id":318,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":320,
         "segment_id":319,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":321,
         "segment_id":320,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":322,
         "segment_id":321,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":323,
         "segment_id":322,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":324,
         "segment_id":323,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":325,
         "segment_id":324,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":326,
         "segment_id":325,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":327,
         "segment_id":326,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":328,
         "segment_id":327,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":329,
         "segment_id":328,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":330,
         "segment_id":329,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":331,
         "segment_id":330,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":332,
         "segment_id":331,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":333,
         "segment_id":332,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":334,
         "segment_id":333,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":335,
         "segment_id":334,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":336,
         "segment_id":335,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":337,
         "segment_id":336,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":338,
         "segment_id":337,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":339,
         "segment_id":338,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":340,
         "segment_id":339,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":341,
         "segment_id":340,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":342,
         "segment_id":341,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":343,
         "segment_id":342,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":344,
         "segment_id":343,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":345,
         "segment_id":344,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":346,
         "segment_id":345,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":347,
         "segment_id":346,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":348,
         "segment_id":347,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":349,
         "segment_id":348,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":350,
         "segment_id":349,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":351,
         "segment_id":350,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":352,
         "segment_id":351,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":353,
         "segment_id":352,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":354,
         "segment_id":353,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":355,
         "segment_id":354,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":356,
         "segment_id":355,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":357,
         "segment_id":356,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":358,
         "segment_id":357,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":359,
         "segment_id":358,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":360,
         "segment_id":359,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":361,
         "segment_id":360,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":362,
         "segment_id":361,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":363,
         "segment_id":362,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":364,
         "segment_id":363,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":365,
         "segment_id":364,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":366,
         "segment_id":365,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":367,
         "segment_id":366,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":368,
         "segment_id":367,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":369,
         "segment_id":368,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":370,
         "segment_id":369,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":371,
         "segment_id":370,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":372,
         "segment_id":371,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":373,
         "segment_id":372,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":374,
         "segment_id":373,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":375,
         "segment_id":374,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":376,
         "segment_id":375,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":377,
         "segment_id":376,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":378,
         "segment_id":377,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":379,
         "segment_id":378,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":380,
         "segment_id":379,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":381,
         "segment_id":380,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":382,
         "segment_id":381,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":383,
         "segment_id":382,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":384,
         "segment_id":383,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":385,
         "segment_id":384,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":386,
         "segment_id":385,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":387,
         "segment_id":386,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":388,
         "segment_id":387,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":389,
         "segment_id":388,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":390,
         "segment_id":389,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":391,
         "segment_id":390,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":392,
         "segment_id":391,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":393,
         "segment_id":392,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":394,
         "segment_id":393,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":395,
         "segment_id":394,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":396,
         "segment_id":395,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":397,
         "segment_id":396,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":398,
         "segment_id":397,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":399,
         "segment_id":398,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":400,
         "segment_id":399,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":401,
         "segment_id":400,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":402,
         "segment_id":401,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":403,
         "segment_id":402,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":404,
         "segment_id":403,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":405,
         "segment_id":404,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":406,
         "segment_id":405,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":407,
         "segment_id":406,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":408,
         "segment_id":407,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":409,
         "segment_id":408,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":410,
         "segment_id":409,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":411,
         "segment_id":410,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":412,
         "segment_id":411,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":413,
         "segment_id":412,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":414,
         "segment_id":413,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":415,
         "segment_id":414,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":416,
         "segment_id":415,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":417,
         "segment_id":416,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":418,
         "segment_id":417,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":419,
         "segment_id":418,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":420,
         "segment_id":419,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":421,
         "segment_id":420,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":422,
         "segment_id":421,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":423,
         "segment_id":422,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":424,
         "segment_id":423,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":425,
         "segment_id":424,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":426,
         "segment_id":425,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":427,
         "segment_id":426,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":428,
         "segment_id":427,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":429,
         "segment_id":428,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":430,
         "segment_id":429,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":431,
         "segment_id":430,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":432,
         "segment_id":431,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":433,
         "segment_id":432,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":434,
         "segment_id":433,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":435,
         "segment_id":434,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":436,
         "segment_id":435,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":437,
         "segment_id":436,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":438,
         "segment_id":437,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":439,
         "segment_id":438,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":440,
         "segment_id":439,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":441,
         "segment_id":440,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":442,
         "segment_id":441,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":443,
         "segment_id":442,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":444,
         "segment_id":443,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":445,
         "segment_id":444,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":446,
         "segment_id":445,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":447,
         "segment_id":446,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":448,
         "segment_id":447,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":449,
         "segment_id":448,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":450,
         "segment_id":449,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":451,
         "segment_id":450,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":452,
         "segment_id":451,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":453,
         "segment_id":452,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":454,
         "segment_id":453,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":455,
         "segment_id":454,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":456,
         "segment_id":455,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":457,
         "segment_id":456,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":458,
         "segment_id":457,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":459,
         "segment_id":458,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":460,
         "segment_id":459,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":461,
         "segment_id":460,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":462,
         "segment_id":461,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":463,
         "segment_id":462,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":464,
         "segment_id":463,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":465,
         "segment_id":464,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":466,
         "segment_id":465,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":467,
         "segment_id":466,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":468,
         "segment_id":467,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":469,
         "segment_id":468,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":470,
         "segment_id":469,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":471,
         "segment_id":470,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":472,
         "segment_id":471,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":473,
         "segment_id":472,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":474,
         "segment_id":473,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":475,
         "segment_id":474,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":476,
         "segment_id":475,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":477,
         "segment_id":476,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":478,
         "segment_id":477,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":479,
         "segment_id":478,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":480,
         "segment_id":479,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":481,
         "segment_id":480,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":482,
         "segment_id":481,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":483,
         "segment_id":482,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":484,
         "segment_id":483,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":485,
         "segment_id":484,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":486,
         "segment_id":485,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":487,
         "segment_id":486,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":488,
         "segment_id":487,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":489,
         "segment_id":488,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":490,
         "segment_id":489,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":491,
         "segment_id":490,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":492,
         "segment_id":491,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":493,
         "segment_id":492,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":494,
         "segment_id":493,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":495,
         "segment_id":494,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":496,
         "segment_id":495,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":497,
         "segment_id":496,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":498,
         "segment_id":497,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":499,
         "segment_id":498,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":500,
         "segment_id":499,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":501,
         "segment_id":500,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":502,
         "segment_id":501,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":503,
         "segment_id":502,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":504,
         "segment_id":503,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":505,
         "segment_id":504,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":506,
         "segment_id":505,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":507,
         "segment_id":506,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":508,
         "segment_id":507,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":509,
         "segment_id":508,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":510,
         "segment_id":509,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":511,
         "segment_id":510,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":512,
         "segment_id":511,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":513,
         "segment_id":512,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":514,
         "segment_id":513,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":515,
         "segment_id":514,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":516,
         "segment_id":515,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":517,
         "segment_id":516,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":518,
         "segment_id":517,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":519,
         "segment_id":518,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":520,
         "segment_id":519,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":521,
         "segment_id":520,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":522,
         "segment_id":521,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":523,
         "segment_id":522,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":524,
         "segment_id":523,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":525,
         "segment_id":524,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":526,
         "segment_id":525,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":527,
         "segment_id":526,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":528,
         "segment_id":527,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":529,
         "segment_id":528,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":530,
         "segment_id":529,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":531,
         "segment_id":530,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":532,
         "segment_id":531,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":533,
         "segment_id":532,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":534,
         "segment_id":533,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":535,
         "segment_id":534,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":536,
         "segment_id":535,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":537,
         "segment_id":536,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":538,
         "segment_id":537,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":539,
         "segment_id":538,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":540,
         "segment_id":539,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":541,
         "segment_id":540,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":542,
         "segment_id":541,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":543,
         "segment_id":542,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":544,
         "segment_id":543,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":545,
         "segment_id":544,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":546,
         "segment_id":545,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":547,
         "segment_id":546,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":548,
         "segment_id":547,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":549,
         "segment_id":548,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":550,
         "segment_id":549,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":551,
         "segment_id":550,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":552,
         "segment_id":551,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":553,
         "segment_id":552,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":554,
         "segment_id":553,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":555,
         "segment_id":554,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":556,
         "segment_id":555,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":557,
         "segment_id":556,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":558,
         "segment_id":557,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":559,
         "segment_id":558,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":560,
         "segment_id":559,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":561,
         "segment_id":560,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":562,
         "segment_id":561,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":563,
         "segment_id":562,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":564,
         "segment_id":563,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":565,
         "segment_id":564,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":566,
         "segment_id":565,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":567,
         "segment_id":566,
-        "weight":0.001568
+        "weight":0.001527
       },
       {
         "cluster_id":568,
         "segment_id":567,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":569,
         "segment_id":568,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":570,
         "segment_id":569,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":571,
         "segment_id":570,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":572,
         "segment_id":571,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":573,
         "segment_id":572,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":574,
         "segment_id":573,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":575,
         "segment_id":574,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":576,
         "segment_id":575,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":577,
         "segment_id":576,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":578,
         "segment_id":577,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":579,
         "segment_id":578,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":580,
         "segment_id":579,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":581,
         "segment_id":580,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":582,
         "segment_id":581,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":583,
         "segment_id":582,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":584,
         "segment_id":583,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":585,
         "segment_id":584,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":586,
         "segment_id":585,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":587,
         "segment_id":586,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":588,
         "segment_id":587,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":589,
         "segment_id":588,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":590,
         "segment_id":589,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":591,
         "segment_id":590,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":592,
         "segment_id":591,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":593,
         "segment_id":592,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":594,
         "segment_id":593,
-        "weight":0.001743
+        "weight":0.001696
       },
       {
         "cluster_id":595,
         "segment_id":594,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":596,
         "segment_id":595,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":597,
         "segment_id":596,
-        "weight":0.001568
+        "weight":0.001696
       },
       {
         "cluster_id":598,
         "segment_id":597,
-        "weight":0.001394
+        "weight":0.001696
       },
       {
         "cluster_id":599,
         "segment_id":598,
-        "weight":0.001743
+        "weight":0.001527
       },
       {
         "cluster_id":600,
         "segment_id":599,
-        "weight":0.001743
+        "weight":0.001696
       }
     ]
   },


### PR DESCRIPTION
I made some changes to the iterative tracing sequence due to issues with running the simulation:

1. Renamed folders to follow the "Timestep_#" format before running raw2trace.
2. Updated the yabloc tracing folder.
3. Set a limit on the maximum process count during the raw2trace stage.