### PR TITLE
Instruction cnt discrepancy between dynamorio and simpoints

### DIFF
--- a/fingerprint_src/fpg.cpp
+++ b/fingerprint_src/fpg.cpp
@@ -387,18 +387,8 @@ clean_call(uint instruction_count, uint64 bb_id, uint64 segment_size, uint emula
     // }
 
     if (is_rep_emulation && first_addr == t_data->prev_first_addr) {
-        // if the current bb is rep emulation and
-        // it was just executed,
-        // only the first execution counts as fetched execution
-        if (op_use_fetched_count.get_value()) {
-            // user wants to use fetched count as segment size
-            // so don't count this
-        } else {
-            // user wants to use executed count for the segment size
-            // so even though non-fetched rep, count it as execution
-            DR_ASSERT(instruction_count == 1);
-            return;
-        }
+        // We are not counting the REP consequent instructions for basic block vectors
+        return;
     } else {
         // otherwise just increment
         if (is_rep_emulation) {


### PR DESCRIPTION
## Issue
Instruction cnt discrepancy between dynamorio and simpoints

## Simpoint basic block implementation
```c++
run_simpoint_trace.py

def cluster_then_trace() {

...
    fp_cmd = f"{dynamorio_home}/bin64/drrun -max_bb_instrs 4096 -opt_cleancall 2 -c $tmpdir/libfpg.so -no_use_bb_pc -no_use_fetched_count -segment_size {seg_size} -output {workload_home}/fingerprint/bbfp -pcmap_output {workload_home}/fingerprint/pcmap -- {bincmd}"
...

}


# from libfpg.so implementation
fpg.c

    if (is_rep_emulation && first_addr == t_data->prev_first_addr) {
        // if the current bb is rep emulation and
        // it was just executed,
        // only the first execution counts as fetched execution
        if (op_use_fetched_count.get_value()) {
            // user wants to use fetched count as segment size
            // so don't count this
        } else {
            // user wants to use executed count for the segment size
            // so even though non-fetched rep, count it as execution
            DR_ASSERT(instruction_count == 1);
            t_data->cur_counter += instruction_count;    <<< REP consequent
        }
``` 

-no_use_fetched_count (fetched + non_fetched for simpoints, including REP consequents as non_fetched).


## Dynamorio segment chunking

```c++
def cluster_then_trace() {
...
    trace_cmd = f"{dynamorio_home}/bin64/drrun -t drcachesim -jobs 40 -outdir {seg_dir} -offline -trace_after_instrs {roi_start} -exit_after_tracing {roi_length} -- {bincmd}"
...
}
``` 
The "trace_after_instrs" parameter counts instruction with fetched and non_fetched without REP consequents according to the Dynamorio internal implementation like below.


```c
Dynamorio drcachesim offline mode's instruction counts

instru.cpp
int
instru_t::count_app_instrs(instrlist_t *ilist)
{
    int count = 0;
    bool in_emulation_region = false;
    for (instr_t *inst = instrlist_first(ilist); inst != NULL;
         inst = instr_get_next(inst)) {
        if (!in_emulation_region && drmgr_is_emulation_start(inst)) {
            in_emulation_region = true;  << skip REP consequent
            // Each emulation region corresponds to a single app instr.
            ++count;    <<< only for first REP 
        }
        if (!in_emulation_region && instr_is_app(inst)) {
            // Hooked native functions end up with an artificial jump whose translation
            // is its target.  We do not want to count these.
            if (!(instr_is_ubr(inst) && opnd_is_pc(instr_get_target(inst)) &&
                  opnd_get_pc(instr_get_target(inst)) == instr_get_app_pc(inst)))
                ++count;
        }
        if (in_emulation_region && drmgr_is_emulation_end(inst))
            in_emulation_region = false;
    }
    return count;
}

``` 

DynamoRIO counts only the first instruction of a REP sequence.