### PR TITLE
Fix ModuleNotFoundError which results in workflow failure

### DIFF
--- a/scarab_stats/scarab_stats.py
+++ b/scarab_stats/scarab_stats.py
@@ -11,6 +11,7 @@ import os
 import math
 import importlib
 import sys
+sys.path.append("../")
 import scripts.utilities as utilities
 importlib.reload(utilities)
 

--- a/scarab_stats/scarab_stats.py
+++ b/scarab_stats/scarab_stats.py
@@ -11,7 +11,6 @@ import os
 import math
 import importlib
 import sys
-sys.path.append("../") # go to parent dir
 import scripts.utilities as utilities
 importlib.reload(utilities)
 

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -7,6 +7,7 @@ import subprocess
 import argparse
 import os
 import docker
+import sys
 
 from utilities import (
         info,

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -228,7 +228,10 @@ if __name__ == "__main__":
     infra_dir = args.scarab_infra
 
     if infra_dir == None:
-        infra_dir = subprocess.check_output(["pwd"]).decode("utf-8").split("\n")[0]
+        infra_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+    # Add the project root to sys.path
+    sys.path.insert(0, infra_dir)
 
     # Get user for commands
     user = subprocess.check_output("whoami").decode('utf-8')[:-1]

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -9,11 +9,6 @@ import re
 import docker
 import importlib
 import sys
-
-# Add the project root to sys.path
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, project_root)
-
 import workloads.extract_top_simpoints as extract_top_simpoints
 importlib.reload(extract_top_simpoints)
 

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -10,15 +10,12 @@ import docker
 import importlib
 import sys
 
-# Temporarily add the project root to sys.path
+# Add the project root to sys.path
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, project_root)
 
 import workloads.extract_top_simpoints as extract_top_simpoints
 importlib.reload(extract_top_simpoints)
-
-# Restore sys.path to avoid polluting the global import space
-sys.path.pop(0)
 
 # Print an error message if on right debugging level
 def err(msg: str, level: int):

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -9,10 +9,16 @@ import re
 import docker
 import importlib
 import sys
-sys.path.append("../") # go to parent dir
+
+# Temporarily add the project root to sys.path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, project_root)
+
 import workloads.extract_top_simpoints as extract_top_simpoints
 importlib.reload(extract_top_simpoints)
 
+# Restore sys.path to avoid polluting the global import space
+sys.path.pop(0)
 
 # Print an error message if on right debugging level
 def err(msg: str, level: int):

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -8,7 +8,6 @@ import subprocess
 import re
 import docker
 import importlib
-import sys
 import workloads.extract_top_simpoints as extract_top_simpoints
 importlib.reload(extract_top_simpoints)
 


### PR DESCRIPTION
# Intro
Previous commit add `__init__` makes workload become module, but it is still not found.
This commit fixes ModuleNotFoundError by replacing relative sys.path.append("../") with an absolute path insertion.

# Eval
Works in an env without conda