### PR TITLE
Unify conda path resolution for manual runs

### DIFF
--- a/scarab_stats/serve_jupyter.sh
+++ b/scarab_stats/serve_jupyter.sh
@@ -2,7 +2,15 @@
 # set -x #echo on
 
 # Activate conda environment first
-CONDA_BIN=$(command -v conda)
+CONDA_BIN="${CONDA_EXE}"
+if [[ -z "$CONDA_BIN" ]]; then
+    USER_CONDA="$HOME/miniconda3/bin/conda"
+    if [[ -x "$USER_CONDA" ]]; then
+        CONDA_BIN="$USER_CONDA"
+    else
+        CONDA_BIN=$(command -v conda)
+    fi
+fi
 if [[ -z "$CONDA_BIN" ]]; then
     echo "ERR: conda not found on PATH."
     exit 1


### PR DESCRIPTION
- prefer CONDA_EXE and ~/miniconda3/bin/conda before PATH
- resolve scarabinfra env via conda env list
- align serve_jupyter.sh conda lookup with sci behavior

This should fix the following error in the manual mode.

EnvironmentLocationNotFound: Not a conda environment: /soe/surim/.conda/envs/scarabinfra
