### PR TITLE
Automate preparing different scarab versions required for a JSON descriptor

### DIFF
--- a/json/exp.json
+++ b/json/exp.json
@@ -55,11 +55,11 @@
   "_configurations":"scarab configurations to sweep",
   "configurations":{
     "icache_32k": {
-      "params": "--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32",
+      "params": "--icache_size 32768",
       "binary": "scarab_current"
     },
     "icache_64k": {
-      "params": "--bp_mech tage64k --fdip_enable 1 --btb_entries 8192 --perfect_crs 1 --wp_collect_stats 1 --mem_req_buffer_entries 64 --ramulator_readq_entries 64 --fe_ftq_block_num 32 --icache_size 65536",
+      "params": "--icache_size 65536",
       "binary": "scarab_current"
     }
   },


### PR DESCRIPTION
Currently, `scarab-infra` requires users to manually check out and build specific scarab commits when running simulations that reference multiple Scarab binaries (different hashes). For example, running `./sci --sim ft`
may fail with:
```
surim@bohr1:~/src/infra $ ./sci --sim ft
[spec2017, None, None, None, None] is a valid simulation option. Submitting jobs..
ERR: Scarab binary named scarab_887ef4f39dd612755e3044827b66981289bd2c49 not found in cache. Please check out that version and build it
```
This occurs when the simulation configuration specifies different Scarab binaries for comparison:
```
  "_configurations":"scarab configurations to sweep",
  "configurations":{
    "baseline": {
      "params": "",
      "binary": "scarab_887ef4f39dd612755e3044827b66981289bd2c49"
    },
    "per_core_fix": {
      "params": "",
      "binary": "scarab_current"
    }
  },
```

**Current Workflow and Limitations**
A common workflow for evaluating a new Scarab change is:
1. Apply a fix on top of the `main` branch of Scarab
2. Build Scarab with the fix (producing `scarab_current`) (`--build-scarab`)
3. Run simulations comparing the new binary against a baseline Scarab version (`--sim`)

However, in practice, users often do not have a prebuilt baseline binary (e.g., `scarab_887ef4f39dd612755e3044827b66981289bd2c49`). As a result, simulations fail and require the user to:
* Manually check out the baseline Scarab commit.
* Build the binary.
* Retry the simulation. 

**What This PR Does**
This PR automates the checkout and build of all required Scarab binaries referenced by a simulation configuration.
* When a required Scarab binary is missing from the cache, `scarab-infra` will automatically:
    * Check out the corresponding Scarab commit.
    * Build the binary.
    * Cache it for reuse.
* Users can run simulations that sweep across multiple Scarab versions without manual intervention.
