### PR TITLE
Add a missing warmup field update in top_simpoint.json

### DIFF
--- a/json/top_simpoint.json
+++ b/json/top_simpoint.json
@@ -24,7 +24,8 @@
       "subsuite":"rate_int",
       "workload":"perlbench",
       "cluster_id":29229,
-      "simulation_type":"memtrace"
+      "simulation_type":"memtrace",
+      "warmup":null
     }
   ],
   "_configurations": "scarab configurations to sweep",


### PR DESCRIPTION
`warmup` key has been introduced in https://github.com/litz-lab/scarab-infra/pull/177
Add a missing key in `top_simpoint.json` not only in `exp.json`.

This change will make the scarab workflow run 50M warmup and 10M warmup.
The trace itself (release - top_simpoint_traces.tar.gz) has been updated already.