### PR TITLE
Fix a bug on the image_exist exception handler

### DIFF
--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -69,7 +69,7 @@ def prepare_docker_image(nodes, docker_prefix, githash, dbg_lvl = 1):
                 except subprocess.CalledProcessError as e:
                     err("Docker pull failed:\n" + e.output.decode(), dbg_lvl)
                     subprocess.check_output(["srun", f"--nodelist={node}", "./run.sh", "-b", docker_prefix])
-                    if not image_exist(image_tag):
+                    if not image_exist(image_tag, node):
                         err(f"Still couldn't find image {image_tag} after trying to build one", dbg_lvl)
                         exit(1)
             available_nodes.append(node)

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -54,6 +54,11 @@ def write_json_descriptor(filename, descriptor_data, dbg_lvl = 1):
     except json.JSONDecodeError as e:
             print(f"JSONDecodeError: {e}")
 
+def run_on_node(cmd, node=None, **kwargs):
+    if node != None:
+        cmd = ["srun", f"--nodelist={node}"] + cmd
+    return subprocess.run(cmd, **kwargs)
+
 def validate_simulation(workloads_data, simulations, dbg_lvl = 2):
     for simulation in simulations:
         suite = simulation["suite"]
@@ -765,9 +770,9 @@ def count_interactive_shells(container_name, dbg_lvl):
         print(f"Error: {e}")
         return 0
 
-def image_exist(image_tag):
+def image_exist(image_tag, node=None):
     try:
-        output = subprocess.check_output(["docker", "images", "-q", image_tag])
-        return bool(output.strip())
+        output = run_on_node(["docker", "images", "-q", image_tag], node, capture_output=True, text=True)
+        return bool(output.stdout.strip())
     except subprocess.CalledProcessError:
         return False


### PR DESCRIPTION
image_exist function bug fix

The image_exist implementation didn't cover the slurm use-cases.
If "docker pull fail" occurs, we should run the image_check function to the target_node, not local.