### PR TITLE
Fix for a workflow error

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -66,7 +66,8 @@ jobs:
 
       - name: Build Docker image
         if: steps.changes.outputs.changed == 'true'
-        run: docker build . \
+        run: |
+          docker build . \
           --file ./workloads/allbench_traces/Dockerfile \
           --no-cache \
           --tag ghcr.io/litz-lab/scarab-infra/allbench_traces:${{ steps.current_hash.outputs.githash }}


### PR DESCRIPTION
Since https://github.com/litz-lab/scarab-infra/pull/158, we have never executed the command (docker build) within the workflow. https://github.com/litz-lab/scarab-infra/pull/158 made the workflow only build the image when we find the changes within ./common.

https://github.com/litz-lab/scarab-infra/pull/160 first tried to build the image within the workflow, and it failed due to a missing `|` for the command with the line breaks.

Before that, I used the single-line command instead of with the line break. The line break requires | for the run part.