### PR TITLE
Add Claude support to --init and --perf-analyze

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ scarab-infra is a set of tools that automate the execution of Scarab simulations
    ```
    ./sci --init
    ```
-   This installs Docker when possible, configures socket permissions, installs Miniconda if needed, creates/updates the `scarabinfra` conda environment, validates activation, ensures you have an SSH key, and optionally fetches SimPoint traces, Slurm, ghcr.io credentials, and AI CLIs (Codex/Gemini).
+   This installs Docker when possible, configures socket permissions, installs Miniconda if needed, creates/updates the `scarabinfra` conda environment, validates activation, ensures you have an SSH key, and optionally fetches SimPoint traces, Slurm, ghcr.io credentials, and AI CLIs (Codex/Gemini/Claude).
 
 2. **Prepare (or update) your descriptor**
    ```
@@ -83,7 +83,7 @@ Set `visualize.baseline` to force the speedup plots to use a specific configurat
 ```
 ./sci --perf-analyze <descriptor>
 ```
-Diffs collected stats against a baseline configuration, writes a deterministic drift report, and optionally invokes an analyzer CLI (for example Codex or Gemini) for root-cause hypotheses.
+Diffs collected stats against a baseline configuration, writes a deterministic drift report, and optionally invokes an analyzer CLI (for example Codex, Gemini, or Claude) for root-cause hypotheses.
 
 Use:
 ```json
@@ -109,7 +109,7 @@ Notes:
 - `prompt_budget_tokens` limits prompt size (approximate token budgeting) before invoking the analyzer CLI.
 - `threshold_pct` is an absolute percent-delta threshold.
 - `analyzer_cli_cmd` supports `{prompt_file}`, `{summary_file}`, and `{report_file}` placeholders. If `{prompt_file}` is omitted, the prompt path is appended as the last argument.
-- Example commands: `codex` (auto-converted to non-interactive `codex exec -`), `codex exec -`, `gemini -p "@{prompt_file}"`.
+- Example commands: `codex` (auto-converted to non-interactive `codex exec -`), `codex exec -`, `gemini -p "@{prompt_file}"`, `claude` (auto-converted to non-interactive `claude -p` and prompt content over stdin).
 - If compared configurations use different Scarab binary hashes, `--perf-analyze` runs `git diff` in `scarab_path` and includes changed files/commit summaries in the report and AI prompt.
 - Outputs are written beside `collected_stats.csv`: `perf_diff_summary.json`, `perf_drift_report.md`, `perf_drift_prompt.md`, and optionally `perf_ai_report.md`.
 

--- a/json/exp.json
+++ b/json/exp.json
@@ -83,7 +83,7 @@
       }
     ]
   },
-  "_perf_analyze":"Performance drift analysis settings for ./sci --perf-analyze. It diffs stats and also compares baseline-vs-target Scarab binary hashes; when hashes differ it runs git diff/log in scarab_path and includes that context in reports and AI prompt. analyzer_cli_cmd examples: codex (auto-runs as non-interactive codex exec -), codex exec -, or gemini -p \"@{prompt_file}\". Supported placeholders: {prompt_file}, {summary_file}, {report_file}.",
+  "_perf_analyze":"Performance drift analysis settings for ./sci --perf-analyze. It diffs stats and also compares baseline-vs-target Scarab binary hashes; when hashes differ it runs git diff/log in scarab_path and includes that context in reports and AI prompt. analyzer_cli_cmd examples: codex (auto-runs as non-interactive codex exec -), codex exec -, gemini -p \"@{prompt_file}\", or claude (auto-runs as non-interactive claude -p via stdin). Supported placeholders: {prompt_file}, {summary_file}, {report_file}.",
   "perf_analyze":{
     "baseline":"icache_32k",
     "counters":[
@@ -105,7 +105,7 @@
     "_prompt_budget_tokens":"Approximate max tokens allowed for analyzer prompt assembly.",
     "prompt_budget_tokens":12000,
     "threshold_pct":2.0,
-    "_analyzer_cli_cmd":"CLI command for LLM-based analysis. Examples: codex, codex exec -, gemini -p \"@{prompt_file}\"",
+    "_analyzer_cli_cmd":"CLI command for LLM-based analysis. Examples: codex, codex exec -, gemini -p \"@{prompt_file}\", claude",
     "analyzer_cli_cmd":"codex"
   }
 }

--- a/json/top_simpoint.json
+++ b/json/top_simpoint.json
@@ -43,7 +43,7 @@
       "IPC"
     ]
   },
-  "_perf_analyze":"Performance drift analysis settings for ./sci --perf-analyze. It diffs stats and also compares baseline-vs-target Scarab binary hashes; when hashes differ it runs git diff/log in scarab_path and includes that context in reports and AI prompt. analyzer_cli_cmd examples: codex (auto-runs as non-interactive codex exec -), codex exec -, or gemini -p \"@{prompt_file}\". Supported placeholders: {prompt_file}, {summary_file}, {report_file}.",
+  "_perf_analyze":"Performance drift analysis settings for ./sci --perf-analyze. It diffs stats and also compares baseline-vs-target Scarab binary hashes; when hashes differ it runs git diff/log in scarab_path and includes that context in reports and AI prompt. analyzer_cli_cmd examples: codex (auto-runs as non-interactive codex exec -), codex exec -, gemini -p \"@{prompt_file}\", or claude (auto-runs as non-interactive claude -p via stdin). Supported placeholders: {prompt_file}, {summary_file}, {report_file}.",
   "perf_analyze":{
     "baseline":"this_pr",
     "counters":[
@@ -64,7 +64,7 @@
     "_prompt_budget_tokens":"Approximate max tokens allowed for analyzer prompt assembly.",
     "prompt_budget_tokens":12000,
     "threshold_pct":2.0,
-    "_analyzer_cli_cmd":"CLI command for LLM-based analysis. Examples: codex, codex exec -, gemini -p \"@{prompt_file}\"",
+    "_analyzer_cli_cmd":"CLI command for LLM-based analysis. Examples: codex, codex exec -, gemini -p \"@{prompt_file}\", claude",
     "analyzer_cli_cmd":"codex"
   }
 }

--- a/json/top_simpoint_dbg.json
+++ b/json/top_simpoint_dbg.json
@@ -43,7 +43,7 @@
       "IPC"
     ]
   },
-  "_perf_analyze":"Performance drift analysis settings for ./sci --perf-analyze. It diffs stats and also compares baseline-vs-target Scarab binary hashes; when hashes differ it runs git diff/log in scarab_path and includes that context in reports and AI prompt. analyzer_cli_cmd examples: codex (auto-runs as non-interactive codex exec -), codex exec -, or gemini -p \"@{prompt_file}\". Supported placeholders: {prompt_file}, {summary_file}, {report_file}.",
+  "_perf_analyze":"Performance drift analysis settings for ./sci --perf-analyze. It diffs stats and also compares baseline-vs-target Scarab binary hashes; when hashes differ it runs git diff/log in scarab_path and includes that context in reports and AI prompt. analyzer_cli_cmd examples: codex (auto-runs as non-interactive codex exec -), codex exec -, gemini -p \"@{prompt_file}\", or claude (auto-runs as non-interactive claude -p via stdin). Supported placeholders: {prompt_file}, {summary_file}, {report_file}.",
   "perf_analyze":{
     "baseline":"this_pr",
     "counters":[
@@ -64,7 +64,7 @@
     "_prompt_budget_tokens":"Approximate max tokens allowed for analyzer prompt assembly.",
     "prompt_budget_tokens":12000,
     "threshold_pct":2.0,
-    "_analyzer_cli_cmd":"CLI command for LLM-based analysis. Examples: codex, codex exec -, gemini -p \"@{prompt_file}\"",
+    "_analyzer_cli_cmd":"CLI command for LLM-based analysis. Examples: codex, codex exec -, gemini -p \"@{prompt_file}\", claude",
     "analyzer_cli_cmd":"codex"
   }
 }

--- a/sci
+++ b/sci
@@ -35,6 +35,7 @@ OPTIONAL_TITLES = {
     "(Optional) ghcr.io login to pull pre-built images from GitHub Container Registry (recommended)",
     "(Optional) Install Codex CLI",
     "(Optional) Install Gemini CLI",
+    "(Optional) Install Claude CLI",
 }
 
 COOKIES_CACHE_PATH = Path.home() / ".cache" / "gdown" / "cookies.txt"
@@ -1913,6 +1914,65 @@ def maybe_install_gemini_cli(_: argparse.Namespace) -> Tuple[bool, str]:
     return True, f"{install_msg} Added GEMINI_API_KEY to {bashrc_path}."
 
 
+def maybe_install_claude_cli(_: argparse.Namespace) -> Tuple[bool, str]:
+    if shutil.which("claude"):
+        install_msg = "Claude CLI already installed."
+    else:
+        print(
+            "Claude CLI can be used as an alternate analyzer command in descriptor "
+            "`perf_analyze.analyzer_cli_cmd`."
+        )
+        if not confirm(
+            "Install Claude CLI (optional)?",
+            default=False,
+        ):
+            return True, "Skipped Claude CLI installation."
+        npm = shutil.which("npm")
+        if not npm:
+            return False, "npm not found. Install Node.js/npm, then run: npm install -g @anthropic-ai/claude-code"
+        try:
+            run_command([npm, "install", "-g", "@anthropic-ai/claude-code"])
+        except StepError as exc:
+            return False, str(exc)
+        if not shutil.which("claude"):
+            return False, "Claude CLI install command completed, but `claude` is not on PATH."
+        install_msg = "Installed Claude CLI."
+
+    print(
+        "Claude auth setup (official references):\n"
+        "- Claude Code docs: https://docs.anthropic.com/en/docs/claude-code/overview\n"
+        "- Anthropic API keys: https://console.anthropic.com/settings/keys\n"
+        "For API key mode, use `ANTHROPIC_API_KEY`."
+    )
+    # If already authenticated, skip key prompt.
+    if (os.environ.get("ANTHROPIC_API_KEY") or "").strip():
+        return True, f"{install_msg} Claude auth already configured (ANTHROPIC_API_KEY present)."
+    if command_succeeds(["claude", "auth", "status"], timeout_sec=10):
+        return True, f"{install_msg} Claude auth already configured."
+    if command_succeeds(["claude", "login", "status"], timeout_sec=10):
+        return True, f"{install_msg} Claude auth already configured."
+
+    if not confirm(
+        "Configure Claude auth now by writing ANTHROPIC_API_KEY to ~/.bashrc (optional)?",
+        default=True,
+    ):
+        return True, f"{install_msg} Skipped Claude auth setup."
+
+    api_key = (os.environ.get("ANTHROPIC_API_KEY") or "").strip()
+    if not api_key:
+        api_key = getpass.getpass("Enter ANTHROPIC_API_KEY (input hidden): ").strip()
+    if not api_key:
+        return False, "ANTHROPIC_API_KEY not provided; Claude auth setup skipped."
+
+    os.environ["ANTHROPIC_API_KEY"] = api_key
+    try:
+        bashrc_path = upsert_shell_export("ANTHROPIC_API_KEY", api_key)
+    except OSError as exc:
+        return False, f"Failed to update ~/.bashrc with ANTHROPIC_API_KEY: {exc}"
+
+    return True, f"{install_msg} Added ANTHROPIC_API_KEY to {bashrc_path}."
+
+
 def run_init(args: argparse.Namespace) -> int:
     if sys.stdin.isatty():
         print_heading("Prepare Google Drive cookies.txt")
@@ -1944,6 +2004,7 @@ def run_init(args: argparse.Namespace) -> int:
         ("(Optional) ghcr.io login to pull pre-built images from GitHub Container Registry (recommended)", maybe_docker_login),
         ("(Optional) Install Codex CLI", maybe_install_codex_cli),
         ("(Optional) Install Gemini CLI", maybe_install_gemini_cli),
+        ("(Optional) Install Claude CLI", maybe_install_claude_cli),
     ]
     summary: List[Tuple[str, bool, str]] = []
     for title, func in steps:
@@ -1985,6 +2046,7 @@ def run_ci_init(args: argparse.Namespace) -> int:
         ("(Optional) ghcr.io login to pull pre-built images from GitHub Container Registry (recommended)", maybe_docker_login),
         ("(Optional) Install Codex CLI", maybe_install_codex_cli),
         ("(Optional) Install Gemini CLI", maybe_install_gemini_cli),
+        ("(Optional) Install Claude CLI", maybe_install_claude_cli),
     ]
     summary: List[Tuple[str, bool, str]] = []
     for title, func in steps:
@@ -3560,7 +3622,7 @@ def run_perf_analyze(descriptor_name: str) -> int:
             print("Configured analyzer_cli_cmd is empty after parsing; skipping AI analysis.")
             return 0
         stdin_payload: Optional[str] = None
-        # Common ergonomic default: "codex" should work in non-interactive mode.
+        # Common ergonomic defaults: "codex" and "claude" should work in non-interactive mode.
         if cmd[0] == "codex" and len(cmd) == 1:
             cmd = ["codex", "exec", "-"]
             stdin_payload = prompt_path.read_text(encoding="utf-8")
@@ -3569,6 +3631,12 @@ def run_perf_analyze(descriptor_name: str) -> int:
                 stdin_payload = prompt_path.read_text(encoding="utf-8")
             elif not has_prompt_placeholder:
                 cmd.append(str(prompt_path))
+        elif cmd[0] == "claude" and len(cmd) == 1:
+            cmd = ["claude", "-p"]
+            stdin_payload = prompt_path.read_text(encoding="utf-8")
+        elif cmd[0] == "claude" and len(cmd) >= 2 and cmd[1] == "-p":
+            if not has_prompt_placeholder:
+                stdin_payload = prompt_path.read_text(encoding="utf-8")
         elif not has_prompt_placeholder:
             cmd.append(str(prompt_path))
         print(f"Running analyzer CLI: {' '.join(cmd)}")


### PR DESCRIPTION
`./sci --init` will help you set up Claude.

```
.
.
.
==> (Optional) Install Claude CLI
Claude auth setup (official references):
- Claude Code docs: https://docs.anthropic.com/en/docs/claude-code/overview
- Anthropic API keys: https://console.anthropic.com/settings/keys
For API key mode, use `ANTHROPIC_API_KEY`.
Configure Claude auth now by writing ANTHROPIC_API_KEY to ~/.bashrc (optional)? [Y/n] Y
Enter ANTHROPIC_API_KEY (input hidden):
   Claude CLI already installed. Added ANTHROPIC_API_KEY to /soe/surim/.bashrc.

Init summary:
- [ok] Install Docker: Docker already available at /usr/bin/docker
- [ok] Start Docker daemon: Docker daemon already running.
- [ok] Configure Docker permissions: Docker socket already has 0666 permissions.
- [ok] Install Miniconda: Using existing Miniconda at /soe/surim/miniconda3. Add `/soe/surim/miniconda3/bin` to PATH in future shells.
- [ok] Create scarabinfra conda env: Conda environment already up to date.
- [ok] Configure conda shell hook: Conda shell hook already configured in /soe/surim/.bashrc.
- [ok] Validate conda env activation: Conda environment validated. Activate with `conda activate scarabinfra` when needed.
- [ok] Ensure GitHub SSH key: Found existing SSH key at /soe/surim/.ssh/id_rsa.pub
- [ok] Download simpoint traces: Skipped 78 trace(s) missing drive_id: google/google/arizona:1013732, google/google/arizona:18313, google/google/arizona:356145, google/google/bravo.a:1630230, google/google/bravo.a:1632013 (and more).
- [ok] (Optional) Slurm installation: Slurm already installed.
- [ok] (Optional) ghcr.io login to pull pre-built images from GitHub Container Registry (recommended): ghcr.io credentials already configured. Prebuilt image allbench_traces:0cf5426 already pulled.
- [ok] (Optional) Install Codex CLI: Codex CLI already installed. Codex auth already configured.
- [ok] (Optional) Install Gemini CLI: Gemini CLI already installed. Gemini auth already configured (GEMINI_API_KEY present).
- [ok] (Optional) Install Claude CLI: Claude CLI already installed. Added ANTHROPIC_API_KEY to /soe/surim/.bashrc. 
```

@yql5510718 , I tested it, but please test it on your end and approve this PR if it works.