### PR TITLE
Make docker build lock file world-writable to avoid cross-user permission errors

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -201,6 +201,7 @@ def validate_simulation(workloads_data, simulations, dbg_lvl = 2):
 
 import os
 import fcntl
+import stat
 from contextlib import contextmanager
 
 @contextmanager
@@ -212,6 +213,16 @@ def file_lock(lock_path):
     os.makedirs(os.path.dirname(lock_path), exist_ok=True)
     fd = os.open(lock_path, os.O_CREAT | os.O_RDWR)
     try:
+        # Ensure other users can use the same lock file.
+        os.fchmod(
+            fd,
+            stat.S_IRUSR
+            | stat.S_IWUSR
+            | stat.S_IRGRP
+            | stat.S_IWGRP
+            | stat.S_IROTH
+            | stat.S_IWOTH,
+        )
         fcntl.flock(fd, fcntl.LOCK_EX)  # blocks until lock acquired
         yield
     finally:


### PR DESCRIPTION
```
scarab-infra$ ./sci --sim top_simpoint
Experiment '/soe/sutanaka/lab/docker-home/simulations/top_simpoint' already exists. It will overwrite the existing simulation results!
[spec2017, rate_int, perlbench, 29229, None] is a valid simulation option.
An exception occurred: [Errno 13] Permission denied: '/tmp/docker_build_allbench_traces_559bd4b.lock'
Traceback (most recent call last):
  File "/soe/sutanaka/lab/scarab-infra/scripts/slurm_runner.py", line 807, in run_simulation
    scarab_githash, image_tag_list = prepare_simulation(user, scarab_path, scarab_build, descriptor_data['root_dir'], experiment_name, architecture, docker_prefix_list, githash, infra_dir, scarab_binaries, False, dbg_lvl)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/soe/sutanaka/lab/scarab-infra/scripts/utilities.py", line 558, in prepare_simulation
    raise e
  File "/soe/sutanaka/lab/scarab-infra/scripts/utilities.py", line 552, in prepare_simulation
    prepare_docker_image(docker_prefix, image_tag, dbg_lvl)
  File "/soe/sutanaka/lab/scarab-infra/scripts/utilities.py", line 236, in prepare_docker_image
    with file_lock(lock_path):
         ^^^^^^^^^^^^^^^^^^^^
  File "/soe/sutanaka/miniconda3/envs/scarabinfra/lib/python3.12/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/soe/sutanaka/lab/scarab-infra/scripts/utilities.py", line 213, in file_lock
    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/tmp/docker_build_allbench_traces_559bd4b.lock'
No job found.
```

It should resolve this error where the lock is accessible across users.