### PR TITLE
DCPerf new workloads (tao_bench server, django_bench server)

### DIFF
--- a/workloads/workloads_db.json
+++ b/workloads/workloads_db.json
@@ -9921,7 +9921,7 @@
           "memtrace":{
             "image_name":"allbench_traces",
             "segment_size":10000000,
-            "warmup":10000000,
+            "warmup":50000000,
             "whole_trace_file":"drmemtrace.tao_bench_server.184919.7249.trace.zip",
             "trace_type":"trace_then_cluster"
           }
@@ -9973,7 +9973,7 @@
           "memtrace":{
             "image_name":"allbench_traces",
             "segment_size":10000000,
-            "warmup":10000000,
+            "warmup":50000000,
             "whole_trace_file":"drmemtrace.uwsgi.214106.1772.trace.zip",
             "trace_type":"trace_then_cluster"
           }

--- a/workloads/workloads_top_simp.json
+++ b/workloads/workloads_top_simp.json
@@ -2305,7 +2305,7 @@
           "memtrace":{
             "image_name":"allbench_traces",
             "segment_size":10000000,
-            "warmup":10000000,
+            "warmup":50000000,
             "whole_trace_file":"drmemtrace.tao_bench_server.184919.7249.trace.zip",
             "trace_type":"trace_then_cluster"
           }
@@ -2347,7 +2347,7 @@
           "memtrace":{
             "image_name":"allbench_traces",
             "segment_size":10000000,
-            "warmup":10000000,
+            "warmup":50000000,
             "whole_trace_file":"drmemtrace.uwsgi.214106.1772.trace.zip",
             "trace_type":"trace_then_cluster"
           }


### PR DESCRIPTION
Hello, @5surim 

I've tried 6 different workloads from DCPerf packages,

1. tao_bench : frontend bound >= 40%
2. django_bench : frontend bound >= 55%
3. spark_standalone : JAVA based execution file, not applicable for dynamorio tracing
4. media_wiki : SELInux disable requires with sudo permission.
5. health_check : backend bound >= 50%
6. video_transcode_bench : backend bound >= 35%

binary commands have been updated into that sheet.
* https://docs.google.com/spreadsheets/d/1ukcN5AcN87CX4VLAnTMnmGyvWLP-OKOqnY7RZ5wmrNA/edit?pli=1&gid=1795543077#gid=1795543077

This commit includes only two workloads(tao_server & django_server) which show high frontend bound (at least >= 30%), 
And, these are more detailed top-down analysis & QPS results for both of them.

## tao bench server test result
| curr_it (M) | fast_qps | slow_qps | hit_rate |
|------------:|---------:|---------:|---------:|
| 0.03        | 0.2      | 2841.8   | 0.000 |
| 0.04        | 0.8      | 3030.0   | 0.000 |
| 0.06        | 1.4      | 2627.0   | 0.001 |
| 0.07        | 1.6      | 2922.8   | 0.001 |
| 0.09        | 1.2      | 2851.2   | 0.000 |
etc...

```
# 5.01-full-perf on Intel(R) Xeon(R) Gold 5117 CPU @ 2.00GHz [skx/skylake] |   |   |   |   |  
-- | -- | -- | -- | -- | --
S0-C0    FE               Frontend_Bound                      % Slots                       41.3    [14.3%] |   |   |   |   |  
S0-C0    BAD              Bad_Speculation                     % Slots                        5.6  < [14.3%] |   |   |   |   |  
S0-C0    BE               Backend_Bound                       % Slots                       27.2    [14.3%] |   |   |   |   |  
S0-C0    RET              Retiring                            % Slots                       25.9  < [14.3%] |   |   |   |   |  
S0-C0    FE               Frontend_Bound.Fetch_Latency        % Slots                       30.2    [14.3%]<== |   |   |   |   |  
S0-C0    FE               Frontend_Bound.Fetch_Bandwidth      % Slots                       11.1  < [14.3%] |   |   |   |   |  
S0-C0    BAD              Bad_Speculation.Branch_Mispredicts  % Slots                        5.0  < [14.3%] |   |   |   |   |  
S0-C0    BAD              Bad_Speculation.Machine_Clears      % Slots                        0.5  < [14.3%] |   |   |   |   |  
S0-C0    BE/Mem           Backend_Bound.Memory_Bound          % Slots                       16.0  < [14.3%] |   |   |   |   |  
S0-C0    BE/Core          Backend_Bound.Core_Bound            % Slots                       11.3    [14.3%] |   |   |   |   |  
S0-C0    RET              Retiring.Light_Operations           % Slots                       20.3  < [14.3%] |   |   |   |   |  
S0-C0    RET              Retiring.Heavy_Operations           % Slots                        5.6  < [14.3%] |   |   |   |   |  
S0-C0-T0 MUX                                                  %                             14.29 |   |   |   |   |  
S0-C0-T1 MUX                                                  %                             14.28 |   |   |   |   |  
``` 

## django bench server test result

| Metric                   | Value       |
|-------------------------|------------:|
| transactions            | 42,506      |
| availability            | 100.00%     |
| elapsed_time            | 1808.36 s   |
| data_transferred        | 28.54 MB    |
| response_time (avg)     | 0.04 s      |
| transaction_rate (QPS)  | **23.51**   |
| throughput              | 0.02 MB/s   |
| concurrency             | 1.00        |
| successful_transactions | 42,506      |
| failed_transactions     | 0          |
| longest_transaction     | 0.46 s      |
| shortest_transaction    | 0.04 s      |

```
# 5.01-full-perf on Intel(R) Xeon(R) Gold 5117 CPU @ 2.00GHz [skx/skylake] |   |   |   |   |  
-- | -- | -- | -- | -- | --
S0-C0    FE               Frontend_Bound                      % Slots                       63.5    [14.3%] |   |   |   |   |  
S0-C0    BAD              Bad_Speculation                     % Slots                       11.0  < [14.3%] |   |   |   |   |  
S0-C0    BE               Backend_Bound                       % Slots                        9.1  < [14.3%] |   |   |   |   |  
S0-C0    RET              Retiring                            % Slots                       16.4  < [14.3%] |   |   |   |   |  
S0-C0    FE               Frontend_Bound.Fetch_Latency        % Slots                       50.9    [14.3%]<== |   |   |   |   |  
S0-C0    FE               Frontend_Bound.Fetch_Bandwidth      % Slots                       12.7  < [14.3%] |   |   |   |   |  
S0-C0    BAD              Bad_Speculation.Branch_Mispredicts  % Slots                       10.8  < [14.3%] |   |   |   |   |  
S0-C0    BAD              Bad_Speculation.Machine_Clears      % Slots                        0.1  < [14.3%] |   |   |   |   |  
S0-C0    BE/Mem           Backend_Bound.Memory_Bound          % Slots                        4.8  < [14.3%] |   |   |   |   |  
S0-C0    BE/Core          Backend_Bound.Core_Bound            % Slots                        4.3  < [14.3%] |   |   |   |   |  
S0-C0    RET              Retiring.Light_Operations           % Slots                       14.7  < [14.3%] |   |   |   |   |  
S0-C0    RET              Retiring.Heavy_Operations           % Slots                        1.8  < [14.3%] |   |   |   |   |  
S0-C0-T0 MUX                                                  %                             14.29 |   |   |   |   |  
S0-C0-T1 MUX                                                  %                             14.29 |   |   |   |   |  
``` 

++
FYI) two simpoints bbv error rate were less then 1%.

Thanks.
Best regards,
