### PR TITLE
Add more detailed exception msg

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -248,6 +248,8 @@ def prepare_simulation(user, scarab_path, scarab_build, docker_home, experiment_
         os.system(f"cp {scarab_path}/bin/scarab_globals/*  {experiment_dir}/scarab/bin/scarab_globals/ ")
 
         return scarab_githash
+    except subprocess.CalledProcessError as e:
+        info(e.stderr.strip(), dbg_lvl)
     except Exception as e:
         subprocess.run(["docker", "rm", "-f", docker_container_name], check=True)
         info(f"Removed container: {docker_container_name}", dbg_lvl)

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -248,11 +248,10 @@ def prepare_simulation(user, scarab_path, scarab_build, docker_home, experiment_
         os.system(f"cp {scarab_path}/bin/scarab_globals/*  {experiment_dir}/scarab/bin/scarab_globals/ ")
 
         return scarab_githash
-    except subprocess.CalledProcessError as e:
-        info(e.stderr.strip(), dbg_lvl)
     except Exception as e:
         subprocess.run(["docker", "rm", "-f", docker_container_name], check=True)
         info(f"Removed container: {docker_container_name}", dbg_lvl)
+        info(e.stderr.strip(), dbg_lvl)
         raise e
 
 def finish_simulation(user, docker_home, descriptor_path, root_dir, experiment_name, slurm_ids = None):


### PR DESCRIPTION
I think we need more detailed exception msg, when we don't have a proper docker image for generating container.

As-is
```shell
Traceback (most recent call last):
  File "/soe/mkim293/seop/scarab-infra/scripts/slurm_runner.py", line 416, in run_simulation
    scarab_githash = prepare_simulation(user, scarab_path, scarab_build, descriptor_data['root_dir'], experiment_name, architecture, docker_prefix, githash, infra_dir, False, dbg_lvl)^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/soe/mkim293/seop/scarab-infra/scripts/utilities.py", line 254, in prepare_simulation
    raise e
  File "/soe/mkim293/seop/scarab-infra/scripts/utilities.py", line 183, in prepare_simulation
    subprocess.run(
  File "/usr/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
``` 

to-be
```shell
Unable to find image 'allbench_traces:b3ec486' locally
``` 
