### PR TITLE
Some random traces have been skipped accidentally by the wrong “check…

### DIFF
--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -179,7 +179,7 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                     # Create temp file with run command and run it
                     filename = f"{docker_container_name}_tmp_run.sh"
 
-                    if check_can_skip(descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, debug_lvl=dbg_lvl):
+                    if check_can_skip(descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, sim_mode, user, debug_lvl=dbg_lvl):
                         info(f"Skipping {workload} with config {config_key} and cluster id {cluster_id}", dbg_lvl)
                         continue
 

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -646,7 +646,7 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                     for node_list in slurm_running_sims.values():
                         running_sims += node_list
 
-                    if check_can_skip(descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, running_sims, dbg_lvl):
+                    if check_can_skip(descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, running_sims, sim_mode, user, dbg_lvl):
                         info(f"Skipping {workload} with config {config_key} and cluster id {cluster_id}", dbg_lvl)
                         continue
 

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -956,7 +956,7 @@ def clean_failed_run (descriptor_data, config_key, suite, subsuite, workload, ex
 # Please use as follows:
 # if check_can_skip(...):
 #     continue
-def check_can_skip (descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, slurm_queue=None, debug_lvl=1):
+def check_can_skip (descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, sim_mode, user, slurm_queue=None, debug_lvl=1):
     # Check (re)run conditions 
     if check_sp_exist(descriptor_data, config_key, suite, subsuite, workload, cluster_id):
         # Previous run exists, check if it failed
@@ -984,7 +984,7 @@ def check_can_skip (descriptor_data, config_key, suite, subsuite, workload, clus
             for entry in slurm_queue:
                 # Check for following identifier. Should be of form <docker_prefix>_...as below..._<sim_mode>_<user>
                 # Docker prefix and username checked in slurm_runner
-                if f"{suite}_{subsuite}_{workload}_{descriptor_data["experiment"]}_{config_key}_{cluster_id}_" in entry:
+                if f"{suite}_{subsuite}_{workload}_{descriptor_data["experiment"]}_{config_key}_{cluster_id}_{sim_mode}_{user}" in entry:
                     # Job is in the queue, it will be run shortly.
                     info(f"Job for {config_key} for workload {workload} is in the queue. Other script will run it.", debug_lvl)
                     return True

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -984,7 +984,7 @@ def check_can_skip (descriptor_data, config_key, suite, subsuite, workload, clus
             for entry in slurm_queue:
                 # Check for following identifier. Should be of form <docker_prefix>_...as below..._<sim_mode>_<user>
                 # Docker prefix and username checked in slurm_runner
-                if f"{suite}_{subsuite}_{workload}_{descriptor_data["experiment"]}_{config_key}_{cluster_id}_{sim_mode}_{user}" in entry:
+                if f"{suite}_{subsuite}_{workload}_{descriptor_data["experiment"]}_{config_key.replace("/", "-")}_{cluster_id}_{sim_mode}_{user}" in entry:
                     # Job is in the queue, it will be run shortly.
                     info(f"Job for {config_key} for workload {workload} is in the queue. Other script will run it.", debug_lvl)
                     return True

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -984,7 +984,7 @@ def check_can_skip (descriptor_data, config_key, suite, subsuite, workload, clus
             for entry in slurm_queue:
                 # Check for following identifier. Should be of form <docker_prefix>_...as below..._<sim_mode>_<user>
                 # Docker prefix and username checked in slurm_runner
-                if f"{suite}_{subsuite}_{workload}_{descriptor_data["experiment"]}_{config_key}_{cluster_id}" in entry:
+                if f"{suite}_{subsuite}_{workload}_{descriptor_data["experiment"]}_{config_key}_{cluster_id}_" in entry:
                     # Job is in the queue, it will be run shortly.
                     info(f"Job for {config_key} for workload {workload} is in the queue. Other script will run it.", debug_lvl)
                     return True


### PR DESCRIPTION
Some random traces have been skipped accidentally by the wrong “check_can_skip” function’s implementation.

Example)
cluster_id : 48
/soe/mkim293/seop/simulations/spec2017_cascade_lake/spec2017/spec2017/rate_int_test/omnetpp_r/48

Experiment for cluster_id “48” has been skipped as the check_can_skip function condition.

```shell
issue log

if f"{suite}_{subsuite}_{workload}_{descriptor_data["experiment"]}_{config_key}_{cluster_id}" in entry:
    skip

"allbench_traces_spec2017_rate_int_test_omnetpp_r_spec2017_cascade_lake_spec2017_48"_memtrace_mkim293
“allbench_traces_spec2017_rate_int_test_omnetpp_r_spec2017_cascade_lake_spec2017_48”54_memtrace_mkim293
(The 2nd experiment will be filtered out)

~spec2017_4854_memtrace_mkim293 was skipped accidently as "~spec2017_48" has been already added.
``` 

The “If” statement returns “true” because, the 4854(cluster_id) contains the “48”.