### PR TITLE
Added markdown table output for visualize runs for an easy github report

### DIFF
--- a/scarab_stats/scarab_stats.py
+++ b/scarab_stats/scarab_stats.py
@@ -741,7 +741,6 @@ class stat_aggregator:
 
         configs_to_load = configs
         all_data = experiment.retrieve_stats(configs_to_load, stats, workloads)
-        print(all_data)
         if all_data is None:
             print("ERROR: retrieve_stats returned None. This means either:")
             print("1. The requested workloads don't exist in the dataframe")


### PR DESCRIPTION
`./sci --visualize <json_descriptor>`

Now prints a Markdown table for a GitHub summary, allowing users to copy and paste it into a PR summary.

```
surim@bohr1:~/src/infra $ ./sci --visualize btb
Using stats file: /soe/surim/simulations/btb/collected_stats.csv
Workloads: 24; Configurations: 2; Speedup baseline: single_btb

Markdown table for Periodic_IPC:
| Workload | single_btb (Periodic_IPC) | multi_btb (Periodic_IPC) | multi_btb speedup vs single_btb (%) |
| --- | --- | --- | --- |
| blender | 2.6674 | 2.6674 | 0% |
| bwaves | 0.8639 | 0.8636 | -0.04% |
| cactuBSSN | 0.5938 | 0.5938 | 0% |
| cam4 | 1.4222 | 1.4207 | -0.11% |
| deepsjeng | 1.8774 | 1.8778 | 0.03% |
| exchange2 | 3.9953 | 3.9953 | 0% |
| fotonik3d | 1.3898 | 1.3898 | 0% |
| gcc | 1.5398 | 1.5379 | -0.12% |
| imagick | 3.8723 | 3.8723 | 0% |
| lbm | 1.1837 | 1.1837 | 0% |
| leela | 1.762 | 1.762 | 0% |
| mcf | 0.7606 | 0.7606 | 0% |
| mongodb | 2.6612 | 2.2942 | -13.79% |
| nab | 1.6356 | 1.6356 | 0% |
| namd | 3.4959 | 3.4959 | 0% |
| omnetpp | 0.9325 | 0.9317 | -0.09% |
| parest | 1.6788 | 1.6792 | 0.02% |
| perlbench | 2.1626 | 2.1644 | 0.08% |
| povray | 3.0896 | 3.0878 | -0.06% |
| roms | 1.0719 | 1.0719 | 0% |
| wrf | 1.2717 | 1.2717 | 0% |
| x264 | 4.6628 | 4.6627 | -0% |
| xalancbmk | 0.9218 | 0.9218 | -0% |
| xz | 1.4295 | 1.429 | -0.03% |
| Avg | 1.9559 | 1.9404 | -0.79% |
Plotting 'Periodic_IPC' → Periodic_IPC_ipc.png, Periodic_IPC_speedup_vs_single_btb.png
```