### PR TITLE
copy scarab binary only when the src/dest binaries differ or no dest binary eixsts

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -218,12 +218,10 @@ def prepare_simulation(user, scarab_path, scarab_build, docker_home, experiment_
             except subprocess.CalledProcessError as e:
                 if e.returncode == 1 or e.returncode == 2:
                     info("scarab binaries differ or the destination binary does not exist. Will copy.", dbg_lvl)
-                    result = subprocess.run(["cp", scarab_bin, f"{experiment_dir}/scarab/src/scarab"],
-                                           capture_output=True,
-                                           text=True)
+                    result = subprocess.run(["cp", scarab_bin, dest_scarab_bin], capture_output=True, text=True)
                     if result.returncode != 0:
                         err(f"Failed to copy scarab binary: {result.stderr}", dbg_lvl)
-                        raise RuntimeError(f"Failed to copy scarab binary: {result.stderr}")
+                        raise RuntimeError(f"Failed to copy scarab binary. Existing binary is in use and differs from the new binary: {result.stderr}")
                 else:
                     raise e
         try:

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -212,11 +212,20 @@ def prepare_simulation(user, scarab_path, scarab_build, docker_home, experiment_
                 scarab_bin = f"{scarab_path}/src/build/{scarab_build}/scarab"
             else:
                 scarab_bin = f"{scarab_path}/src/build/opt/scarab"
-            result = subprocess.run(["cp", scarab_bin, f"{experiment_dir}/scarab/src/scarab"],
-                                   capture_output=True,
-                                   text=True)
-            if result.returncode != 0:
-                err(f"Failed to copy scarab binary: {result.stderr}", dbg_lvl)
+            dest_scarab_bin = f"{experiment_dir}/scarab/src/scarab"
+            try:
+                result = subprocess.run(['diff', '-q', scarab_bin, dest_scarab_bin], capture_output=True, text=True, check=True)
+            except subprocess.CalledProcessError as e:
+                if e.returncode == 1 or e.returncode == 2:
+                    info("scarab binaries differ or the destination binary does not exist. Will copy.", dbg_lvl)
+                    result = subprocess.run(["cp", scarab_bin, f"{experiment_dir}/scarab/src/scarab"],
+                                           capture_output=True,
+                                           text=True)
+                    if result.returncode != 0:
+                        err(f"Failed to copy scarab binary: {result.stderr}", dbg_lvl)
+                        raise RuntimeError(f"Failed to copy scarab binary: {result.stderr}")
+                else:
+                    raise e
         try:
             os.symlink(f"{experiment_dir}/scarab/src/scarab", f"{experiment_dir}/scarab/src/scarab_{scarab_githash}")
         except FileExistsError:

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -217,7 +217,6 @@ def prepare_simulation(user, scarab_path, scarab_build, docker_home, experiment_
                                    text=True)
             if result.returncode != 0:
                 err(f"Failed to copy scarab binary: {result.stderr}", dbg_lvl)
-                raise RuntimeError(f"Failed to copy scarab binary: {result.stderr}")
         try:
             os.symlink(f"{experiment_dir}/scarab/src/scarab", f"{experiment_dir}/scarab/src/scarab_{scarab_githash}")
         except FileExistsError:


### PR DESCRIPTION
This will allow running additional configurations within the same experiment directory
while it still checks if the scarab binary is busy when the binary is updated.