### PR TITLE
Fail fast on outdated simulation descriptor JSON format

### DIFF
--- a/.github/workflows/check-json-validity.yml
+++ b/.github/workflows/check-json-validity.yml
@@ -21,5 +21,38 @@ jobs:
           jq empty ./json/trace.json
           jq empty ./json/perf.json
           jq empty ./json/top_simpoint.json
+          jq empty ./json/top_simpoint_dbg.json
           jq empty ./workloads/workloads_db.json
           jq empty ./workloads/workloads_top_simp.json
+
+      - name: Validate simulation descriptor key parity
+        run: |
+          python3 - <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          exp_path = Path("./json/exp.json")
+          target_paths = [
+              Path("./json/top_simpoint.json"),
+              Path("./json/top_simpoint_dbg.json"),
+          ]
+
+          exp_keys = set(json.loads(exp_path.read_text(encoding="utf-8")).keys())
+          failed = False
+
+          for target in target_paths:
+              keys = set(json.loads(target.read_text(encoding="utf-8")).keys())
+              missing = sorted(exp_keys - keys)
+              extra = sorted(keys - exp_keys)
+              if missing or extra:
+                  failed = True
+                  print(f"{target} is not up-to-date with {exp_path}")
+                  if missing:
+                      print("  missing keys:", ", ".join(missing))
+                  if extra:
+                      print("  extra keys:", ", ".join(extra))
+
+          if failed:
+              sys.exit(1)
+          PY

--- a/json/top_simpoint.json
+++ b/json/top_simpoint.json
@@ -35,5 +35,36 @@
         "binary": "scarab_current",
         "slurm_options": "--mem 4G"
       }
+  },
+  "_visualize":"Visualization settings for ./sci --visualize. Configure baseline and counters.",
+  "visualize":{
+    "baseline":"this_pr",
+    "counters":[
+      "IPC"
+    ]
+  },
+  "_perf_analyze":"Performance drift analysis settings for ./sci --perf-analyze. It diffs stats and also compares baseline-vs-target Scarab binary hashes; when hashes differ it runs git diff/log in scarab_path and includes that context in reports and AI prompt. analyzer_cli_cmd examples: codex (auto-runs as non-interactive codex exec -), codex exec -, or gemini -p \"@{prompt_file}\". Supported placeholders: {prompt_file}, {summary_file}, {report_file}.",
+  "perf_analyze":{
+    "baseline":"this_pr",
+    "counters":[
+      "IPC"
+    ],
+    "_stat_groups":"Optional list of Scarab stat groups to compare: bp, core, fetch, inst, l2l1pref, memory, power, pref, stream.",
+    "stat_groups":[
+      "bp",
+      "fetch",
+      "core"
+    ],
+    "_compare_all_stats":"When true, compare all stats in collected_stats.csv that match stat_groups (or all stats if stat_groups is empty). Drift trigger still uses counters[0].",
+    "compare_all_stats":false,
+    "_drift_top_workloads":"How many top drifting workloads (by trigger counter abs delta) to expand in deterministic/AI reports.",
+    "drift_top_workloads":5,
+    "_drift_top_simpoints":"How many top drifting simpoints per selected workload to expand (ranked by abs(delta_pct) * baseline weight).",
+    "drift_top_simpoints":5,
+    "_prompt_budget_tokens":"Approximate max tokens allowed for analyzer prompt assembly.",
+    "prompt_budget_tokens":12000,
+    "threshold_pct":2.0,
+    "_analyzer_cli_cmd":"CLI command for LLM-based analysis. Examples: codex, codex exec -, gemini -p \"@{prompt_file}\"",
+    "analyzer_cli_cmd":"codex"
   }
 }

--- a/json/top_simpoint_dbg.json
+++ b/json/top_simpoint_dbg.json
@@ -35,5 +35,36 @@
         "binary": "scarab_current",
         "slurm_options": "--mem 4G"
       }
+  },
+  "_visualize":"Visualization settings for ./sci --visualize. Configure baseline and counters.",
+  "visualize":{
+    "baseline":"this_pr",
+    "counters":[
+      "IPC"
+    ]
+  },
+  "_perf_analyze":"Performance drift analysis settings for ./sci --perf-analyze. It diffs stats and also compares baseline-vs-target Scarab binary hashes; when hashes differ it runs git diff/log in scarab_path and includes that context in reports and AI prompt. analyzer_cli_cmd examples: codex (auto-runs as non-interactive codex exec -), codex exec -, or gemini -p \"@{prompt_file}\". Supported placeholders: {prompt_file}, {summary_file}, {report_file}.",
+  "perf_analyze":{
+    "baseline":"this_pr",
+    "counters":[
+      "IPC"
+    ],
+    "_stat_groups":"Optional list of Scarab stat groups to compare: bp, core, fetch, inst, l2l1pref, memory, power, pref, stream.",
+    "stat_groups":[
+      "bp",
+      "fetch",
+      "core"
+    ],
+    "_compare_all_stats":"When true, compare all stats in collected_stats.csv that match stat_groups (or all stats if stat_groups is empty). Drift trigger still uses counters[0].",
+    "compare_all_stats":false,
+    "_drift_top_workloads":"How many top drifting workloads (by trigger counter abs delta) to expand in deterministic/AI reports.",
+    "drift_top_workloads":5,
+    "_drift_top_simpoints":"How many top drifting simpoints per selected workload to expand (ranked by abs(delta_pct) * baseline weight).",
+    "drift_top_simpoints":5,
+    "_prompt_budget_tokens":"Approximate max tokens allowed for analyzer prompt assembly.",
+    "prompt_budget_tokens":12000,
+    "threshold_pct":2.0,
+    "_analyzer_cli_cmd":"CLI command for LLM-based analysis. Examples: codex, codex exec -, gemini -p \"@{prompt_file}\"",
+    "analyzer_cli_cmd":"codex"
   }
 }

--- a/sci
+++ b/sci
@@ -270,6 +270,25 @@ def read_descriptor(descriptor_name: str):
     data = infra_utils.read_descriptor_from_json(str(path))
     if data is None:
         raise StepError(f"Failed to read descriptor {path}")
+    if data.get("descriptor_type") == "simulation":
+        exp_path = REPO_ROOT / "json" / "exp.json"
+        exp_data = infra_utils.read_descriptor_from_json(str(exp_path))
+        if exp_data is None:
+            raise StepError(f"Failed to read reference descriptor {exp_path}")
+        exp_keys = set(exp_data.keys())
+        actual_keys = set(data.keys())
+        missing_keys = sorted(exp_keys - actual_keys)
+        extra_keys = sorted(actual_keys - exp_keys)
+        if missing_keys or extra_keys:
+            details: List[str] = []
+            if missing_keys:
+                details.append(f"missing keys: {', '.join(missing_keys)}")
+            if extra_keys:
+                details.append(f"extra keys: {', '.join(extra_keys)}")
+            raise StepError(
+                "Descriptor JSON format is out of date. "
+                f"Top-level keys must exactly match json/exp.json ({'; '.join(details)})."
+            )
     return path, data
 
 
@@ -1454,12 +1473,7 @@ def prebuilt_image_present() -> Tuple[bool, str]:
 
 def run_build_scarab(descriptor_name: str) -> int:
     infra_utils = load_infra_utilities()
-    descriptor_path = REPO_ROOT / "json" / f"{descriptor_name}.json"
-    if not descriptor_path.is_file():
-        raise StepError(f"Descriptor not found at {descriptor_path}")
-    descriptor = infra_utils.read_descriptor_from_json(str(descriptor_path))
-    if descriptor is None:
-        raise StepError(f"Failed to read descriptor {descriptor_path}")
+    descriptor_path, descriptor = read_descriptor(descriptor_name)
     if descriptor.get("descriptor_type") != "simulation":
         raise StepError("`--build` currently supports simulation descriptors only.")
 


### PR DESCRIPTION
- Users often hit downstream failures in simulation flows when their descriptor JSON is based on an older schema. The root cause is usually key drift from the current template, but existing errors do not clearly point to that.
- This change validates simulation descriptors at load time by comparing their top-level keys to `json/exp.json` (treated as the up-to-date format). If keys do not match exactly, it raises a clear error that lists both missing keys and extra keys.
- Add syntax validation for ./json/top_simpoint_dbg.json in CI workflow
- Add a new step `validate simulation descriptor key parity` in CI workflow