### PR TITLE
Add spec2017 image build for exec-driven

### DIFF
--- a/workloads/spec2017/Dockerfile
+++ b/workloads/spec2017/Dockerfile
@@ -13,12 +13,19 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 WORKDIR $tmpdir
 
+# The SPEC CPU2017 installer tarball is not checked in.
+# If the build errors with "file not found in build context" for spec2017.tar.gz,
+# place your licensed tarball at workloads/spec2017/spec2017.tar.gz or pass
+# --build-arg SPEC2017_TARBALL=<relative path inside build context>.
+# If you're not Litz-lab member, please match the location described in workload_user_entrypoint.sh with your spec2017 directory. 
+ARG SPEC2017_TARBALL=workloads/spec2017/spec2017.tar.gz
+
 RUN cd $tmpdir && wget https://apt.llvm.org/llvm.sh
 RUN chmod u+x llvm.sh
 RUN sudo ./llvm.sh 16
 RUN echo "copying spec2017.tar.gz to $tmpdir/application"
 RUN mkdir -p $tmpdir/application
-COPY ./workloads/spec2017/spec2017.tar.gz $tmpdir/application/
+COPY ${SPEC2017_TARBALL} $tmpdir/application/spec2017.tar.gz
 RUN echo "extracting spec2017.tar.gz to $tmpdir/application"
 RUN tar -xzf $tmpdir/application/spec2017.tar.gz -C $tmpdir/application && rm $tmpdir/application/spec2017.tar.gz
 RUN echo "done"


### PR DESCRIPTION
This PR is for spec2017 image build. 
Dockerfile copies the staged tar.gz file in `workloads/spec2017/` into the container. 
The compressed zip file has a ready-to-go application below.

**Compiled applications**: 
500.perlbench_r 507.cactuBSSN_r 519.lbm_r 525.x264_r 538.imagick_r 549.fotonik3d_r
502.gcc_r 508.namd_r 520.omnetpp_r 526.blender_r 541.leela_r 554.roms_r 
503.bwaves_r 510.parest_r 521.wrf_r 527.cam4_r 544.nab_r 557.xz_r 
505.mcf_r 511.povray_r 523.xalancbmk_r 531.deepsjeng_r 548.exchange2_r 

**size of zip file: 6.8G**
