### PR TITLE
trace_then_cluster pipeline bug

### DIFF
--- a/common/scripts/run_trace_post_processing.sh
+++ b/common/scripts/run_trace_post_processing.sh
@@ -74,13 +74,20 @@ do
   mkdir $segmentID
   # do not care about the params file
   cd $segmentID
+
+  ROI_BEGIN=$(( segmentID * SEGSIZE + 1 ))
+  ROI_END=$(( segmentID * SEGSIZE + SEGSIZE ))
+  if [ "$segmentID" -eq 0 ]; then
+    ROI_BEGIN=2
+    ROI_END=$(( SEGSIZE + 1 ))
+  fi
+  
   scarabCmd="$SIMPOINTHOME/scarab/src/scarab --frontend memtrace \
             --cbp_trace_r0=$TRACEFILE \
-            --memtrace_modules_log=$MODULESDIR \
             --mode=trace_bbv_distributed \
             --segment_instr_count=$SEGSIZE \
-            --memtrace_roi_begin=$(( $segmentID * $SEGSIZE + 1 )) \
-            --memtrace_roi_end=$(( $segmentID * $SEGSIZE + $SEGSIZE )) \
+            --memtrace_roi_begin=$ROI_BEGIN \
+            --memtrace_roi_end=$ROI_END \
             --trace_bbv_output=$OUTDIR/fingerprint/pieces/segment.$segmentID \
             --trace_footprint_output=$OUTDIR/fingerprint/footprint_pieces/segment.$segmentID \
             --use_fetched_count=1 \

--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -347,7 +347,7 @@ def run_tracing(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl = 2)
             err("Error: Not in a Git repository or unable to retrieve Git hash.")
 
 
-        prepare_trace(user, scarab_path, scarab_build, docker_home, trace_name, infra_dir, docker_prefix_list, githash, False, None, dbg_lvl)
+        prepare_trace(user, scarab_path, scarab_build, docker_home, trace_name, infra_dir, docker_prefix_list, githash, False, dbg_lvl=dbg_lvl)
 
         # Iterate over each trace configuration
         for config in trace_configs:

--- a/scripts/run_trace.py
+++ b/scripts/run_trace.py
@@ -135,7 +135,7 @@ def open_interactive_shell(user, descriptor_data, infra_dir, dbg_lvl = 1):
             if entry not in f.read():
                 f.write(f"\n{entry}\n")
 
-        prepare_trace(user, scarab_path, scarab_build, docker_home, trace_name, infra_dir, docker_prefix, githash, True, dbg_lvl)
+        prepare_trace(user, scarab_path, scarab_build, docker_home, trace_name, infra_dir, docker_prefix, githash, True, dbg_lvl=dbg_lvl)
         if trace_scenario["env_vars"] != None:
             env_vars = trace_scenario["env_vars"].split()
         else:

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -830,7 +830,7 @@ def run_tracing(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl = 2)
             exit(1)
 
         trace_dir = f"{descriptor_data['root_dir']}/simpoint_flow/{trace_name}"
-        prepare_trace(user, scarab_path, scarab_build, docker_home, trace_name, infra_dir, docker_prefix_list, githash, False, available_slurm_nodes, dbg_lvl)
+        prepare_trace(user, scarab_path, scarab_build, docker_home, trace_name, infra_dir, docker_prefix_list, githash, False, available_slurm_nodes, dbg_lvl=dbg_lvl)
 
         # Iterate over each trace configuration
         for config in trace_configs:


### PR DESCRIPTION
1. segment.0 was fail with segfault (ROI_BEGIN: 1, ROI_END: 10000000 setup)
2. available_slurm_nodes was delivered with "None" from local_runner.py and it caused an error at "nodes = [None] + nodes, utilities.py 188 line".