### PR TITLE
Fix quickstart_env.yaml for non-stats-lib python scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ sudo chmod 666 /var/run/docker.sock
 ```
 conda env create --file quickstart_env.yaml
 ```
+Optional: if you want to remove the existing `scarabinfra` and re-create it, run the following first.
+```
+conda env remove -n scarabinfra
+```
 4. Activate the virtual environment.
 ```
 conda activate scarabinfra

--- a/quickstart_env.yaml
+++ b/quickstart_env.yaml
@@ -2,12 +2,12 @@ name: scarabinfra
 channels:
 - conda-forge
 dependencies:
-- python=3.8.10
+- python=3.12
 - pip
 - pip:
   - notebook==7.1.3
-  - pandas==1.4.1
-  - matplotlib==3.5.1
-  - numpy==1.22.2
+  - pandas>=2.1.0
+  - matplotlib>=3.8.0
+  - numpy>=1.26.0
   - psutil==5.9.8
-  - docker==5.0.3
+  - docker>=6.1.0


### PR DESCRIPTION
non-stats-lib python scripts have been running without conda venv on our machines.
This PR integrates the package versions to make all the Python scripts we have work within a single virtual environment.