### PR TITLE
Print tail detail of the first error

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -8,6 +8,7 @@ import subprocess
 import re
 import shlex
 import shutil
+from collections import deque
 from pathlib import Path
 import importlib
 import sys
@@ -1471,6 +1472,19 @@ def print_simulation_status_summary(
         print(f"\033[31mErroneous Jobs: {len(error_list)}\033[0m")
         print(f"\033[31mErrors found in {len(error_list)}/{len(log_files)} latest log files.")
         print("First 5 error runs:\n", "\n".join(error_list[:5]), "\033[0m", sep='')
+        first_error_log = error_list[0]
+        print()
+        print(f"\033[94mTail of the first error ({first_error_log}):")
+        try:
+            with open(first_error_log, "r", errors="replace") as first_error_log_file:
+                tail_lines = list(deque(first_error_log_file, maxlen=20))
+            if tail_lines:
+                print("".join(tail_lines).rstrip("\n"))
+            else:
+                print("<empty log file>")
+        except OSError as exc:
+            print(f"<unable to read log file: {exc}>")
+        print("\033[0m", end="")
     else:
         print(f"\033[92mNo errors found in log files\033[0m")
 


### PR DESCRIPTION
This will print the actual error in scarab side workflow when we run --status

something like
```
surim@bohr1:~/src/infra $ ./sci --status early_bp_lat3
Experiment '/soe/surim/simulations/early_bp_lat3' already exists. It will overwrite the existing simulation results!
[datacenter, datacenter, mongodb, None, None] is a valid simulation option.
[spec2017, rate_int_v2, perlbench_r, None, None] is a valid simulation option.
NOT RUNNING: local
More log files than total runs. Maybe same experiment name was run multiple times?
Currently running 0 simulations (from logs: 0)
WARN: Log file count doesn't match number of accounted jobs.
Configuration     | Completed | Failed | Failed - Prep | Running | Pending | Non-existant | Total
-------------------------------------------------------------------------------------------------
baseline          | 6         | 0      | 0             | 0       | 0       | 0            | 6
single_bp_tage64k | 6         | 0      | 0             | 0       | 0       | 0            | 6
two_level_lat3    | 0         | 6      | 0             | 0       | 0       | 0            | 6

Erroneous Jobs: 6
Errors found in 6/19 latest log files.
First 5 error runs:
/soe/surim/simulations/early_bp_lat3/two_level_lat3/datacenter/datacenter/mongodb/1362/sim.log
/soe/surim/simulations/early_bp_lat3/two_level_lat3/datacenter/datacenter/mongodb/4118/sim.log
/soe/surim/simulations/early_bp_lat3/two_level_lat3/datacenter/datacenter/mongodb/5198/sim.log
/soe/surim/simulations/early_bp_lat3/two_level_lat3/spec2017/rate_int_v2/perlbench_r/109678/sim.log
/soe/surim/simulations/early_bp_lat3/two_level_lat3/spec2017/rate_int_v2/perlbench_r/52790/sim.log

Tail of first error (/soe/surim/simulations/early_bp_lat3/two_level_lat3/datacenter/datacenter/mongodb/1362/sim.log):
Scarab gitrev: bdf9d55
Warning: Scarab expects the trace file type to include OFFLINE_FILE_TYPE_ARCH_REGDEPS (0x20000), but got type: 0xe40
Scarab started at Wed Mar  4 22:06:17 2026

Initialized Ramulator.

/scarab/src/icache_stage.c:754: ASSERT FAILED (P=0  O=400919  I=66131  C=287746):  uop_cache_line.n_uops == uc->sd.op_count - op_num_prev_fetch_target
Obtained 9 stack frames.
/home/surim/simulations/early_bp_lat3/scarab/src/scarab_current(+0x1e5a94) [0x555555739a94]
/home/surim/simulations/early_bp_lat3/scarab/src/scarab_current(+0x2df849) [0x555555833849]
/home/surim/simulations/early_bp_lat3/scarab/src/scarab_current(+0x2dfdbe) [0x555555833dbe]
/home/surim/simulations/early_bp_lat3/scarab/src/scarab_current(+0x2e1c9a) [0x555555835c9a]
/home/surim/simulations/early_bp_lat3/scarab/src/scarab_current(+0x2c34ff) [0x5555558174ff]
/home/surim/simulations/early_bp_lat3/scarab/src/scarab_current(+0x3269a6) [0x55555587a9a6]
/home/surim/simulations/early_bp_lat3/scarab/src/scarab_current(+0x1e11cf) [0x5555557351cf]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7ffff7819083]
/home/surim/simulations/early_bp_lat3/scarab/src/scarab_current(+0x1e50ce) [0x5555557390ce]
```