### PR TITLE
Fix auto-merge CLI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -123,24 +123,45 @@ jobs:
           echo "PR creation response:"
           echo "$PR_RESPONSE"
 
+          # After you create the PR, capture both number and node_id
           PR_NUMBER=$(echo "$PR_RESPONSE" | jq -r .number)
+          PR_NODE_ID=$(echo "$PR_RESPONSE" | jq -r .node_id)
 
-          if [[ "$PR_NUMBER" == "null" || -z "$PR_NUMBER" ]]; then
-            echo "Failed to create PR. Exiting."
+          if [[ "$PR_NUMBER" == "null" || -z "$PR_NUMBER" || "$PR_NODE_ID" == "null" || -z "$PR_NODE_ID" ]]; then
+            echo "Failed to create PR or get node_id. Exiting."
             exit 1
           fi
 
           echo "Created PR #$PR_NUMBER"
-          sleep 10  # Delay to ensure PR is available for auto-merge
+
+          # Optional small delay to let GitHub index the PR
+          sleep 5
 
           if [[ "${{ github.event_name }}" == "push" ]]; then
             echo "Enabling auto-merge for PR #$PR_NUMBER"
-            curl -s -X PUT \
+
+            read -r -d '' GQL_QUERY <<'EOF'
+            mutation($prId: ID!) {
+              enablePullRequestAutoMerge(input: { pullRequestId: $prId, mergeMethod: SQUASH }) {
+                pullRequest { number, autoMergeRequest { enabledAt } }
+              }
+            }
+          EOF
+
+            curl -s -X POST https://api.github.com/graphql \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/$GITHUB_REPO/pulls/$PR_NUMBER/auto-merge \
-              -d '{"merge_method":"squash"}' || echo "Auto-merge API call failed; ensure repository allows auto-merge for this PR."
+              -d "$(jq -n --arg prId "$PR_NODE_ID" --arg q "$GQL_QUERY" '{query:$q,variables:{prId:$prId}}')" \
+            | tee enable_automerge_response.json
+
+            # Basic success check
+            if jq -e '.data.enablePullRequestAutoMerge.pullRequest.autoMergeRequest.enabledAt' enable_automerge_response.json >/dev/null; then
+              echo "Auto-merge enabled."
+            else
+              echo "Failed to enable auto-merge:"
+              cat enable_automerge_response.json
+              exit 1
+            fi
           else
             echo "Skipping auto-merge because this is a manual run (workflow_dispatch)"
           fi


### PR DESCRIPTION
The current Auto-merge does not work with the following error.
```
Created PR #222 Enabling auto-merge for PR #222 { "message": "Not Found", "documentation_url": "https://docs.github.com/rest", "status": "404" }
```
Previously, I increased the wait time to see the auto-generated PR, but it was not the root cause.

Try:

- Replace the REST call with GraphQL
- Use the PR’s node_id (present in the REST create-PR response) and call the GraphQL mutation `enablePullRequestAutoMerge`.
- `enablePullRequestAutoMerge` is the supported way to toggle auto-merge via API (https://docs.github.com/en/graphql/reference/mutations).
- The PR’s node_id is already available in the REST response, so you don’t need a separate GraphQL lookup.

Hope this works for the following rebuild-required PRs.

I had made sure of the following.
Settings → Pull requests → Allow auto-merge must be enabled.
Give the workflow token the right scopes (top of the workflow or job):
```
permissions:
  contents: write
  pull-requests: write
```