### PR TITLE
bug fix for the extract_top_simpoint func

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -839,8 +839,8 @@ def finish_trace(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl):
             workload_db_data[suite][subsuite][workload] = workload_dict
 
         write_json_descriptor(workload_db_path, workload_db_data, dbg_lvl)
-        top_simpoint_workload = extract_top_simpoints.extract_workloads_with_simpoints(workload_db_data)
-        write_json_descriptor(f"{infra_dir}/workloads/workloads_top_simp.json", top_simpoint_workload, dbg_lvl)
+        extract_top_simpoints.modify_simpoints_in_place(workload_db_data)
+        write_json_descriptor(f"{infra_dir}/workloads/workloads_top_simp.json", workload_db_data, dbg_lvl)
 
         print("Recover the ASLR setting with sudo. Provide password..")
         os.system("echo 2 | sudo tee /proc/sys/kernel/randomize_va_space")


### PR DESCRIPTION
There was no matching function for extract_top_simpoints.modify_simpoints_in_place in extract_top_simpoints.py.
And, extract_workloads_with_simpoints seems like the core entry func for this script. So, I made this change.