### PR TITLE
Fix bug in cluster_then_trace for setup roi

### DIFF
--- a/common/Dockerfile.common
+++ b/common/Dockerfile.common
@@ -51,9 +51,23 @@ RUN mkdir -p $tmpdir && chmod -R 755 $tmpdir
 WORKDIR $tmpdir
 
 # DynamoRIO package
-RUN cd $tmpdir && wget https://github.com/DynamoRIO/dynamorio/releases/download/release_10.0.0/DynamoRIO-Linux-10.0.0.tar.gz && tar -xzvf DynamoRIO-Linux-10.0.0.tar.gz
-ENV DYNAMORIO_HOME=$tmpdir/DynamoRIO-Linux-10.0.0/
-RUN chmod 777 $tmpdir/DynamoRIO-Linux-10.0.0/lib64/release/libdynamorio.so
+# We will switch back to the official DynamoRIO once the fetched instruction counting logic is resolved (https://github.com/DynamoRIO/dynamorio/issues/4948)
+# RUN cd $tmpdir && wget https://github.com/DynamoRIO/dynamorio/releases/download/release_10.0.0/DynamoRIO-Linux-10.0.0.tar.gz && tar -xzvf DynamoRIO-Linux-10.0.0.tar.gz
+RUN cd $tmpdir && \
+    git clone --branch release_10.0.0 --depth 1 https://github.com/moonseoppkim/dynamorio.git DynamoRIO-Linux-10.0.0 && \
+    cd DynamoRIO-Linux-10.0.0 && \
+    git submodule update --init --recursive && \
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DBUILD_DOCS=OFF \
+          -DGENERATE_DOCS=OFF \
+          -DDOXYGEN=OFF \
+          . && \
+    make -j$(nproc) all && \
+    make install && \
+    mkdir -p tools/bin64 && cp -r clients/bin64/* tools/bin64/
+ENV DYNAMORIO_HOME=$tmpdir/DynamoRIO-Linux-10.0.0/exports
+RUN chmod 777 $DYNAMORIO_HOME/lib64/release/libdynamorio.so
+
 
 # Build fingerprint client
 COPY fingerprint_src $tmpdir/fingerprint_src/


### PR DESCRIPTION
## Changes
```
1. Use a customized DynamoRIO for Scarab
   1) trace_after_instrs: count only fetched instructions
      - The fpg.cpp uses the "count_app_instrs" internal function to count fetched instructions for each Basic Block generated by DynamoRIO
      - However, we skip some basic blocks that have the same PC as the previous block in order to construct BBV
      - Therefore, we need to add "prev_pc" checking logic to DynamoRIO's trace_after_instrs & trace_for_instrs to count instructions the same way as fpg.cpp
   2) trace_for_instrs: count only fetched instructions
2. max_bb_instrs count (4096 -> 4095)
  1) ASSERT FAILURE: /dynamorio_full_original/dynamorio/clients/drcachesim/tracer/tracer.cpp:2608: max_bb_instrs < uint64(1) << 12 ()
  2) max_bb_instrs should be lesser than 2^12(4096), and we need to use same parameters for both executions, so that DynamoRIO can generate same basic blocks.
  3) default value for "max_bb_instrs" is 1024.
``` 

We need to merge #252 together with newly collected traces.


Note : https://github.com/litz-lab/scarab-infra/issues/264