### PR TITLE
Improve robustness

### DIFF
--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -256,6 +256,12 @@ def run_simulation_command(descriptor_path, action, dbg_lvl=2, infra_dir=None):
     workload_manager = descriptor_data.get("workload_manager")
     experiment_name = descriptor_data.get("experiment")
     simulations = descriptor_data.get("simulations") or []
+
+    try:
+        verify_descriptor(descriptor_data, workloads_data, False, dbg_lvl)
+    except SystemExit as exc:
+        return 1
+
     docker_image_list = get_image_list(simulations, workloads_data)
 
     try:
@@ -292,10 +298,6 @@ def run_simulation_command(descriptor_path, action, dbg_lvl=2, infra_dir=None):
             return 0
 
         # default: run simulation
-        try:
-            verify_descriptor(descriptor_data, workloads_data, False, dbg_lvl)
-        except SystemExit as exc:
-            raise RuntimeError("Descriptor verification failed") from exc
 
         if workload_manager == "manual":
             local_runner.run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_path, dbg_lvl)

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -802,7 +802,12 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
 
         # Generate commands for executing in users docker and sbatching to nodes with containers
         experiment_dir = f"{descriptor_data['root_dir']}/simulations/{experiment_name}"
-        scarab_githash, image_tag_list = prepare_simulation(user, scarab_path, scarab_build, descriptor_data['root_dir'], experiment_name, architecture, docker_prefix_list, githash, infra_dir, scarab_binaries, False, dbg_lvl)
+
+        try:
+            scarab_githash, image_tag_list = prepare_simulation(user, scarab_path, scarab_build, descriptor_data['root_dir'], experiment_name, architecture, docker_prefix_list, githash, infra_dir, scarab_binaries, False, dbg_lvl)
+        except RuntimeError as e:
+            # This error prints a message. Now stop execution
+            return
 
         # Iterate over each workload and config combo
         tmp_files = []
@@ -834,6 +839,20 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                     if sim_warmup == None:  # Use the whole warmup available in the trace if not specified
                         sim_warmup = workloads_data[suite][subsuite][workload_]["simulation"][sim_mode_]["warmup"]
                     slurm_ids += run_single_workload(suite, subsuite, workload_, exp_cluster_id, sim_mode_, sim_warmup)
+            elif workload != None and subsuite == None:
+                found = False
+                for subsuite_ in workloads_data[suite].keys():
+                    if not workload in workloads_data[suite][subsuite_].keys():
+                        continue
+                    found = True
+                    _subsuite = subsuite_
+                assert found, f"Workload {workload} could not be found for any subsuite of {suite}. Check descriptor validation code"
+                sim_mode_ = sim_mode
+                if sim_mode_ == None:
+                    sim_mode_ = workloads_data[suite][_subsuite][workload]["simulation"]["prioritized_mode"]
+                if sim_warmup == None:  # Use the whole warmup available in the trace if not specified
+                    sim_warmup = workloads_data[suite][_subsuite][workload]["simulation"][sim_mode_]["warmup"]
+                slurm_ids += run_single_workload(suite, _subsuite, workload, exp_cluster_id, sim_mode_, sim_warmup)
             else:
                 sim_mode_ = sim_mode
                 if sim_mode_ == None:

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -167,6 +167,7 @@ def validate_simulation(workloads_data, simulations, dbg_lvl = 2):
             else:
                 if workload not in workloads_data[suite][subsuite].keys():
                     err(f"Workload '{workload}' is not valid in suite {suite} and subsuite {subsuite}.", dbg_lvl)
+                    exit(1)
                 predef_mode = workloads_data[suite][subsuite][workload]["simulation"]["prioritized_mode"]
                 sim_mode_ = sim_mode
                 if sim_mode_ == None:
@@ -985,13 +986,19 @@ def get_image_list(simulations, workloads_data):
                         image_list.append(workloads_data[suite][subsuite][workload_]["simulation"][sim_mode_]["image_name"])
         else:
             if subsuite == None:
+                found = False
                 for subsuite_ in workloads_data[suite].keys():
+                    if not workload in workloads_data[suite][subsuite_].keys():
+                        continue
+
+                    found = True
                     predef_mode = workloads_data[suite][subsuite_][workload]["simulation"]["prioritized_mode"]
                     sim_mode_ = sim_mode
                     if sim_mode_ == None:
                         sim_mode_ = predef_mode
                     if sim_mode_ in workloads_data[suite][subsuite_][workload]["simulation"].keys() and workloads_data[suite][subsuite_][workload]["simulation"][sim_mode_]["image_name"] not in image_list:
                         image_list.append(workloads_data[suite][subsuite_][workload]["simulation"][sim_mode_]["image_name"])
+                assert found, f"Workload {workload} could not be found for any subsuite of {suite}. Check descriptor validation code"
             else:
                 predef_mode = workloads_data[suite][subsuite][workload]["simulation"]["prioritized_mode"]
                 sim_mode_ = sim_mode


### PR DESCRIPTION
Addresses issues outlined in #253 :
2. when a failed simulation is re-simulated, we need to overwrite/replace the old slurm log file. Otherwise we have 2 log files for the same experiment and status will not work.
- Addressed in #262 
3. assert that the number of log files is equal to the total number of simulations. Otherwise some of the status columns will be negative.
- Added assertions to ensure Non-existant column (the only one calculated based on the total count) cannot be negative
4. On failed runs, show path to the scarab log file.
- Changed path displayed when scarab fails. Reports slurm log file for slurm errors
5. if scarab does not compile, sim should fail, and all experiments should be in failed state, right now it seems we are using some old binary.
- Raises an error when compilation fails, preventing running
6. check that we can run some sims, then recompile, then run some more. the old completed sims should not be rerun/overwritten
- Old completed sims are never re-run/overwritten (#257). Failed sims, and sims added to experiment after the initial run, can be run
7. Need to test the --sim --status --kill --visualize commands in the presence of segfault, assertion, misconfigured config file, invalid parameters in json file.
- In progress

Closes #253