### PR TITLE
Install up-to-date nodejs by using curl

### DIFF
--- a/common/Dockerfile.common
+++ b/common/Dockerfile.common
@@ -1,5 +1,5 @@
 # Install required packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
     python3 \
     python3-pip \
     python2 \
@@ -23,7 +23,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     gosu \
     linux-tools-generic \
     gdb \
-    graphviz
+    graphviz \
+    curl
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+RUN apt install -y nodejs
 
 # Copy workflow simpoint/no_simpoint script
 COPY ./scripts/utilities.sh /usr/local/bin/utilities.sh


### PR DESCRIPTION
Install up-to-date nodejs by using curl as the one from Ubuntu's Official repo (apt install nodejs) is years behind.

Node.js is used for Codex CLI tool and VS Code extension. This will enable a user to connect VS Code to the environment inside the docker container (not only the Docker host) and to run Codex CLI inside the container.