### PR TITLE
fix interactive shell bugs from #236.

### DIFF
--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -151,7 +151,6 @@ def open_interactive_shell(user, descriptor_data, workloads_data, infra_dir, dbg
                                             infra_dir,
                                             ["scarab_current"],
                                             interactive_shell=True,
-                                            available_slurm_nodes=[],
                                             dbg_lvl=dbg_lvl)
         workload = descriptor_data['simulations'][0]['workload']
         mode = descriptor_data['simulations'][0]['simulation_type']


### PR DESCRIPTION
In #236, prepare_simulation removed `available_slurm_nodes`, but in run_simulation.py, it still had the variable as an argument. 
The issue was solved after removing the argument. 