### PR TITLE
trim_type is written incorrect in finish_trace

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -639,9 +639,9 @@ def finish_trace(user, descriptor_data, workload_db_path, suite_db_path, dbg_lvl
             exec_dict['client_bincmd'] = config['client_bincmd']
             memtrace_dict = {}
             memtrace_dict['image_name'] = "allbench_traces"
-            if config['trace_type'] == "cluster_then_trace":
+            if config['trace_type'] == "trace_then_cluster":
                 trim_type = 1
-            elif config['trace_type'] == "trace_then_cluster":
+            elif config['trace_type'] == "cluster_then_trace":
                 trim_type = 2
             elif config['trace_type'] == "iterative_trace":
                 trim_type = 3

--- a/workloads/workloads_db.json
+++ b/workloads/workloads_db.json
@@ -9735,7 +9735,7 @@
       },
       "memtrace":{
         "image_name":"allbench_traces",
-        "trim_type":2,
+        "trim_type":1,
         "segment_size":10000000,
         "whole_trace_file":"drmemtrace.geekbench_avx2.00041.5550.trace.zip"
       }
@@ -9823,7 +9823,7 @@
       },
       "memtrace":{
         "image_name":"allbench_traces",
-        "trim_type":2,
+        "trim_type":1,
         "segment_size":10000000,
         "whole_trace_file":"drmemtrace.geekbench_avx2.00041.3463.trace.zip"
       }
@@ -10297,7 +10297,7 @@
       },
       "memtrace":{
         "image_name":"allbench_traces",
-        "trim_type":2,
+        "trim_type":1,
         "segment_size":10000000,
         "whole_trace_file":"drmemtrace.geekbench_avx2.00041.8896.trace.zip"
       }
@@ -10525,7 +10525,7 @@
       },
       "memtrace":{
         "image_name":"allbench_traces",
-        "trim_type":2,
+        "trim_type":1,
         "segment_size":10000000,
         "whole_trace_file":"drmemtrace.geekbench_avx2.00041.9068.trace.zip"
       }
@@ -10658,7 +10658,7 @@
       },
       "memtrace":{
         "image_name":"allbench_traces",
-        "trim_type":2,
+        "trim_type":1,
         "segment_size":10000000,
         "whole_trace_file":"drmemtrace.geekbench_avx2.00041.3949.trace.zip"
       }
@@ -10851,7 +10851,7 @@
       },
       "memtrace":{
         "image_name":"allbench_traces",
-        "trim_type":2,
+        "trim_type":1,
         "segment_size":10000000,
         "whole_trace_file":"drmemtrace.geekbench_avx2.00041.8808.trace.zip"
       }
@@ -11004,7 +11004,7 @@
       },
       "memtrace":{
         "image_name":"allbench_traces",
-        "trim_type":2,
+        "trim_type":1,
         "segment_size":10000000,
         "whole_trace_file":"drmemtrace.geekbench_avx2.00041.5264.trace.zip"
       }
@@ -11172,7 +11172,7 @@
       },
       "memtrace":{
         "image_name":"allbench_traces",
-        "trim_type":2,
+        "trim_type":1,
         "segment_size":10000000,
         "whole_trace_file":"drmemtrace.geekbench_avx2.00041.9238.trace.zip"
       }
@@ -11305,7 +11305,7 @@
       },
       "memtrace":{
         "image_name":"allbench_traces",
-        "trim_type":2,
+        "trim_type":1,
         "segment_size":10000000,
         "whole_trace_file":"drmemtrace.geekbench_avx2.00041.3548.trace.zip"
       }


### PR DESCRIPTION
nine geekbench workloads got wrong trim_type when they were traced