### PR TITLE
Add an instruction for proper 'docker pull' and fix for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,14 @@ gdown https://drive.google.com/uc?id=1tfKL7wYK1mUqpCH8yPaPVvxk2UIAJrOX
 tar -xzvf simpoint_traces.tar.gz
 ```
 5. Optional: Install [Slurm](docs/slurm_install_guide.md)
-
+6. Optional: To pull the pre-built docker image from GitHub Packages, make sure your token has `read:packages` permission.
+You should be able to `docker login`
+```
+echo <YOUR_GITHUB_TOKEN> | docker login ghcr.io -u <YOUR_GITHUB_USERNAME> --password-stdin
+```
 ## Set up the environment (Docker image)
 ### Alternative 1. Download a pre-built Docker image where GitHash refers to the short git hash of the current scarab-infra commit.
+To pull the image, please complete `Requirement 6`.
 ```
 export GIT_HASH=$(git rev-parse --short HEAD)
 docker pull ghcr.io/litz-lab/scarab-infra/allbench_traces:$GIT_HASH

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -777,3 +777,10 @@ def count_interactive_shells(container_name, dbg_lvl):
     except Exception as e:
         print(f"Error: {e}")
         return 0
+
+def image_exist(image_tag):
+    try:
+        output = subprocess.check_output(["docker", "images", "-q", image_tag])
+        return bool(output.strip())
+    except subprocess.CalledProcessError:
+        return False


### PR DESCRIPTION
`docker pull` command became not working without proper permission setup after `Docker Image Manifest V2`.

Fix:
1. Instructions to correctly setup the requirement based on the [GitHub Doc `Working with the Container registry`](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
2. Check the output of `docker pull` command and handle it properly. Only build a new image when it is not available by `docker pull`