### PR TITLE
Increase SimPoint projection dimension to adapt large workloads like …

### DIFF
--- a/common/scripts/run_clustering.sh
+++ b/common/scripts/run_clustering.sh
@@ -19,7 +19,7 @@ else
     maxK=$USERK
 fi
 
-echo "fingerprint size: $lines, maxK: $maxK"
+echo "fingerprint size: $lines, maxk: $maxK"
 # binary search with maxK
 spCmd="$tmpdir/simpoint -maxK $maxK -dim 100 -fixedLength off -numInitSeeds 10 -loadFVFile $FPFILE -saveSimpoints $OUTDIR/simpoints/opt.p -saveSimpointWeights $OUTDIR/simpoints/opt.w -saveVectorWeights $OUTDIR/simpoints/vector.w -saveLabels $OUTDIR/simpoints/opt.l -coveragePct .99 &> $OUTDIR/simpoints/simp.opt.log"
 # search every one with maxK


### PR DESCRIPTION
Related PR from scarab_ll, https://github.com/litz-lab/scarab_ll/pull/371

Increase SimPoint projection dimension to adapt large workloads like SPEC2017

- Simpoint default dim was 15, but it was not enough to represent the entire workloads according to the error_rate matrix from the PR request msg.

# Overview

## spec2017, 502.gcc_r, full dimensions
<img width="1297" height="711" alt="image" src="https://github.com/user-attachments/assets/c8b5e075-7b78-4ed3-87a1-740becc41998" />

<img width="1299" height="720" alt="image" src="https://github.com/user-attachments/assets/07020f5f-ef54-47d6-83bc-96b43ac7c63e" />


from https://cseweb.ucsd.edu/~calder/papers/JMLR-06-SimPoint.pdf

# Experiments result
<img width="1173" height="628" alt="image" src="https://github.com/user-attachments/assets/f786a0e5-f27b-4acd-b5ca-bca95976bfd8" />

