### PR TITLE
Fix sim PARAMS per scarab hash

### DIFF
--- a/common/scripts/run_exec_single_simpoint.sh
+++ b/common/scripts/run_exec_single_simpoint.sh
@@ -18,6 +18,15 @@ BINCMD="${10}"
 CLIENT_BINCMD="${11}"
 SCARAB_BIN="${12}"
 
+PARAMS_FILE="$SCARABHOME/src/PARAMS.$SCARABARCH"
+if [[ "$SCARAB_BIN" =~ ^scarab_([0-9a-fA-F]+) ]]; then
+  HASH="${BASH_REMATCH[1]}"
+  PARAMS_BY_HASH="$SCARABHOME/src/PARAMS.$SCARABARCH.$HASH"
+  if [ -f "$PARAMS_BY_HASH" ]; then
+    PARAMS_FILE="$PARAMS_BY_HASH"
+  fi
+fi
+
 for token in $ENVVAR;
 do
   export $token
@@ -37,7 +46,7 @@ OUTDIR=$SIMHOME
 segID=$SEGMENT_ID
 #echo "SEGMENT ID: $segID"
 mkdir -p $OUTDIR/$segID
-cp $SCARABHOME/src/PARAMS.$SCARABARCH $OUTDIR/$segID/PARAMS.in
+cp "$PARAMS_FILE" "$OUTDIR/$segID/PARAMS.in"
 cd $OUTDIR/$segID
 
 # SEGMENT_ID = 0 represents non-simpoint trace simulation

--- a/common/scripts/run_memtrace_single_simpoint.sh
+++ b/common/scripts/run_memtrace_single_simpoint.sh
@@ -21,6 +21,15 @@ SEGMENT_ID="${10}"
 TRACEFILE="${11}"
 SCARAB_BIN="${12}"
 
+PARAMS_FILE="$SCARABHOME/src/PARAMS.$SCARABARCH"
+if [[ "$SCARAB_BIN" =~ ^scarab_([0-9a-fA-F]+) ]]; then
+  HASH="${BASH_REMATCH[1]}"
+  PARAMS_BY_HASH="$SCARABHOME/src/PARAMS.$SCARABARCH.$HASH"
+  if [ -f "$PARAMS_BY_HASH" ]; then
+    PARAMS_FILE="$PARAMS_BY_HASH"
+  fi
+fi
+
 SIMHOME=$SCENARIO/$WORKLOAD_HOME
 mkdir -p $SIMHOME
 OUTDIR=$SIMHOME
@@ -28,7 +37,7 @@ OUTDIR=$SIMHOME
 segID=$SEGMENT_ID
 #echo "SEGMENT ID: $segID"
 mkdir -p $OUTDIR/$segID
-cp $SCARABHOME/src/PARAMS.$SCARABARCH $OUTDIR/$segID/PARAMS.in
+cp "$PARAMS_FILE" "$OUTDIR/$segID/PARAMS.in"
 cd $OUTDIR/$segID
 
 # SEGMENT_ID = -1 represents whole trace simulation
@@ -139,7 +148,3 @@ fi
 #echo "command: ${scarabCmd}"
 eval $scarabCmd &
 wait $!
-
-# Issues. See sim.log in new_experiment20.
-# Failed to open $trace_home/postgres/traces_simp/trace/postgres0.zip
-# CMD:  docker exec --user aesymons --workdir /home/aesymons --privileged allbench_traces_aesymons slurm_payload.sh "postgres" "allbench_traces" "" "new_experiment20/fe_ftq_block_num.16" "--inst_limit 99900000 --fdip_enable 1 --fe_ftq_block_num 16" "4" "sunny_cove" "1" /home/aesymons/new_experiment20/scarab "3954"

--- a/common/scripts/run_pt_single_simpoint.sh
+++ b/common/scripts/run_pt_single_simpoint.sh
@@ -14,6 +14,15 @@ SCARABHOME="$6"
 SCARAB_BIN="$7"
 SEGMENT_ID=0
 
+PARAMS_FILE="$SCARABHOME/src/PARAMS.$SCARABARCH"
+if [[ "$SCARAB_BIN" =~ ^scarab_([0-9a-fA-F]+) ]]; then
+  HASH="${BASH_REMATCH[1]}"
+  PARAMS_BY_HASH="$SCARABHOME/src/PARAMS.$SCARABARCH.$HASH"
+  if [ -f "$PARAMS_BY_HASH" ]; then
+    PARAMS_FILE="$PARAMS_BY_HASH"
+  fi
+fi
+
 if [ "$SEGMENT_ID" != "0" ]; then
   echo -e "PT trace simulation does not support simpoints currently. cluster id should always be 0."
   exit
@@ -29,7 +38,7 @@ OUTDIR=$SIMHOME
 segID=$SEGMENT_ID
 #echo "SEGMENT ID: $segID"
 mkdir -p $OUTDIR/$segID
-cp $SCARABHOME/src/PARAMS.$SCARABARCH $OUTDIR/$segID/PARAMS.in
+cp "$PARAMS_FILE" "$OUTDIR/$segID/PARAMS.in"
 cd $OUTDIR/$segID
 
 scarabCmd="$SCARABHOME/src/$SCARAB_BIN --full_warmup $WARMUP --frontend pt --cbp_trace_r0=$trace_home/$WORKLOAD_HOME/traces/pt/${traceMap} $SCARABPARAMS &> sim.log"


### PR DESCRIPTION
When running --sim with different scarab hashes (./sci --sim multilev_btb), it checks out the specified git hash and builds scarab to prepare the binary. However, it still uses the same PARAMS.<architecture> file although the different git hashes have differences in `PARAMS.<architecture>`. It should also copy the correct `PARAMS.in` for the corresponding githash not only the binaries.

Fix:
- Export PARAMS.<arch> from each requested scarab git hash into the sim tree
- Update memtrace/pt/exec run scripts to pick hash-specific PARAMS files when present