### PR TITLE
Make USE_FETCHED_COUNT=1 run fetched instruction only simulation

### DIFF
--- a/common/scripts/run_memtrace_single_simpoint.sh
+++ b/common/scripts/run_memtrace_single_simpoint.sh
@@ -119,7 +119,7 @@ else
       --fast_forward_trace_ins=$(( $TRACE_WARMUP - $WARMUP )) \
       --inst_limit=$instLimit \
       --full_warmup=$WARMUP \
-      --use_fetched_count=0 \
+      --use_fetched_count=1 \
       $SCARABPARAMS \
       &> sim.log"
     else
@@ -128,7 +128,7 @@ else
       --cbp_trace_r0=$TRACEFILE \
       --inst_limit=$instLimit \
       --full_warmup=$WARMUP \
-      --use_fetched_count=0 \
+      --use_fetched_count=1 \
       $SCARABPARAMS \
       &> sim.log"
     fi


### PR DESCRIPTION
I think both trace_then_cluster and cluster_then_trace simulation expect fetched-instruction oriented result.

<img width="1159" height="655" alt="image" src="https://github.com/user-attachments/assets/5b096423-7110-405a-9b59-23d2871b974d" />

exit_after_tracing -> after tracing the specified number of references, the process is exited with an exit code of 0. The reference count is approximate

number of ifetch + number of write = 10M (exit_after_tracing limit)
number of instruction = number of ifetch

* dynamorio, parameter documentation
https://dynamorio.org/sec_drcachesim_ops.html


use_fetched_count feature history : https://github.com/litz-lab/scarab-infra/pull/133
