### PR TITLE
Stat retreive fix

### DIFF
--- a/scarab_stats/scarab_stats.py
+++ b/scarab_stats/scarab_stats.py
@@ -1579,24 +1579,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     da = stat_aggregator()
-    
-    # E = da.load_experiment_json(args.descriptor_name, True)
-    # E.to_csv("micro.csv")
-
-    E = da.load_experiment_csv("micro.csv")
-
-    experiment_name = E.get_experiments()[0]
-    wl_to_plot = E.get_workloads()
-    configs_to_plot = E.get_configurations()
-
-    stats_to_plot = ["Cumulative_IPC"]
-
-    da.plot_workloads(E, stats_to_plot, wl_to_plot, configs_to_plot, y_label = "IPC", x_label="Workloads", average=True, plot_name="micro.png")
-    print(E.retrieve_stats(configs_to_plot, stats_to_plot, wl_to_plot))
-
-    exit(1)
-
-
+    E = da.load_experiment_json(args.descriptor_name, True)
     E.to_csv("fast.csv")
     # exit(1)
     EL = da.load_experiment_csv("fast.csv")

--- a/scarab_stats/scarab_stats.py
+++ b/scarab_stats/scarab_stats.py
@@ -99,7 +99,6 @@ class Experiment:
                         values = list(map(float, values))
                         weights = list(map(float, weights))
                         results[f"{c} {w} {stat}"] = sum([v*w for v, w in zip(values, weights)])
-                        print(values, weights, sum([v*w for v, w in zip(values, weights)]))
 
         elif aggregation_level == "Simpoint":
             for c in config:
@@ -1592,7 +1591,7 @@ if __name__ == "__main__":
 
     stats_to_plot = ["Cumulative_IPC"]
 
-    da.plot_workloads(E, stats_to_plot, wl_to_plot, configs_to_plot, y_label = "IPC", x_label="Workloads", average=False, plot_name="micro.png")
+    da.plot_workloads(E, stats_to_plot, wl_to_plot, configs_to_plot, y_label = "IPC", x_label="Workloads", average=True, plot_name="micro.png")
     print(E.retrieve_stats(configs_to_plot, stats_to_plot, wl_to_plot))
 
     exit(1)


### PR DESCRIPTION
Fixed error in retrieving stats that would occur when one config's name was a subset of another config, causing aggregation errors while plotting
Ex:
FDIP would also match Ideal_FDIP, and the weights of both runs would sum to 2.0