### PR TITLE
Improve failed simulation tracking

### DIFF
--- a/scarab_stats/stat_collector.py
+++ b/scarab_stats/stat_collector.py
@@ -2,7 +2,6 @@
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 
@@ -34,26 +33,124 @@ except json.JSONDecodeError as exc:
     print("DONE")
     exit(1)
 
-root_directory = Path(descriptor["root_dir"]) / "simulations" / descriptor["experiment"] / "logs"
+def load_workloads_data(descriptor: dict) -> dict:
+    top = descriptor.get("top_simpoint")
+    filename = "workloads_top_simp.json" if top else "workloads_db.json"
+    workloads_path = project_root / "workloads" / filename
+    try:
+        with workloads_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError:
+        raise RuntimeError(f"Workloads file not found: {workloads_path}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Failed to parse workloads file {workloads_path}: {exc}")
 
-if not root_directory.exists():
-    print(f"Error: log directory '{root_directory}' not found.")
-    print("DONE")
-    exit(1)
 
-error_runs = []
+def resolve_simpoints(workload_entry: dict, sim_mode: str) -> list:
+    if sim_mode == "memtrace":
+        simpoints = workload_entry.get("simpoints") or []
+        ids = []
+        for entry in simpoints:
+            cluster_id = entry.get("cluster_id")
+            if cluster_id is not None:
+                ids.append(str(cluster_id))
+        return ids
+    return ["0"]
 
-for file in root_directory.iterdir():
-    if not file.is_file():
-        continue
-    contents = file.read_text()
-    if "Error" in contents:
-        error_runs.append(file.name)
 
-if error_runs:
-    print(f"Not running due to {len(error_runs)} errors")
-    print("DONE")
-    exit(1)
+def expected_run_paths(descriptor: dict, workloads_data: dict) -> list:
+    configs = descriptor.get("configurations") or {}
+    simulations = descriptor.get("simulations") or []
+    experiment_root = Path(descriptor["root_dir"]) / "simulations" / descriptor["experiment"]
+
+    metadata_errors = set()
+    expected = set()
+
+    for simulation in simulations:
+        suite = simulation.get("suite")
+        subsuite = simulation.get("subsuite")
+        workload = simulation.get("workload")
+        cluster_id = simulation.get("cluster_id")
+        sim_mode = simulation.get("simulation_type")
+
+        if suite not in workloads_data:
+            metadata_errors.add(f"Suite '{suite}' not found in workloads database.")
+            continue
+        suite_data = workloads_data[suite]
+
+        subsuites = [subsuite] if subsuite else list(suite_data.keys())
+        for subsuite_name in subsuites:
+            if subsuite_name not in suite_data:
+                metadata_errors.add(f"Subsuite '{suite}/{subsuite_name}' not found in workloads database.")
+                continue
+            subsuite_data = suite_data[subsuite_name]
+
+            workloads = [workload] if workload else list(subsuite_data.keys())
+            for workload_name in workloads:
+                if workload_name not in subsuite_data:
+                    metadata_errors.add(f"Workload '{suite}/{subsuite_name}/{workload_name}' not found in workloads database.")
+                    continue
+                workload_entry = subsuite_data[workload_name]
+
+                resolved_mode = sim_mode
+                if not resolved_mode:
+                    resolved_mode = workload_entry.get("simulation", {}).get("prioritized_mode")
+                if not resolved_mode:
+                    metadata_errors.add(f"No simulation mode available for '{suite}/{subsuite_name}/{workload_name}'.")
+                    continue
+
+                if cluster_id is None:
+                    cluster_ids = resolve_simpoints(workload_entry, resolved_mode)
+                    if not cluster_ids:
+                        metadata_errors.add(f"No simpoints available for '{suite}/{subsuite_name}/{workload_name}' in mode '{resolved_mode}'.")
+                        continue
+                else:
+                    cluster_ids = [str(cluster_id)]
+
+                for cluster in cluster_ids:
+                    for config_name in configs.keys():
+                        run_dir = experiment_root / config_name / suite / subsuite_name / workload_name / str(cluster)
+                        expected.add(run_dir)
+
+    if metadata_errors:
+        for message in sorted(metadata_errors):
+            print(f"Error: {message}")
+        raise RuntimeError("Descriptor references missing entries in workloads database.")
+
+    return sorted(expected)
+
+
+def verify_simulation_outputs(descriptor: dict) -> None:
+    try:
+        workloads_data = load_workloads_data(descriptor)
+    except RuntimeError as exc:
+        print(exc)
+        print("DONE")
+        exit(1)
+
+    run_dirs = expected_run_paths(descriptor, workloads_data)
+    if not run_dirs:
+        print("No simulation runs described in descriptor; nothing to collect.")
+        print("DONE")
+        exit(0)
+
+    missing = []
+    for run_dir in run_dirs:
+        inst_path = run_dir / "inst.stat.0.csv"
+        if not inst_path.is_file():
+            missing.append(str(run_dir))
+
+    if missing:
+        print("Stat collection aborted: some simulation outputs are incomplete.")
+        for entry in missing[:20]:
+            print(f"Missing inst.stat.0.csv in {entry}")
+        if len(missing) > 20:
+            print(f"... {len(missing) - 20} additional paths omitted ...")
+        print("DONE")
+        exit(1)
+
+
+verify_simulation_outputs(descriptor)
 
 try:
     da = scarab_stats.stat_aggregator()


### PR DESCRIPTION
- Before exporting stats, we now enumerate every simpoint/config path from the descriptor and abort if any run directory lacks inst.stat.0.csv instead of checking new and old logs (stat_collector.py)
- Add helper to compare descriptor expectations with the CSV, automatically re-run the stat collector when worloads/configs are missing, and reload data after a refresh (sci)
- --status uses a set for error logs, flags segfaults explicitly, and verifies that each log's simpoint directory actually contains inst.stat.0.csv before making it successful (slurm_runner.py)
- rebuild_scarab now always rebuilds with scarab_build or "opt" and copies the new binary into cache only when it differs