### PR TITLE
Resolving error for trim_type "2" simulation

### DIFF
--- a/common/scripts/run_memtrace_single_simpoint.sh
+++ b/common/scripts/run_memtrace_single_simpoint.sh
@@ -130,7 +130,7 @@ else
     #                 # do not use fetch count
     scarabCmd="$SCARABHOME/src/scarab \
     --frontend memtrace \
-    --cbp_trace_r0=$TRACEFILE/$segID/trace/$segID.zip \
+    --cbp_trace_r0=$TRACEFILE/trace/$segID.zip \
     --memtrace_modules_log=$MODULESDIR/$segID/raw \
     --inst_limit=$instLimit \
     --full_warmup=$WARMUP \


### PR DESCRIPTION
There was an error on running trim_type "2" simulation as the wrong trace file's path.