### PR TITLE
Ensure manual simulations emit logs for status reporting

### DIFF
--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -274,7 +274,7 @@ def run_simulation_command(descriptor_path, action, dbg_lvl=2, infra_dir=None):
 
         if action == "info":
             if workload_manager == "manual":
-                local_runner.print_status(user, experiment_name, docker_image_list, dbg_lvl)
+                local_runner.print_status(user, experiment_name, docker_image_list, descriptor_data, workloads_data, dbg_lvl)
             else:
                 slurm_runner.print_status(user, experiment_name, docker_image_list, descriptor_data, workloads_data, dbg_lvl)
             return 0


### PR DESCRIPTION
Manual simulation runs did not write per-job log files, so ./sci --status <exp> could only work when Slurm logs existed and would fail or prompt for overwrite in manual mode.

This PR makes local runs write logs into the experiment logs/ directory, then extends manual status to parse those logs and generate the same completion/failed/running summary as Slurm, wiring the descriptor/workload context through the manual status path.