### PR TITLE
Config versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+workloads/spec2017/cpu2017-1_0_5.iso
+scarab_builds/*

--- a/common/scripts/run_exec_single_simpoint.sh
+++ b/common/scripts/run_exec_single_simpoint.sh
@@ -16,6 +16,7 @@ SEGMENT_ID="$8"
 ENVVAR="$9"
 BINCMD="${10}"
 CLIENT_BINCMD="${11}"
+SCARAB_HASH="${12}"
 
 for token in $ENVVAR;
 do
@@ -45,6 +46,7 @@ if [ "$SEGMENT_ID" == "0" ]; then
   start_inst=100000000
   scarabCmd="
   python3 $SCARABHOME/bin/scarab_launch.py --program=\"$BINCMD\" \
+    --scarab=src/scarab_$SCARAB_HASH \
     --simdir=\"$SIMHOME/$SCENARIONUM/\" \
     --pintool_args=\"-hyper_fast_forward_count $start_inst\" \
     --scarab_args=\"--inst_limit $SEGSIZE --full_warmup $WARMUP $SCARABPARAMS\" \
@@ -74,6 +76,7 @@ else
 
   scarabCmd="
   python3 $SCARABHOME/bin/scarab_launch.py --program=\"$BINCMD\" \
+  --scarab=src/scarab_$SCARAB_HASH \
   --simdir=\"$SIMHOME/$SCENARIONUM/$clusterID\" \
   --pintool_args=\"-hyper_fast_forward_count $roiStart\" \
   --scarab_args=\"--inst_limit $instLimit --full_warmup $WARMUP $SCARABPARAMS\" \

--- a/common/scripts/run_memtrace_single_simpoint.sh
+++ b/common/scripts/run_memtrace_single_simpoint.sh
@@ -19,6 +19,7 @@ TRACE_TYPE="$8"
 SCARABHOME="$9"
 SEGMENT_ID="${10}"
 TRACEFILE="${11}"
+SCARAB_HASH="${12}"
 
 SIMHOME=$SCENARIO/$WORKLOAD_HOME
 mkdir -p $SIMHOME
@@ -34,7 +35,7 @@ cd $OUTDIR/$segID
 # SEGMENT_ID > 0 represents segmented trace (simpoint) simulation
 if [ "$SEGMENT_ID" == "0" ]; then
   traceMap=$(ls $trace_home/$WORKLOAD_HOME/traces/whole/)
-  scarabCmd="$SCARABHOME/src/scarab \
+  scarabCmd="$SCARABHOME/src/scarab_$SCARAB_HASH \
   --frontend memtrace \
   --cbp_trace_r0=$trace_home/$WORKLOAD_HOME/traces/whole/${traceMap} \
   $SCARABPARAMS &> sim.log"
@@ -66,7 +67,7 @@ else
     numChunk=$(unzip -l "$TRACEFILE" 2>/dev/null | grep "chunk." | wc -l)
     instLimit=$((numChunk * 10000000))
 
-    scarabCmd="$SCARABHOME/src/scarab \
+    scarabCmd="$SCARABHOME/src/scarab_$SCARAB_HASH \
     --frontend memtrace \
     --cbp_trace_r0=$TRACEFILE \
     --inst_limit=$instLimit \
@@ -86,7 +87,7 @@ else
       #echo "ROISTART"
       #echo "$TRACEFILE"
       #echo "$segID"
-      scarabCmd="$SCARABHOME/src/scarab \
+      scarabCmd="$SCARABHOME/src/scarab_$SCARAB_HASH \
       --frontend memtrace \
       --cbp_trace_r0=$TRACEFILE \
       --memtrace_roi_begin=1 \
@@ -98,7 +99,7 @@ else
       &> sim.log"
     else
       #echo "!ROISTART"
-      scarabCmd="$SCARABHOME/src/scarab \
+      scarabCmd="$SCARABHOME/src/scarab_$SCARAB_HASH \
       --frontend memtrace \
       --cbp_trace_r0=$TRACEFILE \
       --memtrace_roi_begin=$(( $SEGSIZE + 1)) \
@@ -111,7 +112,7 @@ else
     fi
   elif [ "$TRACE_TYPE" == "cluster_then_trace" ]; then
     if [ "$WARMUP" -lt "$TRACE_WARMUP" ]; then
-      scarabCmd="$SCARABHOME/src/scarab \
+      scarabCmd="$SCARABHOME/src/scarab_$SCARAB_HASH \
       --frontend memtrace \
       --cbp_trace_r0=$TRACEFILE \
       --fast_forward=1 \
@@ -122,7 +123,7 @@ else
       $SCARABPARAMS \
       &> sim.log"
     else
-      scarabCmd="$SCARABHOME/src/scarab \
+      scarabCmd="$SCARABHOME/src/scarab_$SCARAB_HASH \
       --frontend memtrace \
       --cbp_trace_r0=$TRACEFILE \
       --inst_limit=$instLimit \

--- a/common/scripts/run_pt_single_simpoint.sh
+++ b/common/scripts/run_pt_single_simpoint.sh
@@ -11,6 +11,7 @@ SCARABPARAMS="$3"
 SCARABARCH="$4"
 WARMUP="$5"
 SCARABHOME="$6"
+SCARAB_HASH="$7"
 SEGMENT_ID=0
 
 if [ "$SEGMENT_ID" != "0" ]; then
@@ -31,7 +32,7 @@ mkdir -p $OUTDIR/$segID
 cp $SCARABHOME/src/PARAMS.$SCARABARCH $OUTDIR/$segID/PARAMS.in
 cd $OUTDIR/$segID
 
-scarabCmd="$SCARABHOME/src/scarab --full_warmup $WARMUP --frontend pt --cbp_trace_r0=$trace_home/$WORKLOAD_HOME/traces/pt/${traceMap} $SCARABPARAMS &> sim.log"
+scarabCmd="$SCARABHOME/src/scarab_$SCARAB_HASH --full_warmup $WARMUP --frontend pt --cbp_trace_r0=$trace_home/$WORKLOAD_HOME/traces/pt/${traceMap} $SCARABPARAMS &> sim.log"
 
 #echo "simulating clusterID ${clusterID}, segment $segID..."
 #echo "command: ${scarabCmd}"

--- a/json/exp.json
+++ b/json/exp.json
@@ -54,9 +54,21 @@
   ],
   "_configurations":"scarab configurations to sweep",
   "configurations":{
-    "baseline":"--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32",
-    "perfect_fdip_lookahead_10000":"--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32 --fdip_perfect_prefetch 1 --trace_buf_size 10000",
-    "perfect_fdip_lookahead_50000":"--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32 --fdip_perfect_prefetch 1 --trace_buf_size 50000",
-    "perfect_fdip_lookahead_100000":"--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32 --fdip_perfect_prefetch 1 --trace_buf_size 100000"
+    "baseline": {
+      "scarab_params": "--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32",
+      "scarab_githash": "current"
+    },
+    "perfect_fdip_lookahead_10000":{
+      "scarab_params": "--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32 --fdip_perfect_prefetch 1 --trace_buf_size 10000",
+      "scarab_githash": "current"
+    },
+    "perfect_fdip_lookahead_50000": {
+      "scarab_params": "--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32 --fdip_perfect_prefetch 1 --trace_buf_size 50000",
+      "scarab_githash": "current"
+    },
+    "perfect_fdip_lookahead_100000":{
+      "scarab_params": "--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32 --fdip_perfect_prefetch 1 --trace_buf_size 100000",
+      "scarab_githash": "current"
+    }
   }
 }

--- a/json/top_simpoint.json
+++ b/json/top_simpoint.json
@@ -30,6 +30,9 @@
   ],
   "_configurations": "scarab configurations to sweep",
   "configurations": {
-      "this_pr":"--bp_mech tage64k"
+      "this_pr": {
+        "scarab_params": "--bp_mech tage64k",
+        "scarab_githash": "current"
+      }
   }
 }

--- a/scripts/docker_cleaner.py
+++ b/scripts/docker_cleaner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
-from .utilities import run_on_node
+from utilities import run_on_node
 
 parser = argparse.ArgumentParser(description="Clean up dangling docker images.")
 

--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -166,7 +166,8 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                 simpoints[f"{exp_cluster_id}"] = weight
 
             for config_key in configs:
-                config = configs[config_key]
+                config = configs[config_key]["scarab_params"]
+                scarab_githash = configs[config_key]["scarab_githash"]
                 if config == "":
                     config = None
 
@@ -218,7 +219,14 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
         except subprocess.CalledProcessError:
             err("Error: Not in a Git repository or unable to retrieve Git hash.")
 
-        scarab_githash, image_tag_list = prepare_simulation(user, scarab_path, scarab_build, descriptor_data['root_dir'], experiment_name, architecture, docker_prefix_list, githash, infra_dir, False, [], dbg_lvl)
+        scarab_hashes = []
+        for sim in simulations:
+            for config_key in configs:
+                scarab_hash = configs[config_key]["scarab_githash"]
+                if scarab_hash not in scarab_hashes:
+                    scarab_hashes.append(scarab_hash)
+
+        scarab_githash, image_tag_list = prepare_simulation(user, scarab_path, scarab_build, descriptor_data['root_dir'], experiment_name, architecture, docker_prefix_list, githash, infra_dir, scarab_hashes, interactive_shell=False, available_slurm_nodes=[], dbg_lvl=dbg_lvl)
 
         # Iterate over each workload and config combo
         for simulation in simulations:

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -137,9 +137,10 @@ def open_interactive_shell(user, descriptor_data, workloads_data, infra_dir, dbg
                                             docker_prefix_list,
                                             githash,
                                             infra_dir,
-                                            True,
-                                            [],
-                                            dbg_lvl)
+                                            ["current"],
+                                            interactive_shell=True,
+                                            available_slurm_nodes=[],
+                                            dbg_lvl=dbg_lvl)
         workload = descriptor_data['simulations'][0]['workload']
         mode = descriptor_data['simulations'][0]['simulation_type']
 

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -626,7 +626,8 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
 
             slurm_ids = []
             for config_key in configs:
-                config = configs[config_key]
+                config = configs[config_key]["scarab_params"]
+                scarab_githash = configs[config_key]["scarab_githash"]
                 if config == "":
                     config = None
 

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -700,9 +700,16 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
             err("Cannot find any running slurm nodes", dbg_lvl)
             exit(1)
 
+        scarab_hashes = []
+        for sim in simulations:
+            for config_key in configs:
+                scarab_hash = configs[config_key]["scarab_githash"]
+                if scarab_hash not in scarab_hashes:
+                    scarab_hashes.append(scarab_hash)
+
         # Generate commands for executing in users docker and sbatching to nodes with containers
         experiment_dir = f"{descriptor_data['root_dir']}/simulations/{experiment_name}"
-        scarab_githash, image_tag_list = prepare_simulation(user, scarab_path, scarab_build, descriptor_data['root_dir'], experiment_name, architecture, docker_prefix_list, githash, infra_dir, False, available_slurm_nodes, dbg_lvl)
+        scarab_githash, image_tag_list = prepare_simulation(user, scarab_path, scarab_build, descriptor_data['root_dir'], experiment_name, architecture, docker_prefix_list, githash, infra_dir, scarab_hashes, False, available_slurm_nodes, dbg_lvl)
 
         # Iterate over each workload and config combo
         tmp_files = []

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -465,7 +465,7 @@ def finish_simulation(user, docker_home, descriptor_path, root_dir, experiment_n
 def generate_single_scarab_run_command(user, workload_home, experiment, config_key, config,
                                        mode, seg_size, arch, scarab_githash, cluster_id,
                                        warmup, trace_warmup, trace_type, trace_file,
-                                       env_vars, bincmd, client_bincmd, hash):
+                                       env_vars, bincmd, client_bincmd):
 
     if mode == "memtrace":
         command = f"run_memtrace_single_simpoint.sh \\\"{workload_home}\\\" \\\"/home/{user}/simulations/{experiment}/{config_key}\\\" \\\"{config}\\\" \\\"{seg_size}\\\" \\\"{arch}\\\" \\\"{warmup}\\\" \\\"{trace_warmup}\\\" \\\"{trace_type}\\\" /home/{user}/simulations/{experiment}/scarab {cluster_id} {trace_file} {scarab_githash}"


### PR DESCRIPTION
Added ability to define scarab githash for each config
- Configs are now dictionaries, `scarab_params` entry is parameters and `scarab_githash` entry specifies git hash to checkout
- Checks new local scarab build cache (`scarab-infra/scarab_builds`) for binaries before building
- Checks out any missing git commit and builds binary for it. 'current' uses currently checked out commit
- Returns scarab repo to the commit it was originally checked out as after building binaries
- Changes to scarab **must** be stashed/committed before running with scarab-infra
- Copies of scarab binary are copied from cache folder into experiment directory for reproducibility
- Race conditions are avoided by file based lock. Other build processes will error and crash if repo is locked

Example of a new config entry:
```
"baseline": {
      "scarab_params": "--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32",
      "scarab_githash": "current"
}
```