### PR TITLE
Fix subprocess deadlock by discarding stdout

### DIFF
--- a/common/scripts/run_simpoint_trace.py
+++ b/common/scripts/run_simpoint_trace.py
@@ -327,7 +327,7 @@ def cluster_then_trace(workload, suite, simpoint_home, bincmd, client_bincmd, si
             else:
                 trace_cmd = f"{dynamorio_home}/bin64/drrun -max_bb_instrs 4095 -opt_cleancall 2 -t drcachesim -jobs 40 -outdir {seg_dir} -offline -count_fetched_instrs -trace_after_instrs {roi_start} -trace_for_instrs {roi_length} -- {bincmd}"
 
-            process = subprocess.Popen("exec " + trace_cmd, stdout=subprocess.PIPE, shell=True)
+            process = subprocess.Popen("exec " + trace_cmd, stdout=subprocess.DEVNULL, shell=True)
             cluster_tracing_processes.add(process)
 
         for p in cluster_tracing_processes:


### PR DESCRIPTION
Hi, @5surim 

I've experienced a minor bug while collecting traces.

### Issue description
Running multiple binary commands with `stdout=PIPE` can exceed the pipe buffer (64KB on Linux) and cause deadlock. Changed to `stdout=DEVNULL`.

Alternative: `communicate()` would work but wastes memory.
If we need to capture stdout messages, we can use the code below. However, this buffers all output in memory:
```python
process = subprocess.Popen("exec " + trace_cmd, stdout=subprocess.PIPE, shell=True)
stdout, stderr = process.communicate()
print(stdout.decode())
```
Ref: https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait

<img width="795" height="103" alt="image" src="https://github.com/user-attachments/assets/d51b0774-c621-4715-9cdc-cfbdd4a78599" />


Thanks.
Best regards,