### PR TITLE
Fix for ./sci --clean (clean up remote Slurm nodes properly)

### DIFF
--- a/json/exp.json
+++ b/json/exp.json
@@ -54,9 +54,7 @@
   ],
   "_configurations":"scarab configurations to sweep",
   "configurations":{
-    "baseline":"--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32",
-    "perfect_fdip_lookahead_10000":"--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32 --fdip_perfect_prefetch 1 --trace_buf_size 10000",
-    "perfect_fdip_lookahead_50000":"--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32 --fdip_perfect_prefetch 1 --trace_buf_size 50000",
-    "perfect_fdip_lookahead_100000":"--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32 --fdip_perfect_prefetch 1 --trace_buf_size 100000"
+    "icache_32k":"--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32",
+    "icache_64k":"--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32 --icache_size 65536"
   }
 }

--- a/scarab_stats/scarab_stats.py
+++ b/scarab_stats/scarab_stats.py
@@ -9,8 +9,12 @@ import matplotlib.patches as mpatches
 import json
 import os
 import math
+from pathlib import Path
 
 from scripts import utilities
+
+def _infra_root() -> Path:
+    return Path(__file__).resolve().parent.parent
 
 def get_elem(l, i):
     return list(map(lambda x:x[i], l))
@@ -560,14 +564,13 @@ class stat_aggregator:
 
         known_stats = None
 
-        current_path = os.getcwd()
-        infra_dir = os.path.dirname(current_path)
+        infra_dir = _infra_root()
         top_simpoint_only = False
         if json_data["top_simpoint"]:
             top_simpoint_only = True
-            workload_db_path = f"{infra_dir}/workloads/workloads_top_simp.json"
+            workload_db_path = str(infra_dir / "workloads" / "workloads_top_simp.json")
         else:
-            workload_db_path = f"{infra_dir}/workloads/workloads_db.json"
+            workload_db_path = str(infra_dir / "workloads" / "workloads_db.json")
         workloads_data = utilities.read_descriptor_from_json(workload_db_path)
 
         experiment = None
@@ -1497,12 +1500,11 @@ class stat_aggregator:
         Returns:
             tuple: (weight, segment_id) if found, None if not found
         """
-        current_path = os.getcwd()
-        infra_dir = os.path.dirname(current_path)
+        infra_dir = _infra_root()
         if top_simpoint_only:
-            workload_db_path = f"{infra_dir}/workloads/workloads_top_simp.json"
+            workload_db_path = str(infra_dir / "workloads" / "workloads_top_simp.json")
         else:
-            workload_db_path = f"{infra_dir}/workloads/workloads_db.json"
+            workload_db_path = str(infra_dir / "workloads" / "workloads_db.json")
         workloads_data = utilities.read_descriptor_from_json(workload_db_path)
 
         try:
@@ -1534,12 +1536,11 @@ class stat_aggregator:
         Returns:
             list: List of cluster_ids if found, None if workload not found
         """
-        current_path = os.getcwd()
-        infra_dir = os.path.dirname(current_path)
+        infra_dir = _infra_root()
         if top_simpoint_only:
-            workload_db_path = f"{infra_dir}/workloads/workloads_top_simp.json"
+            workload_db_path = str(infra_dir / "workloads" / "workloads_top_simp.json")
         else:
-            workload_db_path = f"{infra_dir}/workloads/workloads_db.json"
+            workload_db_path = str(infra_dir / "workloads" / "workloads_db.json")
         workloads_data = utilities.read_descriptor_from_json(workload_db_path)
 
         try:

--- a/scarab_stats/stat_collector.py
+++ b/scarab_stats/stat_collector.py
@@ -1,55 +1,69 @@
 #!/usr/bin/env python3
 
 import argparse
-
+import json
 import os
 import sys
+from pathlib import Path
 
-from scripts.utilities import read_descriptor_from_json
+project_root = Path(__file__).resolve().parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
 import scarab_stats
 
 print("START stat collector")
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-d','--descriptor_name', required=True, help='Experiment descriptor name. Usage: -d exp.json')
-parser.add_argument('-o','--outfile', required=True, help='Experiment descriptor name. Usage: -d out.csv')
+parser.add_argument('-d', '--descriptor_name', required=True, help='Experiment descriptor name. Usage: -d exp.json')
+parser.add_argument('-o', '--outfile', required=True, help='Output csv path. Usage: -o out.csv')
 args = parser.parse_args()
 
-descriptor_name = args.descriptor_name
+descriptor_path = Path(args.descriptor_name)
 outfile = args.outfile
 
-json = read_descriptor_from_json(descriptor_name)
-if json is None:
-    print("Error: JSON file not found or invalid.")
+try:
+    with descriptor_path.open("r", encoding="utf-8") as handle:
+        descriptor = json.load(handle)
+except FileNotFoundError:
+    print(f"Error: descriptor '{descriptor_path}' not found.")
+    print("DONE")
     exit(1)
-    
-root_directory = json["root_dir"] + "/simulations/" + json["experiment"] + "/logs/"
+except json.JSONDecodeError as exc:
+    print(f"Error decoding descriptor '{descriptor_path}': {exc}")
+    print("DONE")
+    exit(1)
 
-log_files = os.listdir(root_directory)
+root_directory = Path(descriptor["root_dir"]) / "simulations" / descriptor["experiment"] / "logs"
+
+if not root_directory.exists():
+    print(f"Error: log directory '{root_directory}' not found.")
+    print("DONE")
+    exit(1)
 
 error_runs = []
 
-for file in log_files:
-    with open(root_directory+file, 'r') as f:
-        contents = f.read()
-        if 'Error' in contents:
-            error_runs += [file]
+for file in root_directory.iterdir():
+    if not file.is_file():
+        continue
+    contents = file.read_text()
+    if "Error" in contents:
+        error_runs.append(file.name)
 
-if len(error_runs) > 0:
+if error_runs:
     print(f"Not running due to {len(error_runs)} errors")
     print("DONE")
     exit(1)
 
 try:
     da = scarab_stats.stat_aggregator()
-    print(f"Loading {descriptor_name}")
-    E = da.load_experiment_json(descriptor_name, True)
-    E.to_csv(f"{outfile}")
+    print(f"Loading {descriptor_path}")
+    experiment = da.load_experiment_json(str(descriptor_path), True)
+    experiment.to_csv(outfile)
 
-    # This is the 'success' message
-    if E is not None:
-        print(f"Statistics collected for {json['experiment']}")
-except:
-    pass
+    if experiment is not None:
+        print(f"Statistics collected for {descriptor['experiment']}")
+except Exception as exc:
+    print(f"Stat collector failed: {exc}")
 finally:
     print("DONE")

--- a/sci
+++ b/sci
@@ -903,7 +903,10 @@ def ensure_traces(_: argparse.Namespace) -> Tuple[bool, str]:
             )
 
         prompt += "?"
-        default_choice = False if suite_missing else True
+        if suite == "spec2017":
+            default_choice = not suite_missing
+        else:
+            default_choice = False
         if not confirm(prompt, default=default_choice):
             info(f"Skipped downloads for suite '{suite}' by user choice.")
             continue

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -7,6 +7,7 @@ import subprocess
 import argparse
 import os
 import sys
+from pathlib import Path
 import docker
 
 from .utilities import (
@@ -14,6 +15,7 @@ from .utilities import (
     err,
     read_descriptor_from_json,
     remove_docker_containers,
+    remove_tmp_run_scripts,
     get_image_list,
     prepare_simulation,
     get_image_name,
@@ -255,6 +257,12 @@ def run_simulation_command(descriptor_path, action, dbg_lvl=2, infra_dir=None):
             return 0
 
         if action == "clean":
+            if workload_manager == "slurm":
+                slurm_runner.clean_containers(user, experiment_name, docker_image_list, dbg_lvl)
+                descriptor_root = Path(descriptor_data["root_dir"])
+                experiment_dir = descriptor_root / "simulations" / experiment_name
+                remove_tmp_run_scripts(Path(infra_dir), experiment_name, user, dbg_lvl)
+                remove_tmp_run_scripts(experiment_dir, experiment_name, user, dbg_lvl)
             remove_docker_containers(docker_image_list, experiment_name, user, dbg_lvl)
             return 0
 

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -188,6 +188,33 @@ def check_available_nodes(dbg_lvl = 1):
     except Exception as e:
         raise e
 
+def list_cluster_nodes(dbg_lvl = 1):
+    try:
+        response = subprocess.check_output(["sinfo", "-h", "-N", "-o", "%N %T"]).decode("utf-8")
+    except subprocess.CalledProcessError as exc:
+        warn(f"Unable to query slurm nodes: {exc}", dbg_lvl)
+        return []
+    except Exception as exc:
+        warn(f"Unexpected error querying slurm nodes: {exc}", dbg_lvl)
+        return []
+
+    nodes = []
+    seen = set()
+    for line in response.splitlines():
+        parts = line.split()
+        if not parts:
+            continue
+        node = parts[0]
+        state = parts[1] if len(parts) > 1 else ""
+        if "[" in node:
+            warn(f"Skipping aggregated sinfo entry '{node}'", dbg_lvl)
+            continue
+        if node in seen:
+            continue
+        seen.add(node)
+        nodes.append((node, state))
+    return nodes
+
 # Get command to sbatch scarab runs. 1 core each, exclude nodes where container isn't running
 def generate_sbatch_command(excludes, experiment_dir):
     # If all nodes are usable, no need to exclude
@@ -545,6 +572,106 @@ def kill_jobs(user, job_name, docker_prefix_list, dbg_lvl = 2):
             print("Operation canceled.")
     else:
         print("No job found.")
+
+def clean_containers(user, job_name, docker_prefix_list, dbg_lvl = 2):
+    if not docker_prefix_list:
+        info("No docker images associated with descriptor; nothing to clean.", dbg_lvl)
+        return
+
+    node_entries = list_cluster_nodes(dbg_lvl)
+    if not node_entries:
+        warn("No slurm nodes discovered; skipping remote container cleanup.", dbg_lvl)
+        return
+
+    all_nodes = []
+    for node, state in node_entries:
+        normalized_state = state.lower()
+        if any(token in normalized_state for token in ("down", "drain", "fail", "maint", "unk")):
+            info(f"Skipping node {node} in state '{state}'.", dbg_lvl)
+            continue
+        all_nodes.append(node)
+
+    if not all_nodes:
+        warn("All discovered slurm nodes are unavailable; skipping remote container cleanup.", dbg_lvl)
+        return
+
+    patterns = [re.compile(fr"^{docker_prefix}_.*_{job_name}.*_.*_{user}$") for docker_prefix in docker_prefix_list]
+    removed_any = False
+
+    for node in all_nodes:
+        try:
+            result = run_on_node(
+                ["docker", "ps", "-a", "--format", "{{.Names}}"],
+                node=node,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            warn(f"Failed to list containers on {node}: {exc}", dbg_lvl)
+            continue
+        except Exception as exc:
+            warn(f"Error while listing containers on {node}: {exc}", dbg_lvl)
+            continue
+
+        container_names = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        matching = []
+        for name in container_names:
+            if any(pattern.match(name) for pattern in patterns):
+                matching.append(name)
+
+        if not matching:
+            info(f"No containers to remove on {node}.", dbg_lvl)
+            continue
+
+        for container in matching:
+            try:
+                run_on_node(["docker", "rm", "-f", container], node=node, check=True)
+                print(f"Removed container {container} on {node}")
+                removed_any = True
+            except subprocess.CalledProcessError as exc:
+                err(f"Failed to remove container {container} on {node}: {exc}", dbg_lvl)
+            except Exception as exc:
+                err(f"Unexpected error removing container {container} on {node}: {exc}", dbg_lvl)
+
+    if not removed_any:
+        print("No matching containers found on any slurm node.")
+
+    clean_tmp_run_scripts(all_nodes, job_name, user, dbg_lvl)
+
+def clean_tmp_run_scripts(nodes, job_name, user, dbg_lvl = 2):
+    pattern = re.compile(rf".*_{re.escape(job_name)}_.*_{re.escape(user)}_tmp_run\.sh$")
+    for node in nodes:
+        try:
+            result = run_on_node(
+                ["bash", "-lc", "find . -maxdepth 1 -type f -name '*_tmp_run.sh' -print"],
+                node=node,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except Exception as exc:
+            warn(f"Failed to list temporary scripts on {node}: {exc}", dbg_lvl)
+            continue
+        files = []
+        for line in result.stdout.splitlines():
+            candidate = line.strip()
+            if not candidate:
+                continue
+            name = os.path.basename(candidate)
+            if pattern.match(name):
+                files.append(candidate)
+        if not files:
+            info(f"No temporary run scripts on {node}.", dbg_lvl)
+            continue
+        for script in files:
+            try:
+                run_on_node(["rm", "-f", script], node=node, check=True)
+                print(f"Removed {script} on {node}")
+            except subprocess.CalledProcessError as exc:
+                err(f"Failed to remove {script} on {node}: {exc}", dbg_lvl)
+            except Exception as exc:
+                err(f"Unexpected error removing {script} on {node}: {exc}", dbg_lvl)
 
 def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_path, dbg_lvl = 1):
     architecture = descriptor_data["architecture"]


### PR DESCRIPTION
Fix for ./sci --clean (clean up remote Slurm nodes properly)
Simplify the example json
Fix for Stats collector path and manual run


The old clean up mechanism does not perfectly work. It still leaves some dangling docker containers in remote Slurm clusters.