### PR TITLE
Make the interactive shell always accessible even with scarab build failure

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -301,7 +301,7 @@ def build_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_pre
                     f"{docker_container_name}",
                     "/bin/bash",
                     "-c",
-                    f"cd /scarab/src && make {scarab_build}"
+                    f"cd /scarab/src && make clean && make {scarab_build}"
             ]
 
         if stream_build:


### PR DESCRIPTION
scarab build always clean the binary first (make clean) and build again