### PR TITLE
Mem defaults

### DIFF
--- a/workloads/workloads_db.json
+++ b/workloads/workloads_db.json
@@ -1,7 +1,7 @@
 {
   "google":{
     "google":{
-      "_scarab_sim_githash":null,
+      "_scarab_sim_githash":"98dc727e",
       "arizona":{
         "simulation":{
           "prioritized_mode":"memtrace",
@@ -18,61 +18,61 @@
             "cluster_id":1013732,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1863
           },
           {
             "cluster_id":18313,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2668
           },
           {
             "cluster_id":356145,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2967
           },
           {
             "cluster_id":3784177,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2578
           },
           {
             "cluster_id":3785374,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2215
           },
           {
             "cluster_id":3801151,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2765
           },
           {
             "cluster_id":3804254,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2477
           },
           {
             "cluster_id":3815911,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2388
           },
           {
             "cluster_id":3823950,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1493
           },
           {
             "cluster_id":482826,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1620
           }
         ]
       },
@@ -92,61 +92,61 @@
             "cluster_id":1630230,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1876
           },
           {
             "cluster_id":1632013,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3236
           },
           {
             "cluster_id":2760839,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2200
           },
           {
             "cluster_id":2760885,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1991
           },
           {
             "cluster_id":2760886,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1757
           },
           {
             "cluster_id":2761166,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1796
           },
           {
             "cluster_id":2761174,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2248
           },
           {
             "cluster_id":2761345,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2520
           },
           {
             "cluster_id":2761379,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1640
           },
           {
             "cluster_id":2762607,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2601
           }
         ]
       },
@@ -166,61 +166,61 @@
             "cluster_id":2294625,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2578
           },
           {
             "cluster_id":2294629,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2913
           },
           {
             "cluster_id":2294633,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3091
           },
           {
             "cluster_id":2294638,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3998
           },
           {
             "cluster_id":2294648,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3242
           },
           {
             "cluster_id":2294650,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2358
           },
           {
             "cluster_id":2294678,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2360
           },
           {
             "cluster_id":2296542,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2297
           },
           {
             "cluster_id":2296566,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2299
           },
           {
             "cluster_id":2302299,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2337
           }
         ]
       },
@@ -240,61 +240,61 @@
             "cluster_id":636293,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2520
           },
           {
             "cluster_id":636312,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1808
           },
           {
             "cluster_id":636343,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2311
           },
           {
             "cluster_id":636344,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1157
           },
           {
             "cluster_id":636345,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1120
           },
           {
             "cluster_id":636346,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1235
           },
           {
             "cluster_id":636347,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1189
           },
           {
             "cluster_id":636350,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2982
           },
           {
             "cluster_id":636468,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3192
           },
           {
             "cluster_id":636786,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2962
           }
         ]
       },
@@ -314,61 +314,61 @@
             "cluster_id":3342967,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2394
           },
           {
             "cluster_id":3343074,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2617
           },
           {
             "cluster_id":3343075,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2322
           },
           {
             "cluster_id":3343085,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2397
           },
           {
             "cluster_id":3343086,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2517
           },
           {
             "cluster_id":3351885,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":4238
           },
           {
             "cluster_id":3351917,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":4312
           },
           {
             "cluster_id":3352034,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3363
           },
           {
             "cluster_id":3352571,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2645
           },
           {
             "cluster_id":3354234,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2776
           }
         ]
       },
@@ -388,61 +388,61 @@
             "cluster_id":1338450,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2011
           },
           {
             "cluster_id":1338451,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1443
           },
           {
             "cluster_id":1340815,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2365
           },
           {
             "cluster_id":1340853,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2365
           },
           {
             "cluster_id":1340857,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2198
           },
           {
             "cluster_id":1341016,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3392
           },
           {
             "cluster_id":1341044,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3178
           },
           {
             "cluster_id":1341267,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1393
           },
           {
             "cluster_id":1341302,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2367
           },
           {
             "cluster_id":1344500,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1957
           }
         ]
       },
@@ -462,61 +462,61 @@
             "cluster_id":100564,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2386
           },
           {
             "cluster_id":79694,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3115
           },
           {
             "cluster_id":84783,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2662
           },
           {
             "cluster_id":87646,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1445
           },
           {
             "cluster_id":87991,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1591
           },
           {
             "cluster_id":88002,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1850
           },
           {
             "cluster_id":88491,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1574
           },
           {
             "cluster_id":89308,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1837
           },
           {
             "cluster_id":89851,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2182
           },
           {
             "cluster_id":92744,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1353
           }
         ]
       },
@@ -536,61 +536,61 @@
             "cluster_id":2376230,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1537
           },
           {
             "cluster_id":2376612,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2835
           },
           {
             "cluster_id":2376624,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3110
           },
           {
             "cluster_id":2384784,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2680
           },
           {
             "cluster_id":2394172,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2235
           },
           {
             "cluster_id":2397245,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3546
           },
           {
             "cluster_id":2397512,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2600
           },
           {
             "cluster_id":2397540,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":4006
           },
           {
             "cluster_id":2397578,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2630
           },
           {
             "cluster_id":2397605,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3765
           }
         ]
       },
@@ -610,61 +610,61 @@
             "cluster_id":3397110,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2055
           },
           {
             "cluster_id":3397177,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2918
           },
           {
             "cluster_id":3397179,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2729
           },
           {
             "cluster_id":3397187,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2916
           },
           {
             "cluster_id":3397188,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2882
           },
           {
             "cluster_id":3403322,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3946
           },
           {
             "cluster_id":3403460,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2509
           },
           {
             "cluster_id":3403542,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3136
           },
           {
             "cluster_id":3405246,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3018
           },
           {
             "cluster_id":3457824,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1586
           }
         ]
       },
@@ -684,61 +684,61 @@
             "cluster_id":857951,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2355
           },
           {
             "cluster_id":862092,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2994
           },
           {
             "cluster_id":862093,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2689
           },
           {
             "cluster_id":862102,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2200
           },
           {
             "cluster_id":862103,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2129
           },
           {
             "cluster_id":862154,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3578
           },
           {
             "cluster_id":862162,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2620
           },
           {
             "cluster_id":862681,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":4172
           },
           {
             "cluster_id":865437,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3217
           },
           {
             "cluster_id":865491,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1867
           }
         ]
       },
@@ -758,61 +758,61 @@
             "cluster_id":3287020,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2196
           },
           {
             "cluster_id":3287021,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2208
           },
           {
             "cluster_id":3287022,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2259
           },
           {
             "cluster_id":3287023,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2799
           },
           {
             "cluster_id":3287025,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2534
           },
           {
             "cluster_id":3287026,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2617
           },
           {
             "cluster_id":3287027,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2614
           },
           {
             "cluster_id":3287028,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2170
           },
           {
             "cluster_id":3287330,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1431
           },
           {
             "cluster_id":3287332,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1230
           }
         ]
       },
@@ -832,61 +832,61 @@
             "cluster_id":1292577,
             "segment_id":0,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":2291
           },
           {
             "cluster_id":1293239,
             "segment_id":1,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":4254
           },
           {
             "cluster_id":1293267,
             "segment_id":2,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3723
           },
           {
             "cluster_id":1293412,
             "segment_id":3,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":4111
           },
           {
             "cluster_id":1293476,
             "segment_id":4,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":4123
           },
           {
             "cluster_id":1293538,
             "segment_id":5,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3726
           },
           {
             "cluster_id":1293622,
             "segment_id":6,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":4002
           },
           {
             "cluster_id":1293732,
             "segment_id":7,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":4134
           },
           {
             "cluster_id":1293783,
             "segment_id":8,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":1068
           },
           {
             "cluster_id":1293840,
             "segment_id":9,
             "weight":0.1,
-            "base_memory_mb":null
+            "base_memory_mb":3981
           }
         ]
       }
@@ -894,7 +894,7 @@
   },
   "datacenter":{
     "datacenter":{
-      "_scarab_sim_githash":"ee729e9",
+      "_scarab_sim_githash":"98dc727e",
       "clang":{
         "simulation":{
           "prioritized_mode":"memtrace",
@@ -924,7 +924,7 @@
             "weight":0.0192795,
             "drive_id":"1whpf7MaP-Y53j1i6aklHYEVo7usfK2nY",
             "size_bytes":31105756,
-            "base_memory_mb":null
+            "base_memory_mb":4033
           },
           {
             "cluster_id":812,
@@ -932,7 +932,7 @@
             "weight":0.142406,
             "drive_id":"1ou30a046kxNYA80Vk7ll9T_mO3RkT-a0",
             "size_bytes":61205638,
-            "base_memory_mb":3576
+            "base_memory_mb":3477
           },
           {
             "cluster_id":1358,
@@ -940,7 +940,7 @@
             "weight":0.041337,
             "drive_id":"1AZRYgH_rvJcZBFhSYkr9KLBH36nuI5wK",
             "size_bytes":47556353,
-            "base_memory_mb":null
+            "base_memory_mb":3121
           },
           {
             "cluster_id":1778,
@@ -948,7 +948,7 @@
             "weight":0.0293618,
             "drive_id":"1oxl_BJ1-CBKKH_dxSHbujKePQ68F7HtC",
             "size_bytes":79050129,
-            "base_memory_mb":null
+            "base_memory_mb":6045
           },
           {
             "cluster_id":828,
@@ -956,7 +956,7 @@
             "weight":0.0209859,
             "drive_id":"1jg_epgYlUivz0hBEFdpwuz76tr6xm7Qt",
             "size_bytes":25503071,
-            "base_memory_mb":null
+            "base_memory_mb":4480
           },
           {
             "cluster_id":2213,
@@ -964,7 +964,7 @@
             "weight":0.003435,
             "drive_id":"1VnlLV94EmIVdgNf5VHJ2Tva0OnV1-4im",
             "size_bytes":25063815,
-            "base_memory_mb":null
+            "base_memory_mb":2146
           },
           {
             "cluster_id":1726,
@@ -972,7 +972,7 @@
             "weight":0.0278595,
             "drive_id":"1jWlC6p8cH56GunK5LOqV2Kte7yhK4Jnl",
             "size_bytes":25130918,
-            "base_memory_mb":null
+            "base_memory_mb":3608
           },
           {
             "cluster_id":2054,
@@ -980,7 +980,7 @@
             "weight":0.0158624,
             "drive_id":"1YW6Bntnd3kwfq82SDOvaGOvgPWbHZIoE",
             "size_bytes":15310852,
-            "base_memory_mb":null
+            "base_memory_mb":2247
           },
           {
             "cluster_id":1903,
@@ -988,7 +988,7 @@
             "weight":0.00684999,
             "drive_id":"1Lq1_oOZDm7Wbu6acVtx2LDBHyYvKecuW",
             "size_bytes":20882153,
-            "base_memory_mb":null
+            "base_memory_mb":1885
           },
           {
             "cluster_id":509,
@@ -996,7 +996,7 @@
             "weight":0.0569851,
             "drive_id":"1-3w0PErjQZ6qdBfm_ZigH4hf3ZvuSLan",
             "size_bytes":30050584,
-            "base_memory_mb":null
+            "base_memory_mb":3128
           },
           {
             "cluster_id":1751,
@@ -1004,7 +1004,7 @@
             "weight":0.0042904,
             "drive_id":"1-8byJ09aTU-lTOSbM0J13SYoWoU1Te1t",
             "size_bytes":16698573,
-            "base_memory_mb":null
+            "base_memory_mb":2443
           },
           {
             "cluster_id":62,
@@ -1012,7 +1012,7 @@
             "weight":0.017188,
             "drive_id":"1ONBo1W5DyZprlt7gy3AaSEfFTmPpEUnJ",
             "size_bytes":48787427,
-            "base_memory_mb":null
+            "base_memory_mb":2485
           },
           {
             "cluster_id":2151,
@@ -1020,7 +1020,7 @@
             "weight":0.0178037,
             "drive_id":"1mULv0BKMc3OxehxLIfO8QP21vVXiagor",
             "size_bytes":26048257,
-            "base_memory_mb":null
+            "base_memory_mb":4024
           },
           {
             "cluster_id":239,
@@ -1028,7 +1028,7 @@
             "weight":0.0419996,
             "drive_id":"17h-_nkKRMIhIYA2VHJXFaDidLfcCQ-kK",
             "size_bytes":42670822,
-            "base_memory_mb":null
+            "base_memory_mb":2701
           },
           {
             "cluster_id":1893,
@@ -1036,7 +1036,7 @@
             "weight":0.018838,
             "drive_id":"1UzudQRjUdnB_Ow3kD-6obzrN2YW_Ijls",
             "size_bytes":16268496,
-            "base_memory_mb":null
+            "base_memory_mb":1010
           },
           {
             "cluster_id":1305,
@@ -1044,7 +1044,7 @@
             "weight":0.0474163,
             "drive_id":"1vA4ln1fxod_2lYG2NWdiRNAdub-CNPqc",
             "size_bytes":52800055,
-            "base_memory_mb":null
+            "base_memory_mb":3447
           },
           {
             "cluster_id":1673,
@@ -1052,7 +1052,7 @@
             "weight":0.0145797,
             "drive_id":"1r-5tzlMquFBYJ-gFiJ6Hv2i6PLLi8m9u",
             "size_bytes":35569350,
-            "base_memory_mb":null
+            "base_memory_mb":2307
           },
           {
             "cluster_id":492,
@@ -1060,7 +1060,7 @@
             "weight":0.0193129,
             "drive_id":"1H0dceSUap7fP8KYqmim6gRtvbKZl1w74",
             "size_bytes":26714142,
-            "base_memory_mb":null
+            "base_memory_mb":3154
           },
           {
             "cluster_id":2249,
@@ -1068,7 +1068,7 @@
             "weight":0.138357,
             "drive_id":"1PdjBkLzIo8nt8gvP3yGFQnH-oJza76-d",
             "size_bytes":52250802,
-            "base_memory_mb":3834
+            "base_memory_mb":4119
           },
           {
             "cluster_id":264,
@@ -1076,7 +1076,7 @@
             "weight":0.00757737,
             "drive_id":"1aWrLYrUkokLPDH1LHY5CbLrNICd9Uxl1",
             "size_bytes":49338491,
-            "base_memory_mb":null
+            "base_memory_mb":3552
           },
           {
             "cluster_id":2123,
@@ -1084,7 +1084,7 @@
             "weight":0.0111312,
             "drive_id":"19UlbTf9X8a9kROFIdQHuTgE_aGcZvEuq",
             "size_bytes":13066017,
-            "base_memory_mb":null
+            "base_memory_mb":2594
           },
           {
             "cluster_id":116,
@@ -1092,7 +1092,7 @@
             "weight":0.0117037,
             "drive_id":"1hs1EBu1T4lohZFjzdlfKfWU_KVmgGxWm",
             "size_bytes":46718285,
-            "base_memory_mb":null
+            "base_memory_mb":3001
           },
           {
             "cluster_id":1159,
@@ -1100,7 +1100,7 @@
             "weight":0.00772639,
             "drive_id":"11peAeyXpsTsjsnp_AOnnOGsfV70LVPlf",
             "size_bytes":25951515,
-            "base_memory_mb":null
+            "base_memory_mb":3983
           },
           {
             "cluster_id":1270,
@@ -1108,7 +1108,7 @@
             "weight":0.111884,
             "drive_id":"1nwjLATBzRK8SvrY8BJPcVxeLaIzA9K1Y",
             "size_bytes":42968337,
-            "base_memory_mb":4519
+            "base_memory_mb":4567
           },
           {
             "cluster_id":2165,
@@ -1116,7 +1116,7 @@
             "weight":0.0119928,
             "drive_id":"1ujqV_yEWlAoCs-eXClzjGD7m7PmdKHrI",
             "size_bytes":26051820,
-            "base_memory_mb":null
+            "base_memory_mb":3040
           },
           {
             "cluster_id":1152,
@@ -1124,7 +1124,7 @@
             "weight":0.072869,
             "drive_id":"1KAltSG6DQCH03sRnipnhjm_7y7PId1kn",
             "size_bytes":26501019,
-            "base_memory_mb":null
+            "base_memory_mb":2811
           },
           {
             "cluster_id":792,
@@ -1132,7 +1132,7 @@
             "weight":0.0336048,
             "drive_id":"1CBTAEIFjgandguYgUVS73ZyPX-IdnGlT",
             "size_bytes":54768240,
-            "base_memory_mb":null
+            "base_memory_mb":2980
           },
           {
             "cluster_id":1979,
@@ -1140,7 +1140,7 @@
             "weight":0.0219422,
             "drive_id":"1Y_QtCf4ewd0Mxv0D8LyC9sNu1tYGAusZ",
             "size_bytes":21591058,
-            "base_memory_mb":null
+            "base_memory_mb":2690
           },
           {
             "cluster_id":2185,
@@ -1148,7 +1148,7 @@
             "weight":0.0254211,
             "drive_id":"1kgR97p4bs6e62H9dSR07O9o1-P7jYt07",
             "size_bytes":20978968,
-            "base_memory_mb":null
+            "base_memory_mb":4585
           }
         ],
         "performance":{
@@ -1189,7 +1189,7 @@
             "weight":0.0688914,
             "drive_id":"1ags0GGTMPDTgp02cBCd9f2uk7K3ZiIgm",
             "size_bytes":59489391,
-            "base_memory_mb":null
+            "base_memory_mb":13123
           },
           {
             "cluster_id":2298,
@@ -1197,7 +1197,7 @@
             "weight":0.00476039,
             "drive_id":"1JSrW8l9BgOq1Anp4cAP7D0Q1pHjGpeg1",
             "size_bytes":29139106,
-            "base_memory_mb":null
+            "base_memory_mb":2734
           },
           {
             "cluster_id":2235,
@@ -1205,7 +1205,7 @@
             "weight":0.0217863,
             "drive_id":"1nghaWIG647u7q1ELnzdnP8ynqNX9ho8v",
             "size_bytes":35953115,
-            "base_memory_mb":null
+            "base_memory_mb":3465
           },
           {
             "cluster_id":562,
@@ -1213,7 +1213,7 @@
             "weight":0.0448596,
             "drive_id":"14GUlyyd5zXiY6miaEDmRH95DXEXvEtTx",
             "size_bytes":50811099,
-            "base_memory_mb":null
+            "base_memory_mb":4234
           },
           {
             "cluster_id":2322,
@@ -1221,7 +1221,7 @@
             "weight":0.0219116,
             "drive_id":"1GqJBKsdHy-nsLtsbZ5v_wp8a9-vRKH6U",
             "size_bytes":46502597,
-            "base_memory_mb":null
+            "base_memory_mb":4712
           },
           {
             "cluster_id":533,
@@ -1229,7 +1229,7 @@
             "weight":0.023442,
             "drive_id":"1G2KT1N7p63KSFCwJVvG4zyrZZFETWM5J",
             "size_bytes":42545401,
-            "base_memory_mb":null
+            "base_memory_mb":11867
           },
           {
             "cluster_id":655,
@@ -1237,7 +1237,7 @@
             "weight":0.040145,
             "drive_id":"1BQyIvxZqWtRMZQ1YVcHJeIlXci4Q2bzM",
             "size_bytes":40200459,
-            "base_memory_mb":null
+            "base_memory_mb":1773
           },
           {
             "cluster_id":414,
@@ -1245,7 +1245,7 @@
             "weight":0.0619735,
             "drive_id":"1EcDFdeQZvtupaY69XNzwvjZCcqPSppUo",
             "size_bytes":58463765,
-            "base_memory_mb":null
+            "base_memory_mb":6017
           },
           {
             "cluster_id":253,
@@ -1253,7 +1253,7 @@
             "weight":0.0440695,
             "drive_id":"1tR6l74QegujiTFJ5dey8nWMlksIDUMtN",
             "size_bytes":55527446,
-            "base_memory_mb":null
+            "base_memory_mb":4261
           },
           {
             "cluster_id":853,
@@ -1261,7 +1261,7 @@
             "weight":0.0382069,
             "drive_id":"1ILoQF4qwZiH9HgHVDFzdl0w8xyKtwyqY",
             "size_bytes":35335964,
-            "base_memory_mb":null
+            "base_memory_mb":3846
           },
           {
             "cluster_id":907,
@@ -1269,7 +1269,7 @@
             "weight":0.0782983,
             "drive_id":"1nXyFxio1I5tDQWTZHyDkc8KRuYFbwglD",
             "size_bytes":46334644,
-            "base_memory_mb":4868
+            "base_memory_mb":4686
           },
           {
             "cluster_id":1114,
@@ -1277,7 +1277,7 @@
             "weight":0.00493655,
             "drive_id":"1bzVq7i9wz3n-9nSIx83WWr3Q6KMx7xfO",
             "size_bytes":61290049,
-            "base_memory_mb":null
+            "base_memory_mb":3711
           },
           {
             "cluster_id":939,
@@ -1285,7 +1285,7 @@
             "weight":0.312516,
             "drive_id":"1nmi8bgvgvyXiG2TquPseq5u4zF5-06tY",
             "size_bytes":63919024,
-            "base_memory_mb":5534
+            "base_memory_mb":5612
           },
           {
             "cluster_id":2606,
@@ -1293,7 +1293,7 @@
             "weight":0.00481717,
             "drive_id":"1071pfyF3dJtxz7z1gj4qFl0HU9-IHzKH",
             "size_bytes":42605179,
-            "base_memory_mb":null
+            "base_memory_mb":4291
           },
           {
             "cluster_id":2837,
@@ -1301,7 +1301,7 @@
             "weight":0.0452283,
             "drive_id":"12ebUGF7AqvNa-IZkFuWE5KjOYoV-2yGk",
             "size_bytes":63804682,
-            "base_memory_mb":null
+            "base_memory_mb":4153
           },
           {
             "cluster_id":1793,
@@ -1309,7 +1309,7 @@
             "weight":0.0443213,
             "drive_id":"18BlzjnWNyd9c5X7QWHL32s1Lw_jT0H1c",
             "size_bytes":39786181,
-            "base_memory_mb":null
+            "base_memory_mb":4706
           },
           {
             "cluster_id":1046,
@@ -1317,7 +1317,7 @@
             "weight":0.0253286,
             "drive_id":"14ILWP4cMQwTwQHvSLM0vTRsiPeXD8a6X",
             "size_bytes":48755349,
-            "base_memory_mb":null
+            "base_memory_mb":3131
           },
           {
             "cluster_id":554,
@@ -1325,7 +1325,7 @@
             "weight":0.0136878,
             "drive_id":"1STx_t1G2ddK0zAHbqK1Be1nTkQOM12go",
             "size_bytes":36242965,
-            "base_memory_mb":null
+            "base_memory_mb":3650
           },
           {
             "cluster_id":1970,
@@ -1333,7 +1333,7 @@
             "weight":0.100819,
             "drive_id":"1qkGmOObM_g8lg6aRRUFavHrz6mFs9H19",
             "size_bytes":281677302,
-            "base_memory_mb":39499
+            "base_memory_mb":39465
           }
         ],
         "performance":{
@@ -1367,7 +1367,7 @@
             "weight":0.40608,
             "drive_id":"1hoi4Sx62Q4WofnWw1TvFmG0KHlQVDQmj",
             "size_bytes":85501495,
-            "base_memory_mb":4534
+            "base_memory_mb":4694
           },
           {
             "cluster_id":1010,
@@ -1375,7 +1375,7 @@
             "weight":0.00380665,
             "drive_id":"1vR9zJ_ULZvt9TUBZVyQV-otvg5BWW96U",
             "size_bytes":86263451,
-            "base_memory_mb":null
+            "base_memory_mb":4629
           },
           {
             "cluster_id":1362,
@@ -1383,7 +1383,7 @@
             "weight":0.391956,
             "drive_id":"17I0E5t1181oFhgM7KQWKCPWM5-msip3B",
             "size_bytes":85874786,
-            "base_memory_mb":4850
+            "base_memory_mb":4783
           },
           {
             "cluster_id":5198,
@@ -1391,7 +1391,7 @@
             "weight":0.198157,
             "drive_id":"1EzC9rdU-qoFOnc_s5OY2FjCMfjS8Npsl",
             "size_bytes":85243215,
-            "base_memory_mb":4542
+            "base_memory_mb":4687
           }
         ]
       },
@@ -1427,7 +1427,7 @@
             "weight":0.0114004,
             "drive_id":"1qfJqHYWEMWT2fwNNxHuhLW24jG7CVaRD",
             "size_bytes":122358362,
-            "base_memory_mb":4031
+            "base_memory_mb":3995
           },
           {
             "cluster_id":1172,
@@ -1435,7 +1435,7 @@
             "weight":0.9886,
             "drive_id":"1JAL9nJBRvRDpJvRiTtjrzM-l5joA6DoN",
             "size_bytes":131550914,
-            "base_memory_mb":4104
+            "base_memory_mb":4204
           }
         ],
         "performance":{
@@ -1483,7 +1483,7 @@
             "weight":0.136866,
             "drive_id":"1xRwUiufBHwlyoSKVOpGbzGRmODpF5omy",
             "size_bytes":81645164,
-            "base_memory_mb":null
+            "base_memory_mb":3449
           },
           {
             "cluster_id":5297,
@@ -1491,7 +1491,7 @@
             "weight":0.151823,
             "drive_id":"1J1IpEtTR9AYrzEzxZqmduSK5hXerjxnJ",
             "size_bytes":81637119,
-            "base_memory_mb":3373
+            "base_memory_mb":3386
           },
           {
             "cluster_id":5168,
@@ -1499,7 +1499,7 @@
             "weight":0.163489,
             "drive_id":"1rZ0vMTCh_o8jmr97E3RTwrhNPgZImzg8",
             "size_bytes":81660145,
-            "base_memory_mb":3258
+            "base_memory_mb":3361
           },
           {
             "cluster_id":2807,
@@ -1507,7 +1507,7 @@
             "weight":0.165524,
             "drive_id":"1pYSFbTIEw0zpqxK_W4myABCswquDu474",
             "size_bytes":81611504,
-            "base_memory_mb":3413
+            "base_memory_mb":3508
           },
           {
             "cluster_id":2215,
@@ -1515,7 +1515,7 @@
             "weight":0.0861533,
             "drive_id":"1tprbgRRqJHUn5fX6fk8okrKXMZD40Tn6",
             "size_bytes":81617878,
-            "base_memory_mb":null
+            "base_memory_mb":3508
           },
           {
             "cluster_id":1490,
@@ -1523,7 +1523,7 @@
             "weight":0.145715,
             "drive_id":"1W03XIj-ti1A8PnAiDOBFx-94Hakcao7o",
             "size_bytes":81626352,
-            "base_memory_mb":null
+            "base_memory_mb":3399
           },
           {
             "cluster_id":3954,
@@ -1531,7 +1531,7 @@
             "weight":0.0829318,
             "drive_id":"1T9QwHt79qcP0q3zs4KWkt30CBBL4ab7h",
             "size_bytes":81613229,
-            "base_memory_mb":null
+            "base_memory_mb":3414
           },
           {
             "cluster_id":2031,
@@ -1539,7 +1539,7 @@
             "weight":0.067498,
             "drive_id":"1OWEaXmHuqcKyR1RA8SShodxccBCPTfBP",
             "size_bytes":81610128,
-            "base_memory_mb":null
+            "base_memory_mb":3386
           }
         ],
         "performance":{
@@ -1584,7 +1584,7 @@
             "weight":0.0303057,
             "drive_id":"1Jmi5rw2PDFMkfnyJ2jL9JALxosfoYfoT",
             "size_bytes":59860932,
-            "base_memory_mb":null
+            "base_memory_mb":8576
           },
           {
             "cluster_id":24078,
@@ -1592,7 +1592,7 @@
             "weight":0.082645,
             "drive_id":"14O3Thrd96yASgZK5BO2jsY4WFNTxPSXz",
             "size_bytes":59769190,
-            "base_memory_mb":8739
+            "base_memory_mb":8634
           },
           {
             "cluster_id":1937,
@@ -1600,7 +1600,7 @@
             "weight":0.0047999,
             "drive_id":"1gLwoNzUDjyMexOvomvR1JiK9J3iaRfA9",
             "size_bytes":57741968,
-            "base_memory_mb":null
+            "base_memory_mb":8336
           },
           {
             "cluster_id":11681,
@@ -1608,7 +1608,7 @@
             "weight":0.00459564,
             "drive_id":"1rSf3v-km484OuVaMjED0lCg26Cuc1lEg",
             "size_bytes":60336371,
-            "base_memory_mb":null
+            "base_memory_mb":8576
           },
           {
             "cluster_id":239,
@@ -1616,7 +1616,7 @@
             "weight":0.0245867,
             "drive_id":"1DUK1rId6R1okSl5PL-siGc4KfcLzZhnz",
             "size_bytes":6437161,
-            "base_memory_mb":null
+            "base_memory_mb":980
           },
           {
             "cluster_id":2335,
@@ -1624,7 +1624,7 @@
             "weight":0.0105445,
             "drive_id":"1ZXfjfwtWXGCPURIB0L-XvS62nzvf57AL",
             "size_bytes":58870956,
-            "base_memory_mb":null
+            "base_memory_mb":8385
           },
           {
             "cluster_id":3082,
@@ -1632,7 +1632,7 @@
             "weight":0.0226208,
             "drive_id":"1dn11F7fMj7kV1Omnh260Y53suve6rzWg",
             "size_bytes":59797145,
-            "base_memory_mb":null
+            "base_memory_mb":8583
           },
           {
             "cluster_id":25088,
@@ -1640,7 +1640,7 @@
             "weight":0.0240505,
             "drive_id":"1-LwnZihDh-QT7GGdDlELKmMuhD7gXqvV",
             "size_bytes":59790772,
-            "base_memory_mb":null
+            "base_memory_mb":8599
           },
           {
             "cluster_id":2239,
@@ -1648,7 +1648,7 @@
             "weight":0.0187145,
             "drive_id":"1JSYWr2r7dBgBcy2NpfCti7TrGE0l2cLk",
             "size_bytes":59054126,
-            "base_memory_mb":null
+            "base_memory_mb":8589
           },
           {
             "cluster_id":27989,
@@ -1656,7 +1656,7 @@
             "weight":0.0139657,
             "drive_id":"1rf7db1trmapoy4ULzZiW4hBeL-uLUj20",
             "size_bytes":59838272,
-            "base_memory_mb":null
+            "base_memory_mb":8528
           },
           {
             "cluster_id":23604,
@@ -1664,7 +1664,7 @@
             "weight":0.00402165,
             "drive_id":"1_CNMwAFIngLJuqFcpCSlTy1HL5ekRhGb",
             "size_bytes":59459802,
-            "base_memory_mb":null
+            "base_memory_mb":8613
           },
           {
             "cluster_id":38254,
@@ -1672,7 +1672,7 @@
             "weight":0.0253526,
             "drive_id":"13EMjuBkELSNDGaDkfgLQm6C5WS4Kar7E",
             "size_bytes":59657149,
-            "base_memory_mb":null
+            "base_memory_mb":8670
           },
           {
             "cluster_id":5542,
@@ -1680,7 +1680,7 @@
             "weight":0.026093,
             "drive_id":"1fbUu1xW9_jjhcsqMh8g0jZ2xYdJZivqb",
             "size_bytes":59853802,
-            "base_memory_mb":null
+            "base_memory_mb":8783
           },
           {
             "cluster_id":17860,
@@ -1688,7 +1688,7 @@
             "weight":0.029693,
             "drive_id":"1fHhUPgs2o3-9raUzzAvoDa1ZIhbYwRfh",
             "size_bytes":59861667,
-            "base_memory_mb":null
+            "base_memory_mb":8829
           },
           {
             "cluster_id":30390,
@@ -1696,7 +1696,7 @@
             "weight":0.0106466,
             "drive_id":"1kxoKEG8OzO_WAL6rv9N1L3swGSWkt_FX",
             "size_bytes":59100584,
-            "base_memory_mb":null
+            "base_memory_mb":8668
           },
           {
             "cluster_id":1198,
@@ -1704,7 +1704,7 @@
             "weight":0.0114636,
             "drive_id":"1Q0gy36WfkKJ8NFWG4oTNF5-NYKxwh7ye",
             "size_bytes":60349502,
-            "base_memory_mb":null
+            "base_memory_mb":8732
           },
           {
             "cluster_id":23110,
@@ -1712,7 +1712,7 @@
             "weight":0.0416672,
             "drive_id":"1c2NZ4ZWSyHpc_c2qYMOXnuSxmfmn1BNd",
             "size_bytes":59695512,
-            "base_memory_mb":null
+            "base_memory_mb":8700
           },
           {
             "cluster_id":17710,
@@ -1720,7 +1720,7 @@
             "weight":0.0232591,
             "drive_id":"1apGpEOpGRH--KazAYL0QijTLg5Fuajyt",
             "size_bytes":59800950,
-            "base_memory_mb":null
+            "base_memory_mb":8646
           },
           {
             "cluster_id":10138,
@@ -1728,7 +1728,7 @@
             "weight":0.0139401,
             "drive_id":"1Hc2rK1UnLv7wzDsx0x4duIasJntg5f_l",
             "size_bytes":59854636,
-            "base_memory_mb":null
+            "base_memory_mb":8672
           },
           {
             "cluster_id":20946,
@@ -1736,7 +1736,7 @@
             "weight":0.0352333,
             "drive_id":"1H9juWNItgXegfj0xhIZyef64anCfueHj",
             "size_bytes":59809882,
-            "base_memory_mb":null
+            "base_memory_mb":8718
           },
           {
             "cluster_id":5142,
@@ -1744,7 +1744,7 @@
             "weight":0.0315568,
             "drive_id":"1VIDwc9-dLDJZvFwoaPQeerdb6XR6O2iA",
             "size_bytes":59867770,
-            "base_memory_mb":null
+            "base_memory_mb":8847
           },
           {
             "cluster_id":3572,
@@ -1752,7 +1752,7 @@
             "weight":0.0294121,
             "drive_id":"1XmUXb9-hIEGJy7kMpRDuYrFTsaSagSLV",
             "size_bytes":59875967,
-            "base_memory_mb":null
+            "base_memory_mb":8661
           },
           {
             "cluster_id":24023,
@@ -1760,7 +1760,7 @@
             "weight":0.0292334,
             "drive_id":"1sWdgjzcqp42Lf5BpoZdjtsR3uMvySr2l",
             "size_bytes":59734347,
-            "base_memory_mb":null
+            "base_memory_mb":8535
           },
           {
             "cluster_id":9080,
@@ -1768,7 +1768,7 @@
             "weight":0.028927,
             "drive_id":"1LMW3z9-XUrgiCNxXcrItUmK7z23-_rwH",
             "size_bytes":59414592,
-            "base_memory_mb":null
+            "base_memory_mb":8715
           },
           {
             "cluster_id":1127,
@@ -1776,7 +1776,7 @@
             "weight":0.0130721,
             "drive_id":"16GOD0_KCvIQ9VbMHye_Hgd81VgVU5MiN",
             "size_bytes":60255725,
-            "base_memory_mb":null
+            "base_memory_mb":8533
           },
           {
             "cluster_id":32023,
@@ -1784,7 +1784,7 @@
             "weight":0.00411055,
             "drive_id":"1S8CtStDDZVD8CTWOxJ03wY-8PumM7kaH",
             "size_bytes":59872912,
-            "base_memory_mb":null
+            "base_memory_mb":8778
           },
           {
             "cluster_id":37923,
@@ -1792,7 +1792,7 @@
             "weight":0.0442969,
             "drive_id":"1Kwt4YsGC6kpG0o5EghJ8xJLcVfGyg5oH",
             "size_bytes":59851658,
-            "base_memory_mb":null
+            "base_memory_mb":8750
           },
           {
             "cluster_id":20854,
@@ -1800,7 +1800,7 @@
             "weight":0.0425097,
             "drive_id":"13RUxqCrlrcPbhLKunPB9R-R1VAEYg4DB",
             "size_bytes":59735966,
-            "base_memory_mb":null
+            "base_memory_mb":8749
           },
           {
             "cluster_id":22427,
@@ -1808,7 +1808,7 @@
             "weight":0.0296164,
             "drive_id":"1YRdF6pGUdMAo2kmnMs1bBmVMNDANYx3b",
             "size_bytes":59683964,
-            "base_memory_mb":null
+            "base_memory_mb":8720
           },
           {
             "cluster_id":1734,
@@ -1816,7 +1816,7 @@
             "weight":0.012587,
             "drive_id":"1TtxtWJR4iNd-PMhH4Bn8MpnimAFO3cxJ",
             "size_bytes":60254338,
-            "base_memory_mb":null
+            "base_memory_mb":8552
           },
           {
             "cluster_id":23006,
@@ -1824,7 +1824,7 @@
             "weight":0.0152933,
             "drive_id":"1REcVYqc-GLqZ_cpkJa7l_1nqJnY6nWxO",
             "size_bytes":59774137,
-            "base_memory_mb":null
+            "base_memory_mb":8723
           },
           {
             "cluster_id":39251,
@@ -1832,7 +1832,7 @@
             "weight":0.0355397,
             "drive_id":"1BUP9u4_Y0zqdfvmXGnxCPQ49QDEBRoXM",
             "size_bytes":59805809,
-            "base_memory_mb":null
+            "base_memory_mb":8711
           },
           {
             "cluster_id":23256,
@@ -1840,7 +1840,7 @@
             "weight":0.0783302,
             "drive_id":"1GWwt3zLjbnDfroVFZaEON-g9ySUTYF-D",
             "size_bytes":59777715,
-            "base_memory_mb":8890
+            "base_memory_mb":8457
           },
           {
             "cluster_id":7670,
@@ -1848,7 +1848,7 @@
             "weight":0.0406715,
             "drive_id":"1wu9r-ZRS5Mjo5-lOSNexnmsbXBbViBBF",
             "size_bytes":59887276,
-            "base_memory_mb":null
+            "base_memory_mb":8850
           },
           {
             "cluster_id":32215,
@@ -1856,7 +1856,7 @@
             "weight":0.0168252,
             "drive_id":"1EhbTsfO_Aqp4ELEvy5sDkGtZMWgk_x0t",
             "size_bytes":59884710,
-            "base_memory_mb":null
+            "base_memory_mb":8552
           },
           {
             "cluster_id":31568,
@@ -1864,7 +1864,7 @@
             "weight":0.0898193,
             "drive_id":"1v63YIT-szJFYmqip-XZPeerWQ5t1-fo5",
             "size_bytes":59792746,
-            "base_memory_mb":8830
+            "base_memory_mb":8744
           }
         ]
       },
@@ -1893,7 +1893,7 @@
             "weight":0.00641002,
             "drive_id":"1p497iK-8fmDG8wOPKZvVHDR9JUagXRA3",
             "size_bytes":22146768,
-            "base_memory_mb":null
+            "base_memory_mb":1580
           },
           {
             "cluster_id":2470,
@@ -1901,7 +1901,7 @@
             "weight":0.0205471,
             "drive_id":"1tDhvIHat9hZpOI1mlsL65HtRHHoRipLZ",
             "size_bytes":24222673,
-            "base_memory_mb":null
+            "base_memory_mb":2994
           },
           {
             "cluster_id":11,
@@ -1909,7 +1909,7 @@
             "weight":0.00451178,
             "drive_id":"1FsfXrD94Lq8WxBTJJgyNFfWY5WFSAXG6",
             "size_bytes":67921964,
-            "base_memory_mb":null
+            "base_memory_mb":4233
           },
           {
             "cluster_id":463,
@@ -1917,7 +1917,7 @@
             "weight":0.045836,
             "drive_id":"1vqUUE4HVn1pCTQUDFf-U-rQlKkQcuQxn",
             "size_bytes":27786721,
-            "base_memory_mb":1991
+            "base_memory_mb":2042
           },
           {
             "cluster_id":2593,
@@ -1925,7 +1925,7 @@
             "weight":0.00395137,
             "drive_id":"1Yha7Gz5ZPxaEFYpBUTPyzwqFq7vKOKOL",
             "size_bytes":24072240,
-            "base_memory_mb":null
+            "base_memory_mb":2368
           },
           {
             "cluster_id":452,
@@ -1933,7 +1933,7 @@
             "weight":0.0392503,
             "drive_id":"1UT_DPytqhK2ixmgLgVkLLmkuaWFyTDbV",
             "size_bytes":27936031,
-            "base_memory_mb":null
+            "base_memory_mb":2276
           },
           {
             "cluster_id":3311,
@@ -1941,7 +1941,7 @@
             "weight":0.759178,
             "drive_id":"1qlMQ7WFBRul9_j0X5eU0oXX9stP0F0II",
             "size_bytes":113334131,
-            "base_memory_mb":21838
+            "base_memory_mb":22012
           },
           {
             "cluster_id":2021,
@@ -1949,7 +1949,7 @@
             "weight":0.00276466,
             "drive_id":"1y7plWweVBSXFp6BiOA6gB_r4vGcVcaXT",
             "size_bytes":28551914,
-            "base_memory_mb":null
+            "base_memory_mb":2086
           },
           {
             "cluster_id":2625,
@@ -1957,7 +1957,7 @@
             "weight":0.00895644,
             "drive_id":"1J0zlnv48sNVySXj95ShkWvsX2m498SvT",
             "size_bytes":25677640,
-            "base_memory_mb":null
+            "base_memory_mb":4605
           },
           {
             "cluster_id":2735,
@@ -1965,7 +1965,7 @@
             "weight":0.00298548,
             "drive_id":"1cCupBWmZlNk1eKzkzrg2ObaJw4h4oYH_",
             "size_bytes":33594140,
-            "base_memory_mb":null
+            "base_memory_mb":1041
           },
           {
             "cluster_id":2770,
@@ -1973,7 +1973,7 @@
             "weight":0.00272205,
             "drive_id":"18Ls5JGq4iKzRGO1AMzMT0XyfPCDNALyK",
             "size_bytes":39396084,
-            "base_memory_mb":null
+            "base_memory_mb":721
           },
           {
             "cluster_id":247,
@@ -1981,7 +1981,7 @@
             "weight":0.102887,
             "drive_id":"1zJoBRXPo0v4pnTFvwDhztR45mMkEJP_2",
             "size_bytes":28683978,
-            "base_memory_mb":2631
+            "base_memory_mb":2340
           }
         ],
         "performance":{
@@ -2014,7 +2014,7 @@
             "warmup":49999999
           }
         },
-        "base_memory_mb":14924
+        "base_memory_mb":14709
       },
       "drupal":{
         "simulation":{
@@ -2030,7 +2030,7 @@
             "warmup":49999999
           }
         },
-        "base_memory_mb":17242
+        "base_memory_mb":17056
       },
       "finagle-chirper":{
         "simulation":{
@@ -2046,7 +2046,7 @@
             "warmup":49999999
           }
         },
-        "base_memory_mb":19882
+        "base_memory_mb":19827
       },
       "finagle-http":{
         "simulation":{
@@ -2062,7 +2062,7 @@
             "warmup":49999999
           }
         },
-        "base_memory_mb":17927
+        "base_memory_mb":17924
       },
       "kafka":{
         "trace":{
@@ -2081,7 +2081,7 @@
             "warmup":49999999
           }
         },
-        "base_memory_mb":15524
+        "base_memory_mb":15346
       },
       "mediawiki":{
         "simulation":{
@@ -2097,7 +2097,7 @@
             "warmup":49999999
           }
         },
-        "base_memory_mb":21871
+        "base_memory_mb":21694
       },
       "python":{
         "simulation":{
@@ -2107,7 +2107,7 @@
             "warmup":49999999
           }
         },
-        "base_memory_mb":18610
+        "base_memory_mb":18854
       },
       "tomcat":{
         "trace":{
@@ -2126,7 +2126,7 @@
             "warmup":49999999
           }
         },
-        "base_memory_mb":20780
+        "base_memory_mb":20665
       },
       "wordpress":{
         "simulation":{
@@ -2142,7 +2142,7 @@
             "warmup":49999999
           }
         },
-        "base_memory_mb":19900
+        "base_memory_mb":19657
       }
     }
   },
@@ -8163,7 +8163,7 @@
   },
   "spec2017":{
     "rate_int_v2":{
-      "_scarab_sim_githash":"ee729e9",
+      "_scarab_sim_githash":"98dc727e",
       "perlbench_r":{
         "trace":{
           "dynamorio_args":null,
@@ -8193,7 +8193,7 @@
             "weight":0.34724098,
             "drive_id":"1SNZGKagEHnnNJYOH2lMGSjghH1iddXVN",
             "size_bytes":81750735,
-            "base_memory_mb":7739
+            "base_memory_mb":7634
           },
           {
             "cluster_id":52790,
@@ -8201,7 +8201,7 @@
             "weight":0.17565936,
             "drive_id":"1PZA3bRD4EuOWY6M3DqSsgFpOsUOY_VPi",
             "size_bytes":47668770,
-            "base_memory_mb":6435
+            "base_memory_mb":6318
           },
           {
             "cluster_id":109678,
@@ -8209,7 +8209,7 @@
             "weight":0.47709966,
             "drive_id":"1n-HUXBtlBeg7pvzzklzuV1qugyPK-ABK",
             "size_bytes":63485935,
-            "base_memory_mb":7616
+            "base_memory_mb":7415
           }
         ]
       },
@@ -8242,7 +8242,7 @@
             "weight":0.49689996,
             "drive_id":"1niQOKncny34pCARitg4UYLKkaBKmc2U6",
             "size_bytes":73960071,
-            "base_memory_mb":6957
+            "base_memory_mb":7077
           },
           {
             "cluster_id":43154,
@@ -8250,7 +8250,7 @@
             "weight":0.01452509,
             "drive_id":"1QW0aTdyUJ7UidDo4cC1OEN-jJ7lDyLA2",
             "size_bytes":45016646,
-            "base_memory_mb":9149
+            "base_memory_mb":9052
           },
           {
             "cluster_id":55827,
@@ -8258,7 +8258,7 @@
             "weight":0.48857495,
             "drive_id":"1BmWHAttHko83Mw1RAmL2LhQ-sH4Remey",
             "size_bytes":83968761,
-            "base_memory_mb":7964
+            "base_memory_mb":7714
           }
         ]
       },
@@ -8291,7 +8291,7 @@
             "weight":0.07494244,
             "drive_id":"1JajYJQPMEksM4Mp9iMB5CTg0YNqfhWVW",
             "size_bytes":105256001,
-            "base_memory_mb":8300
+            "base_memory_mb":8147
           },
           {
             "cluster_id":12723,
@@ -8299,7 +8299,7 @@
             "weight":0.83540404,
             "drive_id":"1GSV6JgUFgYWUQTRDWwdLTfUkmq9htmJu",
             "size_bytes":50198611,
-            "base_memory_mb":5110
+            "base_memory_mb":4556
           },
           {
             "cluster_id":51347,
@@ -8307,7 +8307,7 @@
             "weight":0.08965351,
             "drive_id":"18_Qdb3HIBCjN1Sh32jL0eO-x4JddOlKb",
             "size_bytes":51389558,
-            "base_memory_mb":5375
+            "base_memory_mb":5383
           }
         ]
       },
@@ -8340,7 +8340,7 @@
             "weight":0.0422845,
             "drive_id":"1KsIM-gGDsO2MvQAwKJWsa-la3IBuCCNZ",
             "size_bytes":92455967,
-            "base_memory_mb":null
+            "base_memory_mb":17240
           },
           {
             "cluster_id":1390,
@@ -8348,7 +8348,7 @@
             "weight":0.07690769,
             "drive_id":"1Pyq08DLJtXRgkzVssJyXXp1jdBJ7Qc5b",
             "size_bytes":97202144,
-            "base_memory_mb":null
+            "base_memory_mb":13596
           },
           {
             "cluster_id":371,
@@ -8356,7 +8356,7 @@
             "weight":0.02057747,
             "drive_id":"1MyIFNWkKFDUwa37SwN7XICC6ICh_zRNu",
             "size_bytes":180265835,
-            "base_memory_mb":null
+            "base_memory_mb":9692
           },
           {
             "cluster_id":18877,
@@ -8364,7 +8364,7 @@
             "weight":0.03113632,
             "drive_id":"1LywEB5byzYGSNVMRsDTldJWfRAs2a-Lv",
             "size_bytes":123369272,
-            "base_memory_mb":null
+            "base_memory_mb":10803
           },
           {
             "cluster_id":13741,
@@ -8372,7 +8372,7 @@
             "weight":0.04302116,
             "drive_id":"1avITyZQrxAzp_C3s2L8_7aR0aAy6XSqx",
             "size_bytes":110614337,
-            "base_memory_mb":null
+            "base_memory_mb":19555
           },
           {
             "cluster_id":510,
@@ -8380,7 +8380,7 @@
             "weight":0.03511786,
             "drive_id":"1rLgLC63YdMOUAiBlJ6Lq1WlHybuQ_IGG",
             "size_bytes":121949946,
-            "base_memory_mb":null
+            "base_memory_mb":15385
           },
           {
             "cluster_id":12369,
@@ -8388,7 +8388,7 @@
             "weight":0.02013548,
             "drive_id":"165KCjlQq9aRrxoCd14dlOGITuvUMqND-",
             "size_bytes":106662996,
-            "base_memory_mb":null
+            "base_memory_mb":22074
           },
           {
             "cluster_id":13966,
@@ -8396,7 +8396,7 @@
             "weight":0.03786451,
             "drive_id":"1Ql7KU_f4buvi76spnRQOaUlx_ZvCDUTe",
             "size_bytes":106697160,
-            "base_memory_mb":null
+            "base_memory_mb":14410
           },
           {
             "cluster_id":19972,
@@ -8404,7 +8404,7 @@
             "weight":0.04577137,
             "drive_id":"1sJjgDmvzfOJOTTLYH7slMu1HMB2-2qDE",
             "size_bytes":99415051,
-            "base_memory_mb":null
+            "base_memory_mb":25554
           },
           {
             "cluster_id":9136,
@@ -8412,7 +8412,7 @@
             "weight":0.06993394,
             "drive_id":"1NSXiVMyYbeDfLUnbATYJ4JoW1LxBUcwg",
             "size_bytes":161447115,
-            "base_memory_mb":null
+            "base_memory_mb":8316
           },
           {
             "cluster_id":17351,
@@ -8420,7 +8420,7 @@
             "weight":0.02416257,
             "drive_id":"1X4plUIP8OcDMe4z-Zk_g5jMMAMnMaLSj",
             "size_bytes":114617401,
-            "base_memory_mb":null
+            "base_memory_mb":15954
           },
           {
             "cluster_id":18096,
@@ -8428,7 +8428,7 @@
             "weight":0.13372903,
             "drive_id":"1hRTDIfG7fqxvSYHEg2yW8uo6FpuRTKA7",
             "size_bytes":110369103,
-            "base_memory_mb":18544
+            "base_memory_mb":18445
           },
           {
             "cluster_id":16405,
@@ -8436,7 +8436,7 @@
             "weight":0.03540897,
             "drive_id":"1X9qk053prcVu8WZ4j7c8Ae1DhBrZj8VW",
             "size_bytes":97379684,
-            "base_memory_mb":null
+            "base_memory_mb":16104
           },
           {
             "cluster_id":11668,
@@ -8444,7 +8444,7 @@
             "weight":0.02882811,
             "drive_id":"1bOk1p8_CNm2Zfla--gvfM4_z-GyPPdL6",
             "size_bytes":110347770,
-            "base_memory_mb":null
+            "base_memory_mb":18567
           },
           {
             "cluster_id":2258,
@@ -8452,7 +8452,7 @@
             "weight":0.09237763,
             "drive_id":"1I94ZrUQlorLIvg25KZo59TurMfxZ4niT",
             "size_bytes":125276212,
-            "base_memory_mb":25783
+            "base_memory_mb":25959
           },
           {
             "cluster_id":16861,
@@ -8460,7 +8460,7 @@
             "weight":0.05117357,
             "drive_id":"1kOBG1-RNS99wWxD3qloXw3W3i1CLYknH",
             "size_bytes":113318294,
-            "base_memory_mb":null
+            "base_memory_mb":16719
           },
           {
             "cluster_id":19034,
@@ -8468,7 +8468,7 @@
             "weight":0.02961388,
             "drive_id":"1y0hEEJ_5yzfCyceFWBdrXam7G9yJ_hEV",
             "size_bytes":104008825,
-            "base_memory_mb":null
+            "base_memory_mb":11865
           },
           {
             "cluster_id":17210,
@@ -8476,7 +8476,7 @@
             "weight":0.14330564,
             "drive_id":"1HWDHMam-nExR2pDwCqA-hZtErcVdJz6x",
             "size_bytes":106153039,
-            "base_memory_mb":20019
+            "base_memory_mb":19636
           },
           {
             "cluster_id":17326,
@@ -8484,7 +8484,7 @@
             "weight":0.03545808,
             "drive_id":"1nXFrkecA_aJotpivl0BijgVU0Lhpx-zl",
             "size_bytes":111019368,
-            "base_memory_mb":null
+            "base_memory_mb":19175
           }
         ]
       },
@@ -8517,7 +8517,7 @@
             "weight":0.02051722,
             "drive_id":"1MYrdZABE-NXFwi1UimmJcMxRsoOPlrAq",
             "size_bytes":118968128,
-            "base_memory_mb":null
+            "base_memory_mb":10460
           },
           {
             "cluster_id":10399,
@@ -8525,7 +8525,7 @@
             "weight":0.10788087,
             "drive_id":"1Mp4UaJLq2ktwHHW_L3lnx6SyjRYse0AH",
             "size_bytes":160425896,
-            "base_memory_mb":9536
+            "base_memory_mb":9347
           },
           {
             "cluster_id":17992,
@@ -8533,7 +8533,7 @@
             "weight":0.04231676,
             "drive_id":"1dsbXt0Wzm_E7UyCvtY4XqqQfnMnQwb4S",
             "size_bytes":110951479,
-            "base_memory_mb":null
+            "base_memory_mb":13680
           },
           {
             "cluster_id":20141,
@@ -8541,7 +8541,7 @@
             "weight":0.05269184,
             "drive_id":"1fAP14zO8e9JSFt7fgt4Dao4cvTV8HS0_",
             "size_bytes":106850325,
-            "base_memory_mb":null
+            "base_memory_mb":14069
           },
           {
             "cluster_id":23896,
@@ -8549,7 +8549,7 @@
             "weight":0.02994852,
             "drive_id":"1dnRbmyK3t5E8lU0ybBWihCIvb0xMhKEw",
             "size_bytes":115235830,
-            "base_memory_mb":null
+            "base_memory_mb":11425
           },
           {
             "cluster_id":4217,
@@ -8557,7 +8557,7 @@
             "weight":0.06978337,
             "drive_id":"1jBWX4fkFSq7EsU6Wghatn7eysnk2T1Kj",
             "size_bytes":123293577,
-            "base_memory_mb":null
+            "base_memory_mb":13813
           },
           {
             "cluster_id":17561,
@@ -8565,7 +8565,7 @@
             "weight":0.02643247,
             "drive_id":"1Ihd_qUpsNElHyqI3LYdLIq8SFKiQxFgJ",
             "size_bytes":94221770,
-            "base_memory_mb":null
+            "base_memory_mb":15201
           },
           {
             "cluster_id":17594,
@@ -8573,7 +8573,7 @@
             "weight":0.04128263,
             "drive_id":"1u8fllmvXynOYvuiRQlscDZWPxvWqf0dG",
             "size_bytes":102139664,
-            "base_memory_mb":null
+            "base_memory_mb":14982
           },
           {
             "cluster_id":11314,
@@ -8581,7 +8581,7 @@
             "weight":0.04182038,
             "drive_id":"1nMqQfJcSZCrZPYOGA30iD524fVy1HL16",
             "size_bytes":166416965,
-            "base_memory_mb":null
+            "base_memory_mb":9375
           },
           {
             "cluster_id":21440,
@@ -8589,7 +8589,7 @@
             "weight":0.03102402,
             "drive_id":"1H-COvHGKEjy7ctTYEBQs7sKwZOdyq7JC",
             "size_bytes":106395298,
-            "base_memory_mb":null
+            "base_memory_mb":10646
           },
           {
             "cluster_id":3647,
@@ -8597,7 +8597,7 @@
             "weight":0.03280273,
             "drive_id":"11CNFSMIURgp8UUvdSWy21fbuzamr0Jcs",
             "size_bytes":106321523,
-            "base_memory_mb":null
+            "base_memory_mb":13980
           },
           {
             "cluster_id":373,
@@ -8605,7 +8605,7 @@
             "weight":0.01770438,
             "drive_id":"1B0VDJZPD30fhDG7nkKE-kizf5qw4eoKf",
             "size_bytes":182534046,
-            "base_memory_mb":null
+            "base_memory_mb":9568
           },
           {
             "cluster_id":1406,
@@ -8613,7 +8613,7 @@
             "weight":0.04876976,
             "drive_id":"1WyZU05uRYAXYFQzhHF0dhP9JFu9qtEEx",
             "size_bytes":111345219,
-            "base_memory_mb":null
+            "base_memory_mb":28639
           },
           {
             "cluster_id":17731,
@@ -8621,7 +8621,7 @@
             "weight":0.04343363,
             "drive_id":"1eruNRsrHu_Iw01WkVJvS4s3i_chKVThr",
             "size_bytes":116885007,
-            "base_memory_mb":null
+            "base_memory_mb":14782
           },
           {
             "cluster_id":2707,
@@ -8629,7 +8629,7 @@
             "weight":0.15834661,
             "drive_id":"1yXydl3bQfAbQmVH0r-unTrujqs6gVUnu",
             "size_bytes":124579192,
-            "base_memory_mb":15808
+            "base_memory_mb":15451
           },
           {
             "cluster_id":3648,
@@ -8637,7 +8637,7 @@
             "weight":0.05625689,
             "drive_id":"1v9K1aUMN_ifUQTuGmniyab6YInWueaX5",
             "size_bytes":101767292,
-            "base_memory_mb":null
+            "base_memory_mb":14906
           },
           {
             "cluster_id":19268,
@@ -8645,7 +8645,7 @@
             "weight":0.03946256,
             "drive_id":"1ZONsoRLtRUQV12ANiAlIrrZrY-gmTw3o",
             "size_bytes":123818506,
-            "base_memory_mb":null
+            "base_memory_mb":18117
           },
           {
             "cluster_id":18055,
@@ -8653,7 +8653,7 @@
             "weight":0.01472607,
             "drive_id":"1ZqsoxZIs3u6zF9ECKCs5Ww4ds6p9bl0e",
             "size_bytes":71781116,
-            "base_memory_mb":null
+            "base_memory_mb":15092
           },
           {
             "cluster_id":20812,
@@ -8661,7 +8661,7 @@
             "weight":0.11503708,
             "drive_id":"153qQ_VTMA4s2yOK4lp8cYMnqRBcKhdED",
             "size_bytes":117342875,
-            "base_memory_mb":16610
+            "base_memory_mb":16607
           }
         ]
       },
@@ -8694,7 +8694,7 @@
             "weight":0.02839764,
             "drive_id":"1gL9FL5hvUyrcvOZPxx54aY-GhY-8t-zq",
             "size_bytes":104170264,
-            "base_memory_mb":null
+            "base_memory_mb":18142
           },
           {
             "cluster_id":9591,
@@ -8702,7 +8702,7 @@
             "weight":0.11181571,
             "drive_id":"1SbdxXe8aNld5MhiAlzXgqobdAl1378Pp",
             "size_bytes":106445488,
-            "base_memory_mb":13666
+            "base_memory_mb":13306
           },
           {
             "cluster_id":21882,
@@ -8710,7 +8710,7 @@
             "weight":0.05200731,
             "drive_id":"1sGU9Xs7C_uuRMqWsiO1tMyAbMgQMiHsU",
             "size_bytes":84856161,
-            "base_memory_mb":null
+            "base_memory_mb":13204
           },
           {
             "cluster_id":19215,
@@ -8718,7 +8718,7 @@
             "weight":0.02947081,
             "drive_id":"1zUwPJPgalY0lqoYE3gg-ZGjUrIh_HHXn",
             "size_bytes":170045109,
-            "base_memory_mb":null
+            "base_memory_mb":11882
           },
           {
             "cluster_id":48,
@@ -8726,7 +8726,7 @@
             "weight":0.01296055,
             "drive_id":"1ufNld9cfL9Ris48jFqqeDNeQ-l6z0Uc0",
             "size_bytes":189406973,
-            "base_memory_mb":null
+            "base_memory_mb":9781
           },
           {
             "cluster_id":1264,
@@ -8734,7 +8734,7 @@
             "weight":0.00941085,
             "drive_id":"1DO3qtCLrJLO3KTnuurIILCVCXrre2XN-",
             "size_bytes":54169008,
-            "base_memory_mb":null
+            "base_memory_mb":9274
           },
           {
             "cluster_id":23288,
@@ -8742,7 +8742,7 @@
             "weight":0.01853276,
             "drive_id":"14uPVm9CpPaTCcA3TnuqEYShSHlpvedEB",
             "size_bytes":98058167,
-            "base_memory_mb":null
+            "base_memory_mb":13811
           },
           {
             "cluster_id":13605,
@@ -8750,7 +8750,7 @@
             "weight":0.04933946,
             "drive_id":"1yhNu3bfzaFHmlFfsVgQacJTrNfSdMFGb",
             "size_bytes":105217178,
-            "base_memory_mb":null
+            "base_memory_mb":15669
           },
           {
             "cluster_id":2181,
@@ -8758,7 +8758,7 @@
             "weight":0.06331683,
             "drive_id":"1FVcUrg3Ft34exP8zbB-jfmK0nbvSTQRK",
             "size_bytes":62444672,
-            "base_memory_mb":null
+            "base_memory_mb":6947
           },
           {
             "cluster_id":22247,
@@ -8766,7 +8766,7 @@
             "weight":0.03479537,
             "drive_id":"1ZWjJGTSL5H4JV6n3EbjEPTqvok7FHivr",
             "size_bytes":101186480,
-            "base_memory_mb":null
+            "base_memory_mb":13855
           },
           {
             "cluster_id":18670,
@@ -8774,7 +8774,7 @@
             "weight":0.06550444,
             "drive_id":"1VA5Ed0JK0qd-vgqQs_iJu1gRgsWGZZz4",
             "size_bytes":164341880,
-            "base_memory_mb":null
+            "base_memory_mb":8408
           },
           {
             "cluster_id":657,
@@ -8782,7 +8782,7 @@
             "weight":0.01114442,
             "drive_id":"1J5RBHhR37PRb3YsbfsiP_7ZUbJL6K8q7",
             "size_bytes":79228732,
-            "base_memory_mb":null
+            "base_memory_mb":22921
           },
           {
             "cluster_id":11284,
@@ -8790,7 +8790,7 @@
             "weight":0.02554962,
             "drive_id":"1ZH7PMqEwk-b_QMf03-t7XJkZJqZ8JLhZ",
             "size_bytes":103713787,
-            "base_memory_mb":null
+            "base_memory_mb":16566
           },
           {
             "cluster_id":2198,
@@ -8798,7 +8798,7 @@
             "weight":0.15020205,
             "drive_id":"1SIItYuqPs-rBfOKPA1nbttaI0W00mgzX",
             "size_bytes":62322932,
-            "base_memory_mb":7057
+            "base_memory_mb":7023
           },
           {
             "cluster_id":12895,
@@ -8806,7 +8806,7 @@
             "weight":0.09344805,
             "drive_id":"1R0EEYBXt0iLQ0xSUy3XHccagjwXfPtVD",
             "size_bytes":121641529,
-            "base_memory_mb":null
+            "base_memory_mb":19163
           },
           {
             "cluster_id":23335,
@@ -8814,7 +8814,7 @@
             "weight":0.03859272,
             "drive_id":"1zUJOZkUsOHqkuvyDc6SKFA9eHMxRWy-6",
             "size_bytes":116999423,
-            "base_memory_mb":null
+            "base_memory_mb":16497
           },
           {
             "cluster_id":14493,
@@ -8822,7 +8822,7 @@
             "weight":0.14838593,
             "drive_id":"1yumxgkHyDnC6GOSMcjpdnHyL8yAK2zp_",
             "size_bytes":114246158,
-            "base_memory_mb":14391
+            "base_memory_mb":14150
           },
           {
             "cluster_id":14237,
@@ -8830,7 +8830,7 @@
             "weight":0.04317432,
             "drive_id":"1VsE0Bb07SSugDbGS6g_iDctBRu1Q3dl7",
             "size_bytes":116463528,
-            "base_memory_mb":null
+            "base_memory_mb":17568
           },
           {
             "cluster_id":6423,
@@ -8838,7 +8838,7 @@
             "weight":0.00899809,
             "drive_id":"1sySJZ8231hbI6eB-pwdoXEJwEKPXgL5w",
             "size_bytes":55541065,
-            "base_memory_mb":null
+            "base_memory_mb":7684
           }
         ]
       },
@@ -8871,7 +8871,7 @@
             "weight":0.05429234,
             "drive_id":"1i_WTxSnbrPHwevHTsA6EpScxfX8x6Ri_",
             "size_bytes":145933011,
-            "base_memory_mb":null
+            "base_memory_mb":9387
           },
           {
             "cluster_id":2054,
@@ -8879,7 +8879,7 @@
             "weight":0.06596363,
             "drive_id":"19Vzl3j_Xj_DU4pWVrKDZGTf4w73X6lL8",
             "size_bytes":98431610,
-            "base_memory_mb":null
+            "base_memory_mb":11491
           },
           {
             "cluster_id":16086,
@@ -8887,7 +8887,7 @@
             "weight":0.03360706,
             "drive_id":"1xZHvqdeQB5mGHQwZXs9aFukXIcpKPGDm",
             "size_bytes":83138032,
-            "base_memory_mb":null
+            "base_memory_mb":13232
           },
           {
             "cluster_id":1886,
@@ -8895,7 +8895,7 @@
             "weight":0.10676105,
             "drive_id":"1Oj4GD9V9s01-1yo0G5AxSUPxQC9st4dd",
             "size_bytes":100977290,
-            "base_memory_mb":11612
+            "base_memory_mb":11560
           },
           {
             "cluster_id":1754,
@@ -8903,7 +8903,7 @@
             "weight":0.0917551,
             "drive_id":"10PPQxUeIKu3ixHba_9LURr-LJTdJz3Ti",
             "size_bytes":112875170,
-            "base_memory_mb":12139
+            "base_memory_mb":12016
           },
           {
             "cluster_id":8062,
@@ -8911,7 +8911,7 @@
             "weight":0.03371127,
             "drive_id":"1_Y3E4CHIeEHkFo2--o97mlcD418gKK6z",
             "size_bytes":173076489,
-            "base_memory_mb":null
+            "base_memory_mb":11203
           },
           {
             "cluster_id":16369,
@@ -8919,7 +8919,7 @@
             "weight":0.03652488,
             "drive_id":"1YfjTjrcFo5k3ymEEEpBBwEN6A0rJZQ-M",
             "size_bytes":94001050,
-            "base_memory_mb":null
+            "base_memory_mb":7370
           },
           {
             "cluster_id":19177,
@@ -8927,7 +8927,7 @@
             "weight":0.01276547,
             "drive_id":"1SDqs9cHQTotX-CLXFFTbfX2ZRbWuWYEZ",
             "size_bytes":174080056,
-            "base_memory_mb":null
+            "base_memory_mb":11823
           },
           {
             "cluster_id":10769,
@@ -8935,7 +8935,7 @@
             "weight":0.01953899,
             "drive_id":"1XmWfIDg5dHNWx6SH_R-Z3BOvuZEEO8QC",
             "size_bytes":173762872,
-            "base_memory_mb":null
+            "base_memory_mb":11122
           },
           {
             "cluster_id":5349,
@@ -8943,7 +8943,7 @@
             "weight":0.04012006,
             "drive_id":"13iaQkEsJXzhxSQHvBOpAcgLlFE5odBSF",
             "size_bytes":120591985,
-            "base_memory_mb":null
+            "base_memory_mb":9098
           },
           {
             "cluster_id":2422,
@@ -8951,7 +8951,7 @@
             "weight":0.05545916,
             "drive_id":"12zn2Z3fWolRpaHwjmQLFvcl1hM9F5jx8",
             "size_bytes":86352693,
-            "base_memory_mb":null
+            "base_memory_mb":12515
           },
           {
             "cluster_id":9075,
@@ -8959,7 +8959,7 @@
             "weight":0.03913008,
             "drive_id":"121oHrK79OWWPxSJJi8ZHNpEhMVE1mVGB",
             "size_bytes":55845760,
-            "base_memory_mb":null
+            "base_memory_mb":10836
           },
           {
             "cluster_id":3385,
@@ -8967,7 +8967,7 @@
             "weight":0.01219233,
             "drive_id":"1mwklHdR7bg8zu1JCnw8G6ggryyMmqAeN",
             "size_bytes":71061191,
-            "base_memory_mb":null
+            "base_memory_mb":11901
           },
           {
             "cluster_id":14844,
@@ -8975,7 +8975,7 @@
             "weight":0.02214419,
             "drive_id":"1rN2QgyNTIOmj6E-aE8ksNBnW0xO4KNY3",
             "size_bytes":133432278,
-            "base_memory_mb":null
+            "base_memory_mb":10986
           },
           {
             "cluster_id":7964,
@@ -8983,7 +8983,7 @@
             "weight":0.03610805,
             "drive_id":"1GwxvuIYyym-sFFXoQiqftVx-kL_yFkBW",
             "size_bytes":66213567,
-            "base_memory_mb":null
+            "base_memory_mb":7000
           },
           {
             "cluster_id":11009,
@@ -8991,7 +8991,7 @@
             "weight":0.06825621,
             "drive_id":"1aEyhIDO_ALDWHN629l2IwYFpZLupzuKk",
             "size_bytes":168224266,
-            "base_memory_mb":null
+            "base_memory_mb":11315
           },
           {
             "cluster_id":13226,
@@ -8999,7 +8999,7 @@
             "weight":0.0236031,
             "drive_id":"1QkDeIvl3LmdRE2IbMe6dn155uTvMXaSK",
             "size_bytes":104073251,
-            "base_memory_mb":null
+            "base_memory_mb":12221
           },
           {
             "cluster_id":7196,
@@ -9007,7 +9007,7 @@
             "weight":0.11765078,
             "drive_id":"1roE65TWaf4N5H4-Msj2IAgcTU_hrqMcj",
             "size_bytes":46043938,
-            "base_memory_mb":7589
+            "base_memory_mb":7512
           },
           {
             "cluster_id":1872,
@@ -9015,7 +9015,7 @@
             "weight":0.07872911,
             "drive_id":"1a7qF4CuP-oTN-Mhit0q43TgtOSIN4txS",
             "size_bytes":107760414,
-            "base_memory_mb":null
+            "base_memory_mb":12105
           },
           {
             "cluster_id":2938,
@@ -9023,7 +9023,7 @@
             "weight":0.05168714,
             "drive_id":"1vw5XerAxlx5Gn3ESQDsxHzqnXQrrtD10",
             "size_bytes":100218454,
-            "base_memory_mb":null
+            "base_memory_mb":9633
           }
         ]
       },
@@ -9056,7 +9056,7 @@
             "weight":0.05059312,
             "drive_id":"1fijzCmPja4BfEeC5d2GtGyreusxuZmud",
             "size_bytes":53851476,
-            "base_memory_mb":null
+            "base_memory_mb":12221
           },
           {
             "cluster_id":5291,
@@ -9064,7 +9064,7 @@
             "weight":0.0631554,
             "drive_id":"1035rF648eKPwGkJ2Ot7ytdrnfDd7OY8P",
             "size_bytes":138170685,
-            "base_memory_mb":null
+            "base_memory_mb":10679
           },
           {
             "cluster_id":17988,
@@ -9072,7 +9072,7 @@
             "weight":0.03090878,
             "drive_id":"1zIUJuLnRaSZICLxhL_rJJnONUvjWrmDi",
             "size_bytes":51537164,
-            "base_memory_mb":null
+            "base_memory_mb":17517
           },
           {
             "cluster_id":19492,
@@ -9080,7 +9080,7 @@
             "weight":0.04654769,
             "drive_id":"1kXPt1tyi4CJLivXqq06cuvtzrS2Pt2p_",
             "size_bytes":63892722,
-            "base_memory_mb":null
+            "base_memory_mb":10827
           },
           {
             "cluster_id":1646,
@@ -9088,7 +9088,7 @@
             "weight":0.05646618,
             "drive_id":"1wQyunStYj9gy7g5RDLy4N8gVfS-YFNzm",
             "size_bytes":99436015,
-            "base_memory_mb":null
+            "base_memory_mb":12266
           },
           {
             "cluster_id":19563,
@@ -9096,7 +9096,7 @@
             "weight":0.01946792,
             "drive_id":"1ylTYhtkechegJW-VTOjZKPojYIC25fbu",
             "size_bytes":61697506,
-            "base_memory_mb":null
+            "base_memory_mb":10572
           },
           {
             "cluster_id":19722,
@@ -9104,7 +9104,7 @@
             "weight":0.03556816,
             "drive_id":"1xOoOsKwBcTI55gQvHq1UiUBXmTnrSkjF",
             "size_bytes":33695905,
-            "base_memory_mb":null
+            "base_memory_mb":6771
           },
           {
             "cluster_id":1751,
@@ -9112,7 +9112,7 @@
             "weight":0.05448248,
             "drive_id":"1-c0Zs0yq1Ojt8NXmFTXfi9LGfvEgogaB",
             "size_bytes":95200818,
-            "base_memory_mb":null
+            "base_memory_mb":9097
           },
           {
             "cluster_id":2083,
@@ -9120,7 +9120,7 @@
             "weight":0.09263406,
             "drive_id":"1vwLOjXF0TjHtP6EyGfJa58yWzwRN8BP6",
             "size_bytes":105136432,
-            "base_memory_mb":10497
+            "base_memory_mb":10193
           },
           {
             "cluster_id":14423,
@@ -9128,7 +9128,7 @@
             "weight":0.05217586,
             "drive_id":"1_1gaCLdeykPqbRXO7YBOknSGuqKhG99c",
             "size_bytes":49964738,
-            "base_memory_mb":null
+            "base_memory_mb":9045
           },
           {
             "cluster_id":2034,
@@ -9136,7 +9136,7 @@
             "weight":0.06384739,
             "drive_id":"1ddHHSzb8IYxsCrzGrjKyLV9eIXt6TP48",
             "size_bytes":94369950,
-            "base_memory_mb":null
+            "base_memory_mb":11837
           },
           {
             "cluster_id":1956,
@@ -9144,7 +9144,7 @@
             "weight":0.10896496,
             "drive_id":"1R4tAf6CC3DmKPu5au6PZ-Eyd_MShOvOm",
             "size_bytes":121965121,
-            "base_memory_mb":12174
+            "base_memory_mb":12093
           },
           {
             "cluster_id":20595,
@@ -9152,7 +9152,7 @@
             "weight":0.04756261,
             "drive_id":"1s4r-yZ5iPCR7BRCV2W-5R6i0H1zO3lPU",
             "size_bytes":169115334,
-            "base_memory_mb":null
+            "base_memory_mb":11122
           },
           {
             "cluster_id":1681,
@@ -9160,7 +9160,7 @@
             "weight":0.03155463,
             "drive_id":"1U694dVeLbNblbut8nmLsDYZIbNgHdNFA",
             "size_bytes":168616452,
-            "base_memory_mb":null
+            "base_memory_mb":14096
           },
           {
             "cluster_id":9398,
@@ -9168,7 +9168,7 @@
             "weight":0.0388897,
             "drive_id":"1Kz2wAZytGvDM1SfnPNS19PPei9TgaASD",
             "size_bytes":73609557,
-            "base_memory_mb":null
+            "base_memory_mb":15805
           },
           {
             "cluster_id":359,
@@ -9176,7 +9176,7 @@
             "weight":0.01577732,
             "drive_id":"1zKwzHOzzEYaUD2HE3-VH8s1OVa3xna8p",
             "size_bytes":172453047,
-            "base_memory_mb":null
+            "base_memory_mb":8378
           },
           {
             "cluster_id":9420,
@@ -9184,7 +9184,7 @@
             "weight":0.03847451,
             "drive_id":"1PVvTqrgEJGpDm0CbAebbdU4elGLqgy48",
             "size_bytes":67132138,
-            "base_memory_mb":null
+            "base_memory_mb":11530
           },
           {
             "cluster_id":2025,
@@ -9192,7 +9192,7 @@
             "weight":0.11362435,
             "drive_id":"1OXv9l-tiAdZMLujXOlH_b1GDR4_zpwTn",
             "size_bytes":126128223,
-            "base_memory_mb":22368
+            "base_memory_mb":21770
           },
           {
             "cluster_id":7262,
@@ -9200,7 +9200,7 @@
             "weight":0.03755186,
             "drive_id":"1fT1RPOnXtcSIzEF-ibHb45M4f5adxjK7",
             "size_bytes":55747561,
-            "base_memory_mb":null
+            "base_memory_mb":13322
           }
         ]
       },
@@ -9233,7 +9233,7 @@
             "weight":0.13461258,
             "drive_id":"1CQ84WHflC_ZWM-rZDluSS4-9wDE1Cfp1",
             "size_bytes":72421782,
-            "base_memory_mb":13680
+            "base_memory_mb":13573
           },
           {
             "cluster_id":85716,
@@ -9241,7 +9241,7 @@
             "weight":0.54475975,
             "drive_id":"14rk3hLP0nx2LMfjy8j8QNZa12-7kCzey",
             "size_bytes":63532197,
-            "base_memory_mb":18965
+            "base_memory_mb":19179
           },
           {
             "cluster_id":63310,
@@ -9249,7 +9249,7 @@
             "weight":0.07917584,
             "drive_id":"1tFYRWD9IQkSfAt2NDQEocmpkSUqtpleT",
             "size_bytes":50125523,
-            "base_memory_mb":null
+            "base_memory_mb":17583
           },
           {
             "cluster_id":93581,
@@ -9257,7 +9257,7 @@
             "weight":0.24145183,
             "drive_id":"1opa2OMC6BPFdlhLeShDE0PRUwgRfAcgI",
             "size_bytes":37100891,
-            "base_memory_mb":7894
+            "base_memory_mb":8050
           }
         ]
       },
@@ -9290,7 +9290,7 @@
             "weight":0.83876729,
             "drive_id":"1HD3FhXGM6wbiPY15JyJjUvNdZZg6EsPH",
             "size_bytes":175929956,
-            "base_memory_mb":8811
+            "base_memory_mb":8512
           },
           {
             "cluster_id":2420,
@@ -9298,7 +9298,7 @@
             "weight":0.15584698,
             "drive_id":"1ySJfOgRUiIrtsrDMEw3_TInvTTh1PbY-",
             "size_bytes":164863964,
-            "base_memory_mb":9350
+            "base_memory_mb":9167
           }
         ]
       },
@@ -9331,7 +9331,7 @@
             "weight":0.06049864,
             "drive_id":"1sFFt7FkNSWygwCSVOZrXl0BbfiuDqAzS",
             "size_bytes":109618222,
-            "base_memory_mb":null
+            "base_memory_mb":8097
           },
           {
             "cluster_id":29880,
@@ -9339,7 +9339,7 @@
             "weight":0.08003628,
             "drive_id":"1ktrTNtHKdz3boe4e5t2u03GJ5ELStDbP",
             "size_bytes":131564495,
-            "base_memory_mb":null
+            "base_memory_mb":8583
           },
           {
             "cluster_id":104011,
@@ -9347,7 +9347,7 @@
             "weight":0.13339379,
             "drive_id":"1JW3GHTiFrSQtuXaYTzF7NSGpEsHs04dq",
             "size_bytes":118644456,
-            "base_memory_mb":7305
+            "base_memory_mb":7177
           },
           {
             "cluster_id":46397,
@@ -9355,7 +9355,7 @@
             "weight":0.11068747,
             "drive_id":"1YNFGFubEOkjOR_3vHEShDQ2UpLN_94UA",
             "size_bytes":132531997,
-            "base_memory_mb":null
+            "base_memory_mb":8197
           },
           {
             "cluster_id":89395,
@@ -9363,7 +9363,7 @@
             "weight":0.09922096,
             "drive_id":"1Ck-ycELY5V05uem7ks5_kCsnMpCM6Db2",
             "size_bytes":137271217,
-            "base_memory_mb":null
+            "base_memory_mb":8195
           },
           {
             "cluster_id":35604,
@@ -9371,7 +9371,7 @@
             "weight":0.06680509,
             "drive_id":"1Bd53iO3Fj9nq_DeGl824EXiW71gRAEgl",
             "size_bytes":138881467,
-            "base_memory_mb":null
+            "base_memory_mb":8720
           },
           {
             "cluster_id":3719,
@@ -9379,7 +9379,7 @@
             "weight":0.05717539,
             "drive_id":"1QSjw36I2vO25NZdyqiCF4qX_BPJcNx6Z",
             "size_bytes":47760149,
-            "base_memory_mb":null
+            "base_memory_mb":10585
           },
           {
             "cluster_id":793,
@@ -9387,7 +9387,7 @@
             "weight":0.01642305,
             "drive_id":"15XUu_cjxj-lHF4Sw0hgdbVDYeFJ1bBA2",
             "size_bytes":67568575,
-            "base_memory_mb":null
+            "base_memory_mb":10951
           },
           {
             "cluster_id":65066,
@@ -9395,7 +9395,7 @@
             "weight":0.04191935,
             "drive_id":"1fY0CDhBJI8Lm-DYeL8LMMaJQl_9c3Zzm",
             "size_bytes":123407074,
-            "base_memory_mb":null
+            "base_memory_mb":7830
           },
           {
             "cluster_id":44066,
@@ -9403,7 +9403,7 @@
             "weight":0.12510112,
             "drive_id":"18vOkWoJAz3_d6uCX-qsiks41PgJuI4xu",
             "size_bytes":124970400,
-            "base_memory_mb":7591
+            "base_memory_mb":7744
           },
           {
             "cluster_id":122989,
@@ -9411,7 +9411,7 @@
             "weight":0.05852015,
             "drive_id":"1fKnsrLE57Dy9EzSyUorYbdpMcvqs4Vvv",
             "size_bytes":118668929,
-            "base_memory_mb":null
+            "base_memory_mb":7892
           },
           {
             "cluster_id":14116,
@@ -9419,7 +9419,7 @@
             "weight":0.15021871,
             "drive_id":"1IRTICM6MX6Gd1UVjt9HuIcJ8XRyOXrmk",
             "size_bytes":45096565,
-            "base_memory_mb":11647
+            "base_memory_mb":11611
           }
         ]
       },
@@ -9452,7 +9452,7 @@
             "weight":0.10634656,
             "drive_id":"1nWafXe7eLWGlO1SlDz0j9Tg6exveR1cF",
             "size_bytes":82351526,
-            "base_memory_mb":null
+            "base_memory_mb":2799
           },
           {
             "cluster_id":90,
@@ -9460,7 +9460,7 @@
             "weight":0.05339483,
             "drive_id":"1XVRDVZUuAFEpie1QT8bdnV_e5yKUilP9",
             "size_bytes":72212567,
-            "base_memory_mb":null
+            "base_memory_mb":856
           },
           {
             "cluster_id":11255,
@@ -9468,7 +9468,7 @@
             "weight":0.27209365,
             "drive_id":"1aSCMFEKoFcYOEu2ReF9NAkL38UaG-7I1",
             "size_bytes":75051675,
-            "base_memory_mb":2450
+            "base_memory_mb":2472
           },
           {
             "cluster_id":35371,
@@ -9476,7 +9476,7 @@
             "weight":0.33402765,
             "drive_id":"1P4rARFl7aGEzI8gg7UoYMsRhyRLKST3X",
             "size_bytes":73545342,
-            "base_memory_mb":3357
+            "base_memory_mb":3253
           },
           {
             "cluster_id":12295,
@@ -9484,7 +9484,7 @@
             "weight":0.23413733,
             "drive_id":"1Ik2G4cQj3a2JIzoMo11PRAk899nAHTQ6",
             "size_bytes":76144805,
-            "base_memory_mb":2353
+            "base_memory_mb":2357
           }
         ]
       },
@@ -9517,7 +9517,7 @@
             "weight":0.24375729,
             "drive_id":"1eWQrkAixA-578_0SHm4tJTELIDpFUmOu",
             "size_bytes":74778098,
-            "base_memory_mb":1958
+            "base_memory_mb":1977
           },
           {
             "cluster_id":104659,
@@ -9525,7 +9525,7 @@
             "weight":0.32645547,
             "drive_id":"1QcD-_gJEY8ZFvfE9loMa03mu4ZbQZ_WA",
             "size_bytes":73576210,
-            "base_memory_mb":2131
+            "base_memory_mb":2141
           },
           {
             "cluster_id":98383,
@@ -9533,7 +9533,7 @@
             "weight":0.42978722,
             "drive_id":"1zZ7QsB2DtHRTg55YPikLhBG1d63VxR7M",
             "size_bytes":78812551,
-            "base_memory_mb":2911
+            "base_memory_mb":2854
           }
         ]
       },
@@ -9566,7 +9566,7 @@
             "weight":0.42330238,
             "drive_id":"15AL997wZH8zdclCWPnwXXVWSzFrsaQ5l",
             "size_bytes":80170790,
-            "base_memory_mb":3059
+            "base_memory_mb":3065
           },
           {
             "cluster_id":194540,
@@ -9574,7 +9574,7 @@
             "weight":0.45998916,
             "drive_id":"1LBDhDSOyTy0pDpQzifGDdtUanVvBRQ7j",
             "size_bytes":76344855,
-            "base_memory_mb":2039
+            "base_memory_mb":2057
           },
           {
             "cluster_id":33181,
@@ -9582,7 +9582,7 @@
             "weight":0.11670845,
             "drive_id":"1z-e2HyCutJu64TF6_H4OcGq5lZTjlgsf",
             "size_bytes":68329142,
-            "base_memory_mb":1813
+            "base_memory_mb":1746
           }
         ]
       },
@@ -9615,7 +9615,7 @@
             "weight":0.31860226,
             "drive_id":"1DXSAdoyiaFrTbhI1gIh50m7oAgpCjqXk",
             "size_bytes":145272546,
-            "base_memory_mb":8487
+            "base_memory_mb":8705
           },
           {
             "cluster_id":3284,
@@ -9623,7 +9623,7 @@
             "weight":0.2442715,
             "drive_id":"1jV1Jhcc3OHDvRmQPV5FFmGW8s67RIvo4",
             "size_bytes":138010067,
-            "base_memory_mb":8529
+            "base_memory_mb":8573
           },
           {
             "cluster_id":50298,
@@ -9631,7 +9631,7 @@
             "weight":0.43712622,
             "drive_id":"1uygCziEEg3sx2h5uvnG3DtY7XO-LKh_y",
             "size_bytes":133392848,
-            "base_memory_mb":8591
+            "base_memory_mb":8483
           }
         ]
       },
@@ -9664,7 +9664,7 @@
             "weight":0.32402956,
             "drive_id":"1Gqb_g4mb4w1aRvJwA8alN_18sOW8rWH_",
             "size_bytes":97312512,
-            "base_memory_mb":12934
+            "base_memory_mb":13037
           },
           {
             "cluster_id":148156,
@@ -9672,7 +9672,7 @@
             "weight":0.46853948,
             "drive_id":"1sp5b4SEqMj_LM-x3vo3MuJWbOqx8Y15f",
             "size_bytes":97075721,
-            "base_memory_mb":12686
+            "base_memory_mb":12647
           },
           {
             "cluster_id":42427,
@@ -9680,7 +9680,7 @@
             "weight":0.20743094,
             "drive_id":"1ljbUpMPFJEeovoN2dGTfskAnl6TXIHlv",
             "size_bytes":95550008,
-            "base_memory_mb":12658
+            "base_memory_mb":12607
           }
         ]
       },
@@ -9713,7 +9713,7 @@
             "weight":0.09178881,
             "drive_id":"1m6Y9oD9rmuTLK6_lrzdNEz_gQOx-mlxx",
             "size_bytes":74223947,
-            "base_memory_mb":13680
+            "base_memory_mb":13503
           },
           {
             "cluster_id":141811,
@@ -9721,7 +9721,7 @@
             "weight":0.54146606,
             "drive_id":"1AFl71JmuxeggO8Wy5YaS5XTr9SI_wgpY",
             "size_bytes":85228648,
-            "base_memory_mb":14602
+            "base_memory_mb":14447
           },
           {
             "cluster_id":41002,
@@ -9729,7 +9729,7 @@
             "weight":0.36674511,
             "drive_id":"1pQCEczUX18ELkXd3XaKN2iI8dNgex2dI",
             "size_bytes":81577115,
-            "base_memory_mb":13512
+            "base_memory_mb":13317
           }
         ]
       },
@@ -9762,7 +9762,7 @@
             "weight":0.37419137,
             "drive_id":"1wyixe8phhYSrwEYDrI5cgGgfgUOxHKyR",
             "size_bytes":53994333,
-            "base_memory_mb":11293
+            "base_memory_mb":11388
           },
           {
             "cluster_id":20105,
@@ -9770,7 +9770,7 @@
             "weight":0.49243918,
             "drive_id":"1SdhYdq5AZqAatam7GEN5Z0oI8m9zN4m-",
             "size_bytes":55434409,
-            "base_memory_mb":10156
+            "base_memory_mb":10328
           },
           {
             "cluster_id":2726,
@@ -9778,7 +9778,7 @@
             "weight":0.13336945,
             "drive_id":"1NvWz5DV9LI5oeRG7jrl3OSYBJ1h--NlG",
             "size_bytes":51863807,
-            "base_memory_mb":9550
+            "base_memory_mb":9695
           }
         ]
       },
@@ -9811,7 +9811,7 @@
             "weight":0.25457475,
             "drive_id":"18j9x_HGTlgUSSLbIQM7oKIi9EhFRLELj",
             "size_bytes":62854350,
-            "base_memory_mb":9289
+            "base_memory_mb":9251
           },
           {
             "cluster_id":52911,
@@ -9819,7 +9819,7 @@
             "weight":0.09297182,
             "drive_id":"1YfusL-XUDyiNE7CmziW8L4vV7QKRD1qU",
             "size_bytes":40186340,
-            "base_memory_mb":null
+            "base_memory_mb":9156
           },
           {
             "cluster_id":51271,
@@ -9827,7 +9827,7 @@
             "weight":0.21495195,
             "drive_id":"1_f8axuJfrYuYEx69rp72bG_We3OL-bGS",
             "size_bytes":84847823,
-            "base_memory_mb":8782
+            "base_memory_mb":8721
           },
           {
             "cluster_id":284,
@@ -9835,7 +9835,7 @@
             "weight":0.03167899,
             "drive_id":"1qnvxRk29BtkuB2WLyn0lqjHdPHzh0pza",
             "size_bytes":42032355,
-            "base_memory_mb":null
+            "base_memory_mb":739
           },
           {
             "cluster_id":34685,
@@ -9843,7 +9843,7 @@
             "weight":0.40582249,
             "drive_id":"1hMEQMxDCysYQEJANa_EnOhlp-mzJgQ_o",
             "size_bytes":60021305,
-            "base_memory_mb":11622
+            "base_memory_mb":11571
           }
         ]
       },
@@ -9876,7 +9876,7 @@
             "weight":0.0159538,
             "drive_id":"1qLULGRW7uR8SyblIrliI9Tz01yRRRqyz",
             "size_bytes":42047659,
-            "base_memory_mb":null
+            "base_memory_mb":763
           },
           {
             "cluster_id":28352,
@@ -9884,7 +9884,7 @@
             "weight":0.291446,
             "drive_id":"1OGb8J5S9uWCllB6RmHU540VpPrPm5zE4",
             "size_bytes":54475924,
-            "base_memory_mb":6194
+            "base_memory_mb":5966
           },
           {
             "cluster_id":40606,
@@ -9892,7 +9892,7 @@
             "weight":0.335186,
             "drive_id":"1o3xn4VReF87uTA0hrvYjjv1Ae9PZq9rn",
             "size_bytes":56203113,
-            "base_memory_mb":6630
+            "base_memory_mb":6534
           },
           {
             "cluster_id":2443,
@@ -9900,7 +9900,7 @@
             "weight":0.23704438,
             "drive_id":"1VuHWwURo5EWUd_i8KDIlbYu6l6QOP9Dg",
             "size_bytes":49797373,
-            "base_memory_mb":4705
+            "base_memory_mb":4612
           },
           {
             "cluster_id":69106,
@@ -9908,13 +9908,13 @@
             "weight":0.12036983,
             "drive_id":"1bbhJUkZxVoyW9G3ZrTKEQbd7XQUHLxWO",
             "size_bytes":56042385,
-            "base_memory_mb":null
+            "base_memory_mb":6838
           }
         ]
       }
     },
     "rate_fp_v2":{
-      "_scarab_sim_githash":"ee729e9",
+      "_scarab_sim_githash":"98dc727e",
       "bwaves_r":{
         "trace":{
           "dynamorio_args":null,
@@ -9944,7 +9944,7 @@
             "weight":0.03098874,
             "drive_id":"1kv2TJ5EsxWvYSTM6nczUJSz6nxFVcyJU",
             "size_bytes":55764502,
-            "base_memory_mb":null
+            "base_memory_mb":441
           },
           {
             "cluster_id":29110,
@@ -9952,7 +9952,7 @@
             "weight":0.01961426,
             "drive_id":"1pTPHYg5e4gcmkPEn38pgSioHOYzO8W0E",
             "size_bytes":62320380,
-            "base_memory_mb":null
+            "base_memory_mb":6545
           },
           {
             "cluster_id":7936,
@@ -9960,7 +9960,7 @@
             "weight":0.01650941,
             "drive_id":"1bqzIi4ljcsZokBewE6eCXWW3j6oSvYcI",
             "size_bytes":63144859,
-            "base_memory_mb":null
+            "base_memory_mb":6568
           },
           {
             "cluster_id":26004,
@@ -9968,7 +9968,7 @@
             "weight":0.57893407,
             "drive_id":"1L8Vi_HAaQ3ikeGoL4OI7ftcKLCVhDc1T",
             "size_bytes":66032784,
-            "base_memory_mb":5177
+            "base_memory_mb":5155
           },
           {
             "cluster_id":29689,
@@ -9976,7 +9976,7 @@
             "weight":0.02439221,
             "drive_id":"1V8LwF_CbwRqN9sP8hYJSVQFtBH7hKZLi",
             "size_bytes":33057176,
-            "base_memory_mb":null
+            "base_memory_mb":1490
           },
           {
             "cluster_id":3063,
@@ -9984,7 +9984,7 @@
             "weight":0.03827318,
             "drive_id":"1b0dMOiC7MZvcVxgsYApWRlIEch_MLSmg",
             "size_bytes":56345234,
-            "base_memory_mb":null
+            "base_memory_mb":10751
           },
           {
             "cluster_id":27341,
@@ -9992,7 +9992,7 @@
             "weight":0.01812154,
             "drive_id":"1UEqiD3pEHILSHuNhQmBN69UcSm-wqw1s",
             "size_bytes":62164586,
-            "base_memory_mb":null
+            "base_memory_mb":8170
           },
           {
             "cluster_id":4349,
@@ -10000,7 +10000,7 @@
             "weight":0.10431083,
             "drive_id":"124FVbgC6EIemz7mRA044g5s2orC-GNpG",
             "size_bytes":35013725,
-            "base_memory_mb":1127
+            "base_memory_mb":1130
           },
           {
             "cluster_id":23367,
@@ -10008,7 +10008,7 @@
             "weight":0.03797464,
             "drive_id":"1ntAFkT0n4XNoe1F9g_pdc4iG8DjTH6qs",
             "size_bytes":62275589,
-            "base_memory_mb":null
+            "base_memory_mb":8017
           },
           {
             "cluster_id":891,
@@ -10016,7 +10016,7 @@
             "weight":0.11099819,
             "drive_id":"1mB3rdh-gLQT3daGKrtVunw1DF2XXmuOX",
             "size_bytes":38399641,
-            "base_memory_mb":1337
+            "base_memory_mb":1376
           },
           {
             "cluster_id":13984,
@@ -10024,7 +10024,7 @@
             "weight":0.01549437,
             "drive_id":"1sWfb4ynKtG-shRhbbsVsNZd_ABTEkBI9",
             "size_bytes":56585991,
-            "base_memory_mb":null
+            "base_memory_mb":295
           }
         ]
       },
@@ -10057,7 +10057,7 @@
             "weight":0.04725296,
             "drive_id":"15MyHMqgiJqQzPw5IVNiPOjDOlL7C_QWu",
             "size_bytes":55989310,
-            "base_memory_mb":null
+            "base_memory_mb":379
           },
           {
             "cluster_id":20236,
@@ -10065,7 +10065,7 @@
             "weight":0.02545729,
             "drive_id":"1NjQDVcBE_hCliIxrTI3NjZWep3AxhjsF",
             "size_bytes":48677608,
-            "base_memory_mb":null
+            "base_memory_mb":1749
           },
           {
             "cluster_id":5201,
@@ -10073,7 +10073,7 @@
             "weight":0.03982075,
             "drive_id":"1DtBLW2RvUjNul8wMr_slgoYl6awlk_Iy",
             "size_bytes":63260634,
-            "base_memory_mb":null
+            "base_memory_mb":6588
           },
           {
             "cluster_id":47124,
@@ -10081,7 +10081,7 @@
             "weight":0.11382209,
             "drive_id":"165PUh1cEA1PEJ7LxIwadeky37EYkZ___",
             "size_bytes":38617619,
-            "base_memory_mb":1177
+            "base_memory_mb":1130
           },
           {
             "cluster_id":25491,
@@ -10089,7 +10089,7 @@
             "weight":0.03070971,
             "drive_id":"1ke3459TxaBOHJs7jORAwOgW2xYYIUmnK",
             "size_bytes":62624570,
-            "base_memory_mb":null
+            "base_memory_mb":6827
           },
           {
             "cluster_id":4299,
@@ -10097,7 +10097,7 @@
             "weight":0.10738965,
             "drive_id":"18fdfqWjtlP6WejRhOsGCOA3NEtn-3QDF",
             "size_bytes":34832585,
-            "base_memory_mb":1137
+            "base_memory_mb":1108
           },
           {
             "cluster_id":32961,
@@ -10105,7 +10105,7 @@
             "weight":0.02580521,
             "drive_id":"1SgZ0MRi_OEF_-iHGeLTIuBlvVnf1qBv0",
             "size_bytes":62352402,
-            "base_memory_mb":null
+            "base_memory_mb":8583
           },
           {
             "cluster_id":40144,
@@ -10113,7 +10113,7 @@
             "weight":0.57637286,
             "drive_id":"1DLPKsf0WcoiUQnvbNxEOUKaw3Ukb0bXF",
             "size_bytes":66014673,
-            "base_memory_mb":5165
+            "base_memory_mb":4974
           },
           {
             "cluster_id":38833,
@@ -10121,7 +10121,7 @@
             "weight":0.02406977,
             "drive_id":"1KUpgZ7X7MZTvBOgX1ZF4Rr-H5x7-zk77",
             "size_bytes":57571215,
-            "base_memory_mb":null
+            "base_memory_mb":9675
           }
         ]
       },
@@ -10154,7 +10154,7 @@
             "weight":0.11375943,
             "drive_id":"11Yd2zpzSo_e8rwCBkpPzcyAC8bmdrAjk",
             "size_bytes":38407323,
-            "base_memory_mb":1193
+            "base_memory_mb":1161
           },
           {
             "cluster_id":36457,
@@ -10162,7 +10162,7 @@
             "weight":0.03180423,
             "drive_id":"1qY2J0ec9xT0iFB3o4a4dI7WALA_8I7U7",
             "size_bytes":56164707,
-            "base_memory_mb":null
+            "base_memory_mb":443
           },
           {
             "cluster_id":5478,
@@ -10170,7 +10170,7 @@
             "weight":0.01628938,
             "drive_id":"1keR_QzWMa4FLX0b4QGV5D-F0IC3RTWQp",
             "size_bytes":35006760,
-            "base_memory_mb":null
+            "base_memory_mb":1287
           },
           {
             "cluster_id":16814,
@@ -10178,7 +10178,7 @@
             "weight":0.03596734,
             "drive_id":"1aiqrD7xIJ1e34N0Fm-X4J9eXlvYyoS1w",
             "size_bytes":56819907,
-            "base_memory_mb":null
+            "base_memory_mb":10759
           },
           {
             "cluster_id":40860,
@@ -10186,7 +10186,7 @@
             "weight":0.01793526,
             "drive_id":"1NmIGG_zoE3ZvMkDZUDCS2KDp3NwRoPbe",
             "size_bytes":62248689,
-            "base_memory_mb":null
+            "base_memory_mb":7981
           },
           {
             "cluster_id":32522,
@@ -10194,7 +10194,7 @@
             "weight":0.0158053,
             "drive_id":"15Hy6-fEJhnnFLGGVffkpcm7Iw45ospsc",
             "size_bytes":63259551,
-            "base_memory_mb":null
+            "base_memory_mb":6782
           },
           {
             "cluster_id":11735,
@@ -10202,7 +10202,7 @@
             "weight":0.1306539,
             "drive_id":"1nGqLlVrOf15svLGixD6VsSwt7aOu6901",
             "size_bytes":28896813,
-            "base_memory_mb":1745
+            "base_memory_mb":1652
           },
           {
             "cluster_id":3577,
@@ -10210,7 +10210,7 @@
             "weight":0.01924228,
             "drive_id":"1jzghP5XSD1xLgUin_Q66KNCpDS0dBW6t",
             "size_bytes":62672532,
-            "base_memory_mb":null
+            "base_memory_mb":6047
           },
           {
             "cluster_id":6401,
@@ -10218,7 +10218,7 @@
             "weight":0.57179844,
             "drive_id":"1TY_6dhUZrf21s_XO1OdHA7jKRxCsIsd4",
             "size_bytes":66239423,
-            "base_memory_mb":5122
+            "base_memory_mb":5067
           },
           {
             "cluster_id":7327,
@@ -10226,7 +10226,7 @@
             "weight":0.03849082,
             "drive_id":"1dscZLOG983VOTtcGbPUcUGAvLC-M4CuH",
             "size_bytes":62343820,
-            "base_memory_mb":null
+            "base_memory_mb":8018
           }
         ]
       },
@@ -10259,7 +10259,7 @@
             "weight":0.10927594,
             "drive_id":"1QwDPZbypVu6rQeu-u4fcL6eDb7j1VtCE",
             "size_bytes":38002832,
-            "base_memory_mb":1198
+            "base_memory_mb":1131
           },
           {
             "cluster_id":45908,
@@ -10267,7 +10267,7 @@
             "weight":0.03411133,
             "drive_id":"1JHJL_43ZFCF7vHkkfOVKkzOx2M04-Vsh",
             "size_bytes":50152377,
-            "base_memory_mb":null
+            "base_memory_mb":1222
           },
           {
             "cluster_id":35361,
@@ -10275,7 +10275,7 @@
             "weight":0.0241971,
             "drive_id":"1NXVdwzSGRwemuwYcXb2RBf76tAoaiw_o",
             "size_bytes":48223148,
-            "base_memory_mb":null
+            "base_memory_mb":1762
           },
           {
             "cluster_id":8517,
@@ -10283,7 +10283,7 @@
             "weight":0.0183124,
             "drive_id":"12I3D1C74prHu8TOIPVujB6y8B9vyCTWn",
             "size_bytes":61867145,
-            "base_memory_mb":null
+            "base_memory_mb":8020
           },
           {
             "cluster_id":3046,
@@ -10291,7 +10291,7 @@
             "weight":0.03855926,
             "drive_id":"1CtEVbuhUzsfR2ozV_28_kRvmavm6GcBz",
             "size_bytes":61932018,
-            "base_memory_mb":null
+            "base_memory_mb":8148
           },
           {
             "cluster_id":46091,
@@ -10299,7 +10299,7 @@
             "weight":0.016158,
             "drive_id":"1GQmf1OJEurLDf7AKBjSzw1RAUDJeNJv5",
             "size_bytes":62806387,
-            "base_memory_mb":null
+            "base_memory_mb":6686
           },
           {
             "cluster_id":48400,
@@ -10307,7 +10307,7 @@
             "weight":0.58138871,
             "drive_id":"1PEsbUyLmIQACtUJIpbDfaG3q16SIwhIr",
             "size_bytes":65725486,
-            "base_memory_mb":5230
+            "base_memory_mb":5136
           },
           {
             "cluster_id":5540,
@@ -10315,7 +10315,7 @@
             "weight":0.1032117,
             "drive_id":"1W_Q6Y3zrO4MYvupRUUjSu4HxyT4QJWhd",
             "size_bytes":34843069,
-            "base_memory_mb":1191
+            "base_memory_mb":1192
           },
           {
             "cluster_id":1459,
@@ -10323,7 +10323,7 @@
             "weight":0.01541992,
             "drive_id":"1qcQYICM0Qw3K00EAX7zgUUij_2z0M9kJ",
             "size_bytes":55914600,
-            "base_memory_mb":null
+            "base_memory_mb":281
           },
           {
             "cluster_id":24967,
@@ -10331,7 +10331,7 @@
             "weight":0.01950929,
             "drive_id":"1zvpSA0jG2hINvI21EQ5wBfsEIGYAlmx9",
             "size_bytes":62023400,
-            "base_memory_mb":null
+            "base_memory_mb":6678
           },
           {
             "cluster_id":41194,
@@ -10339,7 +10339,7 @@
             "weight":0.0360064,
             "drive_id":"1mmhZE5TQcHqF8EcwVUk5JeLt_usnbp8J",
             "size_bytes":56192193,
-            "base_memory_mb":null
+            "base_memory_mb":10921
           }
         ]
       },
@@ -10372,7 +10372,7 @@
             "weight":0.28882003,
             "drive_id":"1qFhVZRszSs4-bEyXiqvT7ZbiDnbEAiSk",
             "size_bytes":257099683,
-            "base_memory_mb":180
+            "base_memory_mb":431
           },
           {
             "cluster_id":101419,
@@ -10380,7 +10380,7 @@
             "weight":0.04949999,
             "drive_id":"1nm53wzC2AG9zoN1TYp12z4j23Nhv2b1a",
             "size_bytes":37445492,
-            "base_memory_mb":null
+            "base_memory_mb":3033
           },
           {
             "cluster_id":774,
@@ -10388,7 +10388,7 @@
             "weight":0.11071357,
             "drive_id":"14-LS74XZP4qb149vRWKDzTQnq7-ZZY7i",
             "size_bytes":46637401,
-            "base_memory_mb":1216
+            "base_memory_mb":1179
           },
           {
             "cluster_id":94978,
@@ -10396,7 +10396,7 @@
             "weight":0.0198535,
             "drive_id":"1TgeofUSWUJoMNXg1KlaoYAjvmtrpWmEf",
             "size_bytes":9540228,
-            "base_memory_mb":null
+            "base_memory_mb":16182
           },
           {
             "cluster_id":38889,
@@ -10404,7 +10404,7 @@
             "weight":0.10436598,
             "drive_id":"1_-7ZyOHJ_lrsD5V1RNkUiD7wlj0dErwj",
             "size_bytes":276982062,
-            "base_memory_mb":null
+            "base_memory_mb":563
           },
           {
             "cluster_id":3206,
@@ -10412,7 +10412,7 @@
             "weight":0.4267469,
             "drive_id":"1RsBvkb9A8We3GJhG-qa5gLU-MZHhaDk1",
             "size_bytes":273521052,
-            "base_memory_mb":456
+            "base_memory_mb":448
           }
         ]
       },
@@ -10445,7 +10445,7 @@
             "weight":0.05621095,
             "drive_id":"1w7QSg8p0O3JPovHNKftFqf-W_AHSbsar",
             "size_bytes":75592832,
-            "base_memory_mb":null
+            "base_memory_mb":734
           },
           {
             "cluster_id":79473,
@@ -10453,7 +10453,7 @@
             "weight":0.02375633,
             "drive_id":"1ef93M2VopGK3NdumsE-szqIERBvSxZCq",
             "size_bytes":62315762,
-            "base_memory_mb":null
+            "base_memory_mb":2936
           },
           {
             "cluster_id":45299,
@@ -10461,7 +10461,7 @@
             "weight":0.06311826,
             "drive_id":"1lyLkSu0QC-Hu1QfwsOsTq6znvE8woY-2",
             "size_bytes":74368387,
-            "base_memory_mb":null
+            "base_memory_mb":1078
           },
           {
             "cluster_id":80062,
@@ -10469,7 +10469,7 @@
             "weight":0.04629775,
             "drive_id":"1-q1RvCDg2Mf3Rx6GlwhsAriP9gI5R6OG",
             "size_bytes":82396086,
-            "base_memory_mb":null
+            "base_memory_mb":785
           },
           {
             "cluster_id":141858,
@@ -10477,7 +10477,7 @@
             "weight":0.02984799,
             "drive_id":"1bT2VV3UlIPD1NqRYy9wCQYHVHDEYe1JE",
             "size_bytes":64931485,
-            "base_memory_mb":null
+            "base_memory_mb":3714
           },
           {
             "cluster_id":12843,
@@ -10485,7 +10485,7 @@
             "weight":0.01117945,
             "drive_id":"16PsRktMX5nX1ow7Lz-Ub_AsnKBXxPkLz",
             "size_bytes":77563685,
-            "base_memory_mb":null
+            "base_memory_mb":2998
           },
           {
             "cluster_id":92357,
@@ -10493,7 +10493,7 @@
             "weight":0.07498787,
             "drive_id":"1wxeKclCxOaRq7wQMlRLq7jVvl1npUUUb",
             "size_bytes":69585252,
-            "base_memory_mb":null
+            "base_memory_mb":911
           },
           {
             "cluster_id":96600,
@@ -10501,7 +10501,7 @@
             "weight":0.11442965,
             "drive_id":"135JEirVqMGbB3FTa6Gkdml4-z9aW0D-K",
             "size_bytes":76494821,
-            "base_memory_mb":886
+            "base_memory_mb":871
           },
           {
             "cluster_id":173837,
@@ -10509,7 +10509,7 @@
             "weight":0.0175563,
             "drive_id":"1gAMca_3N67-t-tDOViXzwSJHXIJ8QrIE",
             "size_bytes":61783197,
-            "base_memory_mb":null
+            "base_memory_mb":2794
           },
           {
             "cluster_id":85893,
@@ -10517,7 +10517,7 @@
             "weight":0.03372657,
             "drive_id":"1_o9jbewKXTw_m_dT3gdBPsKdzEy3njeg",
             "size_bytes":87800079,
-            "base_memory_mb":null
+            "base_memory_mb":811
           },
           {
             "cluster_id":120306,
@@ -10525,7 +10525,7 @@
             "weight":0.03202684,
             "drive_id":"1TxoI2QKlW-9etMVrsvfnNTfzmSN4tLQP",
             "size_bytes":61729918,
-            "base_memory_mb":null
+            "base_memory_mb":3258
           },
           {
             "cluster_id":103841,
@@ -10533,7 +10533,7 @@
             "weight":0.07705265,
             "drive_id":"1x5ORyTeIsC-F7rJyapkrzl4_2pzsB5a7",
             "size_bytes":69025412,
-            "base_memory_mb":null
+            "base_memory_mb":958
           },
           {
             "cluster_id":35605,
@@ -10541,7 +10541,7 @@
             "weight":0.05632503,
             "drive_id":"14NZ454KZE4L-iKnLUIX83NEEQwYFfbyJ",
             "size_bytes":73219535,
-            "base_memory_mb":null
+            "base_memory_mb":676
           },
           {
             "cluster_id":91011,
@@ -10549,7 +10549,7 @@
             "weight":0.0103581,
             "drive_id":"1VMa5uX9WQ-OzQ012Y4-6RuToqm-MfoOj",
             "size_bytes":87609500,
-            "base_memory_mb":null
+            "base_memory_mb":805
           },
           {
             "cluster_id":159716,
@@ -10557,7 +10557,7 @@
             "weight":0.07072712,
             "drive_id":"11kJJzIMpkBQwl-_5BrrqRroLVNl3LElL",
             "size_bytes":76923666,
-            "base_memory_mb":null
+            "base_memory_mb":663
           },
           {
             "cluster_id":20223,
@@ -10565,7 +10565,7 @@
             "weight":0.10469896,
             "drive_id":"10EAjQZays5LkTBFB4Ag1JS56Pu0r8T2C",
             "size_bytes":66152794,
-            "base_memory_mb":693
+            "base_memory_mb":650
           },
           {
             "cluster_id":13935,
@@ -10573,7 +10573,7 @@
             "weight":0.09382182,
             "drive_id":"1tQTc-MDbtL5lWrxWQ7mj_4JmdO2FPWBg",
             "size_bytes":75957709,
-            "base_memory_mb":1067
+            "base_memory_mb":1053
           },
           {
             "cluster_id":19792,
@@ -10581,7 +10581,7 @@
             "weight":0.03547764,
             "drive_id":"1WLm4v0yF_5fFYd9XrIYIBQC9f0Belhov",
             "size_bytes":63366461,
-            "base_memory_mb":null
+            "base_memory_mb":3236
           },
           {
             "cluster_id":161686,
@@ -10589,7 +10589,7 @@
             "weight":0.04590419,
             "drive_id":"1xdZim4zov3En04Ti66tg96q2Jr9XKdXn",
             "size_bytes":84140969,
-            "base_memory_mb":null
+            "base_memory_mb":892
           }
         ]
       },
@@ -10622,7 +10622,7 @@
             "weight":0.01822123,
             "drive_id":"1eIKh6VmhvEOY1vtgTUMbD_T2nFeAgpk7",
             "size_bytes":52986165,
-            "base_memory_mb":null
+            "base_memory_mb":5343
           },
           {
             "cluster_id":151973,
@@ -10630,7 +10630,7 @@
             "weight":0.11207113,
             "drive_id":"1I3FUBPCCCSA7-2-VZcrXLN9bLchfqZUs",
             "size_bytes":61960042,
-            "base_memory_mb":null
+            "base_memory_mb":4175
           },
           {
             "cluster_id":35686,
@@ -10638,7 +10638,7 @@
             "weight":0.0145822,
             "drive_id":"1aDu_vd7Gluiq7J3r-tUSEz3R5rkG9rWz",
             "size_bytes":35723876,
-            "base_memory_mb":null
+            "base_memory_mb":13402
           },
           {
             "cluster_id":209025,
@@ -10646,7 +10646,7 @@
             "weight":0.08026728,
             "drive_id":"15F0dxXtJPfxsvVl4hfp5PCBKl4jGA_IP",
             "size_bytes":112435951,
-            "base_memory_mb":null
+            "base_memory_mb":16416
           },
           {
             "cluster_id":152080,
@@ -10654,7 +10654,7 @@
             "weight":0.20241238,
             "drive_id":"1tSZ2dA3uhZLE8GEeuBONannamnVBcx8_",
             "size_bytes":61589665,
-            "base_memory_mb":4085
+            "base_memory_mb":4041
           },
           {
             "cluster_id":32615,
@@ -10662,7 +10662,7 @@
             "weight":0.09246788,
             "drive_id":"1hxNu95TrdqwkcdbJwPqpv7U25VXMdsxh",
             "size_bytes":61812058,
-            "base_memory_mb":null
+            "base_memory_mb":3603
           },
           {
             "cluster_id":194482,
@@ -10670,7 +10670,7 @@
             "weight":0.24605177,
             "drive_id":"1v5FPfpjNZnW-EMBhFvMXN_ZBpeOM23wH",
             "size_bytes":62013851,
-            "base_memory_mb":4063
+            "base_memory_mb":3979
           },
           {
             "cluster_id":282836,
@@ -10678,7 +10678,7 @@
             "weight":0.02431429,
             "drive_id":"1jylxoPgzmwz8Wz5OLZVDiqw0pWEEE-yd",
             "size_bytes":34724379,
-            "base_memory_mb":null
+            "base_memory_mb":13733
           },
           {
             "cluster_id":270489,
@@ -10686,7 +10686,7 @@
             "weight":0.16354777,
             "drive_id":"1VOAsC7um_gq8ixpq0vnJBZQL5T-SZk1s",
             "size_bytes":61276811,
-            "base_memory_mb":4077
+            "base_memory_mb":4067
           },
           {
             "cluster_id":215242,
@@ -10694,7 +10694,7 @@
             "weight":0.03143879,
             "drive_id":"1u75ENxMSIMgzF-NgemZJJ8rg5CtNUi1i",
             "size_bytes":33284570,
-            "base_memory_mb":null
+            "base_memory_mb":12338
           },
           {
             "cluster_id":120523,
@@ -10702,7 +10702,7 @@
             "weight":0.01462527,
             "drive_id":"1UfMvd-nVxNkGn2AALN07J8q0Nmep6QpO",
             "size_bytes":47086013,
-            "base_memory_mb":null
+            "base_memory_mb":23401
           }
         ]
       },
@@ -10735,7 +10735,7 @@
             "weight":0.43995684,
             "drive_id":"1SjvERjUAIPFLttaCJuTdal380VAyb7gX",
             "size_bytes":88892797,
-            "base_memory_mb":9295
+            "base_memory_mb":9191
           },
           {
             "cluster_id":149154,
@@ -10743,7 +10743,7 @@
             "weight":0.31585094,
             "drive_id":"1cj_koqRqmIJk6Whr7Nrfd5vsJ9wfOEEB",
             "size_bytes":94253021,
-            "base_memory_mb":9158
+            "base_memory_mb":9236
           },
           {
             "cluster_id":259211,
@@ -10751,7 +10751,7 @@
             "weight":0.2441922,
             "drive_id":"1rbifkbRBC6ybgQG22L8wipICAuFOJ0JE",
             "size_bytes":92799065,
-            "base_memory_mb":8831
+            "base_memory_mb":8954
           }
         ]
       },
@@ -10784,7 +10784,7 @@
             "weight":0.97355813,
             "drive_id":"1uAlDqASz33vbXH-Qbhhl19jVcmRI-awM",
             "size_bytes":52845296,
-            "base_memory_mb":367
+            "base_memory_mb":355
           },
           {
             "cluster_id":107196,
@@ -10792,7 +10792,7 @@
             "weight":0.02223744,
             "drive_id":"1h8xz7FeKSAVJhpKUxTjBuXFRq4lJ0dFK",
             "size_bytes":52702710,
-            "base_memory_mb":354
+            "base_memory_mb":398
           }
         ]
       },
@@ -10825,7 +10825,7 @@
             "weight":0.05088364,
             "drive_id":"1mvG1CcOwU19jzNewAAZAsgUPcN7W7mRz",
             "size_bytes":52559837,
-            "base_memory_mb":null
+            "base_memory_mb":3275
           },
           {
             "cluster_id":13203,
@@ -10833,7 +10833,7 @@
             "weight":0.04247437,
             "drive_id":"1jYlvbXmmO6QdBZC9QAwchvR6uDH0diuL",
             "size_bytes":61719451,
-            "base_memory_mb":null
+            "base_memory_mb":3136
           },
           {
             "cluster_id":86809,
@@ -10841,7 +10841,7 @@
             "weight":0.01668007,
             "drive_id":"1DJeTX24wsaGGw8qiDt8IVSVLX6rDQkJA",
             "size_bytes":53701624,
-            "base_memory_mb":null
+            "base_memory_mb":2232
           },
           {
             "cluster_id":125825,
@@ -10849,7 +10849,7 @@
             "weight":0.01853376,
             "drive_id":"1GJVDCYaXIwTOWX46QR2xQLpUh8r0Wse9",
             "size_bytes":80131900,
-            "base_memory_mb":null
+            "base_memory_mb":2165
           },
           {
             "cluster_id":55366,
@@ -10857,7 +10857,7 @@
             "weight":0.03236112,
             "drive_id":"19Dmz2uPUjT0tawgtrgsm-UGKT4J0KGHF",
             "size_bytes":58860177,
-            "base_memory_mb":null
+            "base_memory_mb":975
           },
           {
             "cluster_id":39355,
@@ -10865,7 +10865,7 @@
             "weight":0.03721228,
             "drive_id":"1Dps3uBH8sZCtN1r8AWEzHPjdb_scI8H5",
             "size_bytes":65395797,
-            "base_memory_mb":null
+            "base_memory_mb":1280
           },
           {
             "cluster_id":101516,
@@ -10873,7 +10873,7 @@
             "weight":0.06363288,
             "drive_id":"1oadUcBD5AxoP9gInatklfTLs-vpSjWs9",
             "size_bytes":79337439,
-            "base_memory_mb":null
+            "base_memory_mb":2144
           },
           {
             "cluster_id":311062,
@@ -10881,7 +10881,7 @@
             "weight":0.03136796,
             "drive_id":"16lcDaBqgQJ7nFr3YFG2RKn7L9gbdiwpm",
             "size_bytes":63575313,
-            "base_memory_mb":null
+            "base_memory_mb":1951
           },
           {
             "cluster_id":273808,
@@ -10889,7 +10889,7 @@
             "weight":0.12697621,
             "drive_id":"1GeNUOUU49OCRFNcuiXl2hIAAfLZFbWrA",
             "size_bytes":56593804,
-            "base_memory_mb":3970
+            "base_memory_mb":3977
           },
           {
             "cluster_id":310781,
@@ -10897,7 +10897,7 @@
             "weight":0.19599706,
             "drive_id":"1pvhQLGxwCDYby4oUNQOHtchzCcscbeEV",
             "size_bytes":54472408,
-            "base_memory_mb":2034
+            "base_memory_mb":1950
           },
           {
             "cluster_id":101531,
@@ -10905,7 +10905,7 @@
             "weight":0.02832464,
             "drive_id":"16XzKO48ddjk0jXNofARfWEuBamQuMQDH",
             "size_bytes":51583460,
-            "base_memory_mb":null
+            "base_memory_mb":1699
           },
           {
             "cluster_id":165882,
@@ -10913,7 +10913,7 @@
             "weight":0.02843479,
             "drive_id":"1DvH_eaaq3S2TA26n00aYYkmQkKvcYK8g",
             "size_bytes":55075666,
-            "base_memory_mb":null
+            "base_memory_mb":1436
           },
           {
             "cluster_id":180739,
@@ -10921,7 +10921,7 @@
             "weight":0.0407088,
             "drive_id":"1k_QhEG-hq63amyz85zJ2Hx_gP9o6LL80",
             "size_bytes":68802998,
-            "base_memory_mb":null
+            "base_memory_mb":1734
           },
           {
             "cluster_id":5274,
@@ -10929,7 +10929,7 @@
             "weight":0.03512885,
             "drive_id":"1FTleljBW7qH3dd5yovOVqEv_EfApbMi0",
             "size_bytes":104704095,
-            "base_memory_mb":null
+            "base_memory_mb":4161
           },
           {
             "cluster_id":228395,
@@ -10937,7 +10937,7 @@
             "weight":0.04947999,
             "drive_id":"1-hrVX2p8I9dvqnHyWYa7Hw7FDtUFE4wB",
             "size_bytes":77216195,
-            "base_memory_mb":null
+            "base_memory_mb":1958
           },
           {
             "cluster_id":99138,
@@ -10945,7 +10945,7 @@
             "weight":0.04825574,
             "drive_id":"1TKJaut4ClbO4YvhkYRU76kKNcl4O4Tzi",
             "size_bytes":79526397,
-            "base_memory_mb":null
+            "base_memory_mb":1791
           },
           {
             "cluster_id":316103,
@@ -10953,7 +10953,7 @@
             "weight":0.0190373,
             "drive_id":"1kDSZEUNdhSH3XkMg9ueZTwBLa6VMY4tL",
             "size_bytes":76123985,
-            "base_memory_mb":null
+            "base_memory_mb":1958
           },
           {
             "cluster_id":243792,
@@ -10961,7 +10961,7 @@
             "weight":0.07105393,
             "drive_id":"10x_OdCQ5NkGG1mJGO4iWz-HGwSMAJXxR",
             "size_bytes":52939620,
-            "base_memory_mb":4460
+            "base_memory_mb":4420
           },
           {
             "cluster_id":268040,
@@ -10969,7 +10969,7 @@
             "weight":0.03803684,
             "drive_id":"1yHPwh3Po7cnNg9ASAEIrb1yDGJcwSWhO",
             "size_bytes":78254798,
-            "base_memory_mb":null
+            "base_memory_mb":2007
           },
           {
             "cluster_id":99784,
@@ -10977,7 +10977,7 @@
             "weight":0.02541979,
             "drive_id":"1KjHNrsF6gZsgtn3Tsqe3MhAsPn9bCz4j",
             "size_bytes":69545410,
-            "base_memory_mb":null
+            "base_memory_mb":1575
           }
         ]
       },
@@ -11010,7 +11010,7 @@
             "weight":0.18497767,
             "drive_id":"1Etvz9UKxLlPaN4Bu9zgtzb7OzG9GzXRs",
             "size_bytes":68405439,
-            "base_memory_mb":10805
+            "base_memory_mb":11023
           },
           {
             "cluster_id":36576,
@@ -11018,7 +11018,7 @@
             "weight":0.77214247,
             "drive_id":"10QD039XesKR3bIRE_7kZi2TAfqT7BHhZ",
             "size_bytes":71647431,
-            "base_memory_mb":11518
+            "base_memory_mb":11748
           },
           {
             "cluster_id":141622,
@@ -11026,7 +11026,7 @@
             "weight":0.04287986,
             "drive_id":"1YVuNy_e5c2pN_3VOg4CV7LYpietXB5l3",
             "size_bytes":53567073,
-            "base_memory_mb":5458
+            "base_memory_mb":5328
           }
         ]
       },
@@ -11059,7 +11059,7 @@
             "weight":0.00565614,
             "drive_id":"1ioq0RtoIJGYw4LKSQlBOCm_sbd-VSNRj",
             "size_bytes":32419856,
-            "base_memory_mb":null
+            "base_memory_mb":5201
           },
           {
             "cluster_id":179872,
@@ -11067,7 +11067,7 @@
             "weight":0.14742118,
             "drive_id":"16xDme9bpCYbbkHVb1IA97ON_Gacm55RP",
             "size_bytes":64547185,
-            "base_memory_mb":7060
+            "base_memory_mb":6847
           },
           {
             "cluster_id":58314,
@@ -11075,7 +11075,7 @@
             "weight":0.06852451,
             "drive_id":"1hOjJTPXxurXdS5pZ7s8kIb0Q-boBY0Rf",
             "size_bytes":68080801,
-            "base_memory_mb":null
+            "base_memory_mb":12170
           },
           {
             "cluster_id":146719,
@@ -11083,7 +11083,7 @@
             "weight":0.07985228,
             "drive_id":"1Q6eBCjEHzn5jm32jO8Z6mOs4DPCRbMuG",
             "size_bytes":74845701,
-            "base_memory_mb":53257
+            "base_memory_mb":53187
           },
           {
             "cluster_id":121897,
@@ -11091,7 +11091,7 @@
             "weight":0.06121543,
             "drive_id":"1NhLFluxmjMLgcvdY27ffvn2fm6YGNcm7",
             "size_bytes":53158172,
-            "base_memory_mb":null
+            "base_memory_mb":2956
           },
           {
             "cluster_id":60621,
@@ -11099,7 +11099,7 @@
             "weight":0.09243525,
             "drive_id":"1tbNYsYb3CSb7NvWjqv6eUJ_OYz_uzpvy",
             "size_bytes":69109278,
-            "base_memory_mb":11827
+            "base_memory_mb":11754
           },
           {
             "cluster_id":166831,
@@ -11107,7 +11107,7 @@
             "weight":0.07143264,
             "drive_id":"1ArURaBmRGW-ESbYXrWVYto0xt1dsGZeS",
             "size_bytes":74312101,
-            "base_memory_mb":null
+            "base_memory_mb":53223
           },
           {
             "cluster_id":78104,
@@ -11115,7 +11115,7 @@
             "weight":0.03746998,
             "drive_id":"14Muk5XRxswPkeuXLCBO2hMSeHsQ0KKcy",
             "size_bytes":74534059,
-            "base_memory_mb":null
+            "base_memory_mb":53359
           },
           {
             "cluster_id":122026,
@@ -11123,7 +11123,7 @@
             "weight":0.03787288,
             "drive_id":"12QFiClfYbqvnfygQVLqoaFJ7axRFH6Op",
             "size_bytes":50458323,
-            "base_memory_mb":null
+            "base_memory_mb":2168
           },
           {
             "cluster_id":173450,
@@ -11131,7 +11131,7 @@
             "weight":0.01469563,
             "drive_id":"1ZnRaTihoJ7YpXAbubVw8926el1RUpo3d",
             "size_bytes":50306750,
-            "base_memory_mb":null
+            "base_memory_mb":3157
           },
           {
             "cluster_id":139155,
@@ -11139,7 +11139,7 @@
             "weight":0.02309461,
             "drive_id":"1PswWxCSIYd2FDGHzrIftZSk5yZB4mgIn",
             "size_bytes":74579654,
-            "base_memory_mb":null
+            "base_memory_mb":53353
           },
           {
             "cluster_id":10895,
@@ -11147,7 +11147,7 @@
             "weight":0.07049254,
             "drive_id":"1ocVEdHvXxKTVBM3g2GyNViPAvAnN2-nl",
             "size_bytes":59104248,
-            "base_memory_mb":null
+            "base_memory_mb":1976
           },
           {
             "cluster_id":91836,
@@ -11155,7 +11155,7 @@
             "weight":0.04840002,
             "drive_id":"1vFWijCaTTVMGFLHuY0CrnOQkGGHpRnUc",
             "size_bytes":58970042,
-            "base_memory_mb":null
+            "base_memory_mb":4881
           },
           {
             "cluster_id":24977,
@@ -11163,7 +11163,7 @@
             "weight":0.05567293,
             "drive_id":"18plMKWQK1h3z5E44fP32VUcjtRPyyVMw",
             "size_bytes":74817453,
-            "base_memory_mb":null
+            "base_memory_mb":55438
           },
           {
             "cluster_id":167258,
@@ -11171,7 +11171,7 @@
             "weight":0.04110127,
             "drive_id":"1_LXZ3MAx-AppIHfYvvK-6DKxr3QrfZBS",
             "size_bytes":74892261,
-            "base_memory_mb":null
+            "base_memory_mb":53255
           },
           {
             "cluster_id":13286,
@@ -11179,7 +11179,7 @@
             "weight":0.02873525,
             "drive_id":"1ar5tmatKhKDjMEkwhximdA_BeOtRVg1h",
             "size_bytes":74466771,
-            "base_memory_mb":null
+            "base_memory_mb":53523
           },
           {
             "cluster_id":176729,
@@ -11187,7 +11187,7 @@
             "weight":0.05615848,
             "drive_id":"1Ym1Z-Zd_Wce0DBVTxSWvIOXRU27ktC1d",
             "size_bytes":76181262,
-            "base_memory_mb":null
+            "base_memory_mb":7672
           },
           {
             "cluster_id":99271,
@@ -11195,7 +11195,7 @@
             "weight":0.03479946,
             "drive_id":"15JWvNQ859AULmg907OjWA9WIUwrl3LQe",
             "size_bytes":51407029,
-            "base_memory_mb":null
+            "base_memory_mb":15754
           },
           {
             "cluster_id":193024,
@@ -11203,7 +11203,7 @@
             "weight":0.01957695,
             "drive_id":"1JPkt8CJh969kmLJ9lBHKONWy54uXEXP4",
             "size_bytes":74293820,
-            "base_memory_mb":null
+            "base_memory_mb":53503
           }
         ]
       },
@@ -11236,7 +11236,7 @@
             "weight":0.0173632,
             "drive_id":"1CTf0F4LOJYbt23LpW4QtQ9D1z1ffZowP",
             "size_bytes":39324845,
-            "base_memory_mb":null
+            "base_memory_mb":2845
           },
           {
             "cluster_id":389845,
@@ -11244,7 +11244,7 @@
             "weight":0.11920736,
             "drive_id":"17RBxqCrs1x6HlBlSwfplcn9q6Z859T8R",
             "size_bytes":13358612,
-            "base_memory_mb":null
+            "base_memory_mb":3739
           },
           {
             "cluster_id":326902,
@@ -11252,7 +11252,7 @@
             "weight":0.15149572,
             "drive_id":"18iysXh825TnVt99gCdl7TrthmG_so3UI",
             "size_bytes":13308592,
-            "base_memory_mb":3702
+            "base_memory_mb":3735
           },
           {
             "cluster_id":94577,
@@ -11260,7 +11260,7 @@
             "weight":0.51363224,
             "drive_id":"1vVJHNY-TMcKeVFAu72omr_dRvif_ToW1",
             "size_bytes":35796924,
-            "base_memory_mb":2614
+            "base_memory_mb":2659
           },
           {
             "cluster_id":260089,
@@ -11268,7 +11268,7 @@
             "weight":0.19535159,
             "drive_id":"12t7isSUN9k0AaVVOJO7SIynBpQ05rbnd",
             "size_bytes":14507042,
-            "base_memory_mb":4120
+            "base_memory_mb":4030
           }
         ]
       },
@@ -11301,7 +11301,7 @@
             "weight":0.1092897,
             "drive_id":"1apRf5Zl_qrklgAF2AhM7BV8FPRU9Ln1Q",
             "size_bytes":32487034,
-            "base_memory_mb":null
+            "base_memory_mb":2145
           },
           {
             "cluster_id":130940,
@@ -11309,7 +11309,7 @@
             "weight":0.31200674,
             "drive_id":"1iPnT9PFDy300RH7TWyKQQ7r0XEo97qVN",
             "size_bytes":22868547,
-            "base_memory_mb":3801
+            "base_memory_mb":3636
           },
           {
             "cluster_id":13344,
@@ -11317,7 +11317,7 @@
             "weight":0.1721334,
             "drive_id":"17OdJjBgPr3AkDhZ_LNpElEgB30MgNkgg",
             "size_bytes":36398787,
-            "base_memory_mb":null
+            "base_memory_mb":15947
           },
           {
             "cluster_id":127547,
@@ -11325,7 +11325,7 @@
             "weight":0.1801856,
             "drive_id":"16WRvqByJqC5USuxygv4X5DHuMi1YDWSh",
             "size_bytes":24301507,
-            "base_memory_mb":3853
+            "base_memory_mb":3925
           },
           {
             "cluster_id":59950,
@@ -11333,7 +11333,7 @@
             "weight":0.22638455,
             "drive_id":"1zThpwwQzaBMGJlXLQ1LoE_0lBfvoK5M5",
             "size_bytes":32789920,
-            "base_memory_mb":3378
+            "base_memory_mb":3471
           }
         ]
       },
@@ -11366,7 +11366,7 @@
             "weight":0.0584892,
             "drive_id":"1r5ccZ_fcOLCtgydAvXlQ5EjlbUE5Zp_k",
             "size_bytes":66260026,
-            "base_memory_mb":null
+            "base_memory_mb":1253
           },
           {
             "cluster_id":150651,
@@ -11374,7 +11374,7 @@
             "weight":0.03310826,
             "drive_id":"1nJPEZW6jFebcxywBYZiczWa9frztUD4O",
             "size_bytes":74791984,
-            "base_memory_mb":null
+            "base_memory_mb":985
           },
           {
             "cluster_id":148717,
@@ -11382,7 +11382,7 @@
             "weight":0.17669666,
             "drive_id":"1W5BADhJpnZ7qDzhrwpCFI5tydcY4dRH6",
             "size_bytes":73320188,
-            "base_memory_mb":1056
+            "base_memory_mb":1035
           },
           {
             "cluster_id":146316,
@@ -11390,7 +11390,7 @@
             "weight":0.0398609,
             "drive_id":"1cdH_ooRd7sOKqpCxd3401qjYpIdodKz1",
             "size_bytes":68275584,
-            "base_memory_mb":null
+            "base_memory_mb":968
           },
           {
             "cluster_id":75075,
@@ -11398,7 +11398,7 @@
             "weight":0.03939861,
             "drive_id":"1RN36QMME8Uf2aJZom12ocRmskc5GhREu",
             "size_bytes":78756858,
-            "base_memory_mb":null
+            "base_memory_mb":1232
           },
           {
             "cluster_id":11319,
@@ -11406,7 +11406,7 @@
             "weight":0.02967967,
             "drive_id":"113E0K0X_UtGRVAWA_by932H6EUv4AOV3",
             "size_bytes":71216880,
-            "base_memory_mb":null
+            "base_memory_mb":597
           },
           {
             "cluster_id":53067,
@@ -11414,7 +11414,7 @@
             "weight":0.19919993,
             "drive_id":"1xJ5ZOrzFZXNlzyyqUjdqjI6Z7MJPcnyl",
             "size_bytes":72048696,
-            "base_memory_mb":996
+            "base_memory_mb":931
           },
           {
             "cluster_id":145481,
@@ -11422,7 +11422,7 @@
             "weight":0.30727509,
             "drive_id":"19Zp5Zm3UUcLatSpf9qymWt0_b1toG411",
             "size_bytes":71967960,
-            "base_memory_mb":523
+            "base_memory_mb":535
           },
           {
             "cluster_id":102117,
@@ -11430,7 +11430,7 @@
             "weight":0.03566183,
             "drive_id":"1bSql1t-m7_HdblbZH-SkjPuKnW8K9tix",
             "size_bytes":70646195,
-            "base_memory_mb":null
+            "base_memory_mb":1089
           },
           {
             "cluster_id":78623,
@@ -11438,7 +11438,7 @@
             "weight":0.04409849,
             "drive_id":"1MO86Jp2SONTh2bMghK04eMduIfh2t7_q",
             "size_bytes":76338252,
-            "base_memory_mb":null
+            "base_memory_mb":1506
           },
           {
             "cluster_id":169441,
@@ -11446,7 +11446,7 @@
             "weight":0.0323543,
             "drive_id":"1-OrMvyINdyHzSkEQVqegT43D4D__dPSe",
             "size_bytes":81469705,
-            "base_memory_mb":null
+            "base_memory_mb":622
           }
         ]
       },
@@ -11479,7 +11479,7 @@
             "weight":0.06175291,
             "drive_id":"1t34z4RnSOmu4rbZ53Pl6t0dZJRKW-eGT",
             "size_bytes":82700854,
-            "base_memory_mb":null
+            "base_memory_mb":2397
           },
           {
             "cluster_id":129408,
@@ -11487,7 +11487,7 @@
             "weight":0.04640476,
             "drive_id":"1B9lp_B31-hHgQbIMEKwe1Q3cjgcRjWji",
             "size_bytes":73969085,
-            "base_memory_mb":null
+            "base_memory_mb":1452
           },
           {
             "cluster_id":54007,
@@ -11495,7 +11495,7 @@
             "weight":0.07210511,
             "drive_id":"1R8ltAbf2UtAHK92mFlR20uT_sJRrzDwo",
             "size_bytes":73832365,
-            "base_memory_mb":1409
+            "base_memory_mb":1445
           },
           {
             "cluster_id":6959,
@@ -11503,7 +11503,7 @@
             "weight":0.05643559,
             "drive_id":"1zAaHqxh7X__XFiSSDFnx6a_7pYPdwNrT",
             "size_bytes":73894304,
-            "base_memory_mb":null
+            "base_memory_mb":1488
           },
           {
             "cluster_id":115641,
@@ -11511,7 +11511,7 @@
             "weight":0.07614179,
             "drive_id":"1iJGmsVXUU-WTyghya4j4NyxgSRxDEsUJ",
             "size_bytes":64882115,
-            "base_memory_mb":1133
+            "base_memory_mb":1124
           },
           {
             "cluster_id":159651,
@@ -11519,7 +11519,7 @@
             "weight":0.03838912,
             "drive_id":"1oGNByA45d-zxg7NkL-85Y-6tfRGsg9uR",
             "size_bytes":51546142,
-            "base_memory_mb":null
+            "base_memory_mb":2345
           },
           {
             "cluster_id":94532,
@@ -11527,7 +11527,7 @@
             "weight":0.04377045,
             "drive_id":"1Wu314PsBfhZNNva-L5RvHnzgkkSCOT2V",
             "size_bytes":74197418,
-            "base_memory_mb":null
+            "base_memory_mb":1499
           },
           {
             "cluster_id":84544,
@@ -11535,7 +11535,7 @@
             "weight":0.03396848,
             "drive_id":"1X9VAQgFVSVivh2YdWpPDrumWjCaUTqhz",
             "size_bytes":59570968,
-            "base_memory_mb":null
+            "base_memory_mb":1632
           },
           {
             "cluster_id":179854,
@@ -11543,7 +11543,7 @@
             "weight":0.05406909,
             "drive_id":"1vzKoy20mCgNM95vy0Yz4bOd5yRlZh_yd",
             "size_bytes":35909910,
-            "base_memory_mb":null
+            "base_memory_mb":619
           },
           {
             "cluster_id":12094,
@@ -11551,7 +11551,7 @@
             "weight":0.04689657,
             "drive_id":"1y4jB_jnWXvoB6YxGS950-dh7tk7V1bMG",
             "size_bytes":38693696,
-            "base_memory_mb":null
+            "base_memory_mb":5651
           },
           {
             "cluster_id":51599,
@@ -11559,7 +11559,7 @@
             "weight":0.04174968,
             "drive_id":"1Xw6aEmIiaYDZnqfdi_yd9Qqd25oOdu6l",
             "size_bytes":77980656,
-            "base_memory_mb":null
+            "base_memory_mb":1567
           },
           {
             "cluster_id":188464,
@@ -11567,7 +11567,7 @@
             "weight":0.03319426,
             "drive_id":"1B-9tYwNOHkQlghEEeCVA2V1kRHmmdCnL",
             "size_bytes":63629432,
-            "base_memory_mb":null
+            "base_memory_mb":1199
           },
           {
             "cluster_id":77171,
@@ -11575,7 +11575,7 @@
             "weight":0.03657844,
             "drive_id":"1HXAtBgL8DlPhJjUjFMsn_sUlPavsB3Wu",
             "size_bytes":64821772,
-            "base_memory_mb":null
+            "base_memory_mb":1988
           },
           {
             "cluster_id":47036,
@@ -11583,7 +11583,7 @@
             "weight":0.03939779,
             "drive_id":"1xp3qzg5SGXDwopcRZyqT90dkwo6ulzhy",
             "size_bytes":54917199,
-            "base_memory_mb":null
+            "base_memory_mb":1769
           },
           {
             "cluster_id":70325,
@@ -11591,7 +11591,7 @@
             "weight":0.04240217,
             "drive_id":"1ssaaJ62PaEr3OlQGCP2Py_On7WUdh1cN",
             "size_bytes":73499486,
-            "base_memory_mb":null
+            "base_memory_mb":1468
           },
           {
             "cluster_id":155482,
@@ -11599,7 +11599,7 @@
             "weight":0.07025964,
             "drive_id":"1BwHYAHefQKofOUDoaypGmp3hTNtCb8_V",
             "size_bytes":37611023,
-            "base_memory_mb":null
+            "base_memory_mb":1202
           },
           {
             "cluster_id":161316,
@@ -11607,7 +11607,7 @@
             "weight":0.12490331,
             "drive_id":"1VNMfTNHmlAvqGZ6SXAWm2hHbS3U97-wN",
             "size_bytes":62172065,
-            "base_memory_mb":2163
+            "base_memory_mb":2102
           },
           {
             "cluster_id":192672,
@@ -11615,7 +11615,7 @@
             "weight":0.04196393,
             "drive_id":"1MsP9SsaMliPGQ0Jiqwrk1e6f0XYuecns",
             "size_bytes":26103844,
-            "base_memory_mb":null
+            "base_memory_mb":6133
           },
           {
             "cluster_id":181593,
@@ -11623,7 +11623,7 @@
             "weight":0.03695825,
             "drive_id":"1_rTlL1mxIo8S34Ucf37ynIr-tchBKkWZ",
             "size_bytes":63462608,
-            "base_memory_mb":null
+            "base_memory_mb":1544
           }
         ]
       }
@@ -11631,7 +11631,7 @@
   },
   "geekbench":{
     "single_core":{
-      "_scarab_sim_githash":null,
+      "_scarab_sim_githash":"98dc727e",
       "file_compression":{
         "trace":{
           "dynamorio_args":null,
@@ -11661,7 +11661,7 @@
             "weight":0.0446988,
             "drive_id":"1QEV3PWPAGgR9P_uFOxtSj1sHPeA39YHL",
             "size_bytes":40379907,
-            "base_memory_mb":null
+            "base_memory_mb":2562
           },
           {
             "cluster_id":2044,
@@ -11669,7 +11669,7 @@
             "weight":0.00805237,
             "drive_id":"1SlDPxVKuEhgYYghjIPexqH2QMyDRdEoS",
             "size_bytes":30573252,
-            "base_memory_mb":null
+            "base_memory_mb":2071
           },
           {
             "cluster_id":2116,
@@ -11677,7 +11677,7 @@
             "weight":0.00368425,
             "drive_id":"1wX_vQCbjlzTZ7yuLIgpxQtMTsiJplw9S",
             "size_bytes":25742779,
-            "base_memory_mb":null
+            "base_memory_mb":1523
           },
           {
             "cluster_id":11232,
@@ -11685,7 +11685,7 @@
             "weight":0.058685,
             "drive_id":"1rLCe-Z3iZYzkBx0fH_MQybOVRxbO6C_v",
             "size_bytes":41178706,
-            "base_memory_mb":null
+            "base_memory_mb":2893
           },
           {
             "cluster_id":1009,
@@ -11693,7 +11693,7 @@
             "weight":0.0568458,
             "drive_id":"1SFbIstk4WZEtjRJZuUBIYby11JRW-M59",
             "size_bytes":40973351,
-            "base_memory_mb":null
+            "base_memory_mb":2911
           },
           {
             "cluster_id":10503,
@@ -11701,7 +11701,7 @@
             "weight":0.131806,
             "drive_id":"1waRcr6AfcJ0Zqg0VskKm4ZsapJVSZnSR",
             "size_bytes":15406600,
-            "base_memory_mb":null
+            "base_memory_mb":82
           },
           {
             "cluster_id":402,
@@ -11709,7 +11709,7 @@
             "weight":0.00390981,
             "drive_id":"1jhOV6kTBGzk_2EZE7-btyk0b_7P30vye",
             "size_bytes":12451671,
-            "base_memory_mb":null
+            "base_memory_mb":126
           },
           {
             "cluster_id":6064,
@@ -11717,7 +11717,7 @@
             "weight":0.0292343,
             "drive_id":"19WiTUWiG7dc_l7mJIgzCH28_MKMbIcxS",
             "size_bytes":41420348,
-            "base_memory_mb":null
+            "base_memory_mb":2432
           },
           {
             "cluster_id":11377,
@@ -11725,7 +11725,7 @@
             "weight":0.0119558,
             "drive_id":"144CPfrreXWM7vX5RRp_QS7NTupL87B1D",
             "size_bytes":40970167,
-            "base_memory_mb":null
+            "base_memory_mb":2423
           },
           {
             "cluster_id":3267,
@@ -11733,7 +11733,7 @@
             "weight":0.00645511,
             "drive_id":"1r7niOIAdG7a0Ref4ExjCHptPWSvNEbsc",
             "size_bytes":25789027,
-            "base_memory_mb":null
+            "base_memory_mb":1509
           },
           {
             "cluster_id":150,
@@ -11741,7 +11741,7 @@
             "weight":0.01594,
             "drive_id":"14_EM1L0SogpZbIoP8oKkS1VHhtRJxRRg",
             "size_bytes":12449604,
-            "base_memory_mb":null
+            "base_memory_mb":125
           },
           {
             "cluster_id":2495,
@@ -11749,7 +11749,7 @@
             "weight":0.0330078,
             "drive_id":"1rfQ1xHudn7YK0kTmZoBDFufpaKkUPeaB",
             "size_bytes":15406611,
-            "base_memory_mb":null
+            "base_memory_mb":88
           },
           {
             "cluster_id":2859,
@@ -11757,7 +11757,7 @@
             "weight":0.0318048,
             "drive_id":"1Q5RV-yTlhRBGWMoMG9nogVUOIux32Pbi",
             "size_bytes":15406499,
-            "base_memory_mb":null
+            "base_memory_mb":81
           },
           {
             "cluster_id":9556,
@@ -11765,7 +11765,7 @@
             "weight":0.0464791,
             "drive_id":"12DQ98WbgFTMldw2QdVL0w_SGo2rw7tZm",
             "size_bytes":40725303,
-            "base_memory_mb":null
+            "base_memory_mb":2958
           },
           {
             "cluster_id":9365,
@@ -11773,7 +11773,7 @@
             "weight":0.052828,
             "drive_id":"1owCsiQBUxBCRME2zGKPKV_vbOH3t_qWK",
             "size_bytes":40074668,
-            "base_memory_mb":null
+            "base_memory_mb":2450
           },
           {
             "cluster_id":5737,
@@ -11781,7 +11781,7 @@
             "weight":0.00812838,
             "drive_id":"1FzvFd6icenlJjfoFggz9XWRZ2V7M-797",
             "size_bytes":58715233,
-            "base_memory_mb":null
+            "base_memory_mb":6795
           },
           {
             "cluster_id":1740,
@@ -11789,7 +11789,7 @@
             "weight":0.0283911,
             "drive_id":"1fgTPHz6QdIOY_UQwGzaMqJbcIZO7SIMB",
             "size_bytes":38717357,
-            "base_memory_mb":null
+            "base_memory_mb":2383
           },
           {
             "cluster_id":12616,
@@ -11797,7 +11797,7 @@
             "weight":0.0448877,
             "drive_id":"119A8QCuDZPqXoUKa2_uaLJ-PNhlHPzN1",
             "size_bytes":15421101,
-            "base_memory_mb":null
+            "base_memory_mb":96
           },
           {
             "cluster_id":647,
@@ -11805,7 +11805,7 @@
             "weight":0.0052944,
             "drive_id":"10RUAPxOgoxlkQwZ1kCYjpB2__ytSEYLG",
             "size_bytes":32497417,
-            "base_memory_mb":null
+            "base_memory_mb":3480
           },
           {
             "cluster_id":11419,
@@ -11813,7 +11813,7 @@
             "weight":0.0093412,
             "drive_id":"1iFChNwg_RlF49j2Aw22Sr0hNxmBlG980",
             "size_bytes":39237420,
-            "base_memory_mb":null
+            "base_memory_mb":1979
           },
           {
             "cluster_id":6388,
@@ -11821,7 +11821,7 @@
             "weight":0.00985745,
             "drive_id":"1-Lfu3Gh7ocpWHM5m1MUlzWT7-Xq82_yl",
             "size_bytes":41941399,
-            "base_memory_mb":null
+            "base_memory_mb":2415
           },
           {
             "cluster_id":9601,
@@ -11829,7 +11829,7 @@
             "weight":0.0367848,
             "drive_id":"1YaJDcltl4oliG4JWSPduWwpt1XIznZWE",
             "size_bytes":40482470,
-            "base_memory_mb":null
+            "base_memory_mb":2795
           },
           {
             "cluster_id":10037,
@@ -11837,7 +11837,7 @@
             "weight":0.0906024,
             "drive_id":"1AUohwTQRb1S71DVdvVU_RjpoPHTiooQB",
             "size_bytes":15414781,
-            "base_memory_mb":null
+            "base_memory_mb":96
           },
           {
             "cluster_id":11882,
@@ -11845,7 +11845,7 @@
             "weight":0.0170295,
             "drive_id":"1v0lbKVRr-YbVSy-bQwBhms29gMSug4xI",
             "size_bytes":37611250,
-            "base_memory_mb":null
+            "base_memory_mb":2130
           },
           {
             "cluster_id":2201,
@@ -11853,7 +11853,7 @@
             "weight":0.0371432,
             "drive_id":"1kvvr6HI9MW3zDYk8f4EvWRjgKHZW1Kgk",
             "size_bytes":15406498,
-            "base_memory_mb":null
+            "base_memory_mb":86
           },
           {
             "cluster_id":4406,
@@ -11861,7 +11861,7 @@
             "weight":0.00633833,
             "drive_id":"1GJlHmjx25xeFzdyIv7rAXqHuThzH153v",
             "size_bytes":37672936,
-            "base_memory_mb":null
+            "base_memory_mb":2319
           },
           {
             "cluster_id":99,
@@ -11869,7 +11869,7 @@
             "weight":0.0230077,
             "drive_id":"1-lttM9wX3dAZ7BB2_70H_hAGrSUF1UyY",
             "size_bytes":12449608,
-            "base_memory_mb":null
+            "base_memory_mb":122
           },
           {
             "cluster_id":3429,
@@ -11877,7 +11877,7 @@
             "weight":0.0077076,
             "drive_id":"171PzHsXWP8Tarr342xJM33YcroW1t9E7",
             "size_bytes":41172740,
-            "base_memory_mb":null
+            "base_memory_mb":2800
           },
           {
             "cluster_id":2126,
@@ -11885,7 +11885,7 @@
             "weight":0.0187239,
             "drive_id":"1Txt1mYth6HarymaUm7V5ve0_JAiDQUOt",
             "size_bytes":25010232,
-            "base_memory_mb":null
+            "base_memory_mb":1236
           },
           {
             "cluster_id":10821,
@@ -11893,7 +11893,7 @@
             "weight":0.00888437,
             "drive_id":"1JSMIWjwOCl1nZDbtgG5Dsz-aOBv1ogPj",
             "size_bytes":27561243,
-            "base_memory_mb":null
+            "base_memory_mb":869
           },
           {
             "cluster_id":3230,
@@ -11901,7 +11901,7 @@
             "weight":0.0228634,
             "drive_id":"137QQHMJ4zBlPfAi82k0sz46QYqbQts_B",
             "size_bytes":31785804,
-            "base_memory_mb":null
+            "base_memory_mb":3589
           },
           {
             "cluster_id":773,
@@ -11909,7 +11909,7 @@
             "weight":0.04539,
             "drive_id":"12BqQPCyHk8xNbIY4W3mdjO7Teu3oImKB",
             "size_bytes":28235696,
-            "base_memory_mb":null
+            "base_memory_mb":1907
           },
           {
             "cluster_id":1199,
@@ -11917,7 +11917,7 @@
             "weight":0.0179724,
             "drive_id":"198blpcwhWm1bFVjgfvqPYxHnRa3KJ4P_",
             "size_bytes":42942302,
-            "base_memory_mb":null
+            "base_memory_mb":2352
           },
           {
             "cluster_id":12331,
@@ -11925,7 +11925,7 @@
             "weight":0.0060151,
             "drive_id":"1ihbuj007D-y-BqRIUNpWRKVzZ3Rm_90m",
             "size_bytes":24343890,
-            "base_memory_mb":null
+            "base_memory_mb":1407
           },
           {
             "cluster_id":12302,
@@ -11933,7 +11933,7 @@
             "weight":0.0155777,
             "drive_id":"1sZpNMuoglUKre4hmXROQ2O2bOC-LHXcl",
             "size_bytes":25560879,
-            "base_memory_mb":null
+            "base_memory_mb":1721
           },
           {
             "cluster_id":4193,
@@ -11941,7 +11941,7 @@
             "weight":0.00467246,
             "drive_id":"1eL426BlKon-Rift2DmSe8IY6pK83yq5O",
             "size_bytes":34662394,
-            "base_memory_mb":null
+            "base_memory_mb":2447
           }
         ]
       },
@@ -11974,7 +11974,7 @@
             "weight":0.10711,
             "drive_id":"1dsKYuOGrR1IoYdqGk2r64NdluaN6mujp",
             "size_bytes":12452014,
-            "base_memory_mb":null
+            "base_memory_mb":102
           },
           {
             "cluster_id":4190,
@@ -11982,7 +11982,7 @@
             "weight":0.26654,
             "drive_id":"1L_EsCFszH1-yWXqS05cfIPp7JzfSArua",
             "size_bytes":40323191,
-            "base_memory_mb":null
+            "base_memory_mb":4916
           },
           {
             "cluster_id":4383,
@@ -11990,7 +11990,7 @@
             "weight":0.0119469,
             "drive_id":"15a_poBJeCGBl-0zQs6IppvzAxaqqv42D",
             "size_bytes":34375438,
-            "base_memory_mb":null
+            "base_memory_mb":4029
           },
           {
             "cluster_id":3387,
@@ -11998,7 +11998,7 @@
             "weight":0.0510835,
             "drive_id":"1k9PLWVaT7tOiwMRKQzm39lA-V1EaZQZX",
             "size_bytes":36671286,
-            "base_memory_mb":null
+            "base_memory_mb":4730
           },
           {
             "cluster_id":3799,
@@ -12006,7 +12006,7 @@
             "weight":0.17632,
             "drive_id":"1CvF2BqpIJyAAxh28f999C0kBu0cu8oV9",
             "size_bytes":41419815,
-            "base_memory_mb":null
+            "base_memory_mb":4982
           },
           {
             "cluster_id":4874,
@@ -12014,7 +12014,7 @@
             "weight":0.0135538,
             "drive_id":"1PMHi1MhxN4iysAQE3W7BfWz3DDEFRd5C",
             "size_bytes":23222242,
-            "base_memory_mb":null
+            "base_memory_mb":1799
           },
           {
             "cluster_id":3914,
@@ -12022,7 +12022,7 @@
             "weight":0.0100931,
             "drive_id":"1zZjISjqMlxDufhUcaWyzXq9hOgul8w0f",
             "size_bytes":28011146,
-            "base_memory_mb":null
+            "base_memory_mb":1479
           },
           {
             "cluster_id":3968,
@@ -12030,7 +12030,7 @@
             "weight":0.0187443,
             "drive_id":"1JVwvtFHwqxmehj9OF-gPXh4J5FUQc54h",
             "size_bytes":25365547,
-            "base_memory_mb":null
+            "base_memory_mb":602
           },
           {
             "cluster_id":2548,
@@ -12038,7 +12038,7 @@
             "weight":0.0300733,
             "drive_id":"16LHqg4zsFvMDl2sb3FlumQ6pcNzaajYJ",
             "size_bytes":31315390,
-            "base_memory_mb":null
+            "base_memory_mb":2966
           },
           {
             "cluster_id":2096,
@@ -12046,7 +12046,7 @@
             "weight":0.271484,
             "drive_id":"1cv-8BfXMvQ5ODLJBd2zSBxhQW2CkEL65",
             "size_bytes":41652142,
-            "base_memory_mb":null
+            "base_memory_mb":4946
           },
           {
             "cluster_id":1709,
@@ -12054,7 +12054,7 @@
             "weight":0.0078273,
             "drive_id":"1qIbBVaxWUXbV-Jj9glWwAOOjgtS6DaMO",
             "size_bytes":38495878,
-            "base_memory_mb":null
+            "base_memory_mb":5143
           },
           {
             "cluster_id":588,
@@ -12062,7 +12062,7 @@
             "weight":0.0067974,
             "drive_id":"1nhlHeLJAsqtwJac9KtaMSM_OmACuhT9K",
             "size_bytes":29925931,
-            "base_memory_mb":null
+            "base_memory_mb":8722
           },
           {
             "cluster_id":4020,
@@ -12070,7 +12070,7 @@
             "weight":0.00638543,
             "drive_id":"1Qn9t1dMkNnmwmJE3yNSFcbP2_aG-vkFz",
             "size_bytes":37381769,
-            "base_memory_mb":null
+            "base_memory_mb":6611
           },
           {
             "cluster_id":2375,
@@ -12078,7 +12078,7 @@
             "weight":0.011741,
             "drive_id":"1MGEhdONWpz4HsBYc2Ag8vZnz9h-kbWrr",
             "size_bytes":33380481,
-            "base_memory_mb":null
+            "base_memory_mb":3769
           },
           {
             "cluster_id":280,
@@ -12086,7 +12086,7 @@
             "weight":0.0102991,
             "drive_id":"1v5RdmDpU-0f4meDVGrI4GAuMbokRiQc1",
             "size_bytes":12454089,
-            "base_memory_mb":null
+            "base_memory_mb":129
           }
         ]
       },
@@ -12119,7 +12119,7 @@
             "weight":0.0703963,
             "drive_id":"1IwyAe_ul1EBYl517Hwr_psDlTkc1eW7Z",
             "size_bytes":37917044,
-            "base_memory_mb":null
+            "base_memory_mb":2382
           },
           {
             "cluster_id":835,
@@ -12127,7 +12127,7 @@
             "weight":0.0190607,
             "drive_id":"1M3b4Bcdgq-2go4eznLaVVR0XcObJ7UrN",
             "size_bytes":26813497,
-            "base_memory_mb":null
+            "base_memory_mb":1495
           },
           {
             "cluster_id":1446,
@@ -12135,7 +12135,7 @@
             "weight":0.0130662,
             "drive_id":"1UnYlkHSKH8TnodGxGAL6bge1US6JqQUW",
             "size_bytes":25384145,
-            "base_memory_mb":null
+            "base_memory_mb":1331
           },
           {
             "cluster_id":1278,
@@ -12143,7 +12143,7 @@
             "weight":0.0180131,
             "drive_id":"1ZXGntwo7V9c9ZF4RHzU7dR3gmDs0Nx4d",
             "size_bytes":28250282,
-            "base_memory_mb":null
+            "base_memory_mb":1260
           },
           {
             "cluster_id":1197,
@@ -12151,7 +12151,7 @@
             "weight":0.0528286,
             "drive_id":"1kGCRRuA4lh_MJhuzHhgJQvDr5MFpqGPl",
             "size_bytes":31296989,
-            "base_memory_mb":null
+            "base_memory_mb":2854
           },
           {
             "cluster_id":1548,
@@ -12159,7 +12159,7 @@
             "weight":0.0372311,
             "drive_id":"1sI4m9hRAHvCRN2BdyRG_-Cio-vDecAO9",
             "size_bytes":30091618,
-            "base_memory_mb":null
+            "base_memory_mb":1512
           },
           {
             "cluster_id":708,
@@ -12167,7 +12167,7 @@
             "weight":0.0217031,
             "drive_id":"12oAqRVU4XO4UpaWgBvYbbfiDC19CTGzD",
             "size_bytes":33815998,
-            "base_memory_mb":null
+            "base_memory_mb":1776
           },
           {
             "cluster_id":56,
@@ -12175,7 +12175,7 @@
             "weight":0.372518,
             "drive_id":"16_qUllihJW0uCcxuE6ZJWqAsr-vDjk1Z",
             "size_bytes":12443046,
-            "base_memory_mb":null
+            "base_memory_mb":107
           },
           {
             "cluster_id":643,
@@ -12183,7 +12183,7 @@
             "weight":0.0305225,
             "drive_id":"1f6Wjx-v9gBzN5JH4xNcyC49aYAjlCcab",
             "size_bytes":33145183,
-            "base_memory_mb":null
+            "base_memory_mb":2220
           },
           {
             "cluster_id":1106,
@@ -12191,7 +12191,7 @@
             "weight":0.0838216,
             "drive_id":"1a5L92eTQ24mhzfZATQcNX0sO7TBX2nwr",
             "size_bytes":48320063,
-            "base_memory_mb":null
+            "base_memory_mb":3536
           },
           {
             "cluster_id":780,
@@ -12199,7 +12199,7 @@
             "weight":0.197157,
             "drive_id":"1cBW1rJBalixYWpNCtSxS1z6mNg9aQoQw",
             "size_bytes":29059181,
-            "base_memory_mb":null
+            "base_memory_mb":2190
           },
           {
             "cluster_id":1609,
@@ -12207,7 +12207,7 @@
             "weight":0.0495868,
             "drive_id":"1_jxPTKyqv-bPRzpW3oURK8Nd09a_70r6",
             "size_bytes":32081206,
-            "base_memory_mb":null
+            "base_memory_mb":1288
           },
           {
             "cluster_id":1060,
@@ -12215,7 +12215,7 @@
             "weight":0.0340954,
             "drive_id":"1hnZYlF9rImNcs-OdvFO4PD9VavTrl-zJ",
             "size_bytes":29506944,
-            "base_memory_mb":null
+            "base_memory_mb":1362
           }
         ]
       },
@@ -12248,7 +12248,7 @@
             "weight":0.0187937,
             "drive_id":"1x0QpB-d4qzIFL9ujuzIiIcmGWwK7X8rs",
             "size_bytes":28092614,
-            "base_memory_mb":null
+            "base_memory_mb":1210
           },
           {
             "cluster_id":3102,
@@ -12256,7 +12256,7 @@
             "weight":0.042062,
             "drive_id":"1sDaXWMMqnKL9OkTcKURsc7RhTDgsR_9a",
             "size_bytes":25843135,
-            "base_memory_mb":null
+            "base_memory_mb":1226
           },
           {
             "cluster_id":2641,
@@ -12264,7 +12264,7 @@
             "weight":0.0227314,
             "drive_id":"1Dg47bfzvILbh3457caSleNY-LTFmWCw3",
             "size_bytes":40925822,
-            "base_memory_mb":null
+            "base_memory_mb":2742
           },
           {
             "cluster_id":7,
@@ -12272,7 +12272,7 @@
             "weight":0.0658673,
             "drive_id":"1lexJHXqAMqd64czHWEzIRkyGWaq9zA_M",
             "size_bytes":12442487,
-            "base_memory_mb":null
+            "base_memory_mb":106
           },
           {
             "cluster_id":545,
@@ -12280,7 +12280,7 @@
             "weight":0.00787543,
             "drive_id":"1Yq7R1I8AP1PmnxH9QoH0MufryA0JLQQe",
             "size_bytes":12444542,
-            "base_memory_mb":null
+            "base_memory_mb":128
           },
           {
             "cluster_id":4080,
@@ -12288,7 +12288,7 @@
             "weight":0.00626502,
             "drive_id":"1zx74-3elhUiCTd2MsTY72Sm1EiHJxQCx",
             "size_bytes":25485657,
-            "base_memory_mb":null
+            "base_memory_mb":3817
           },
           {
             "cluster_id":2095,
@@ -12296,7 +12296,7 @@
             "weight":0.0456418,
             "drive_id":"1VPmbScKoJ0KOMAVTxluG6AfzderFwFs8",
             "size_bytes":26525679,
-            "base_memory_mb":null
+            "base_memory_mb":1358
           },
           {
             "cluster_id":1331,
@@ -12304,7 +12304,7 @@
             "weight":0.00483305,
             "drive_id":"1Tc9Wn_hGEOMxKWr4l08UGh6ZPdbhur_6",
             "size_bytes":37319836,
-            "base_memory_mb":null
+            "base_memory_mb":2775
           },
           {
             "cluster_id":3348,
@@ -12312,7 +12312,7 @@
             "weight":0.0270271,
             "drive_id":"1UiceXRMFD93yD4eTTWB8EocMa9dTaObR",
             "size_bytes":28963066,
-            "base_memory_mb":null
+            "base_memory_mb":1280
           },
           {
             "cluster_id":1827,
@@ -12320,7 +12320,7 @@
             "weight":0.102202,
             "drive_id":"1RmOd9aIBxSMORjy9lYA9DZcstfYPDEqW",
             "size_bytes":64282036,
-            "base_memory_mb":null
+            "base_memory_mb":127
           },
           {
             "cluster_id":3865,
@@ -12328,7 +12328,7 @@
             "weight":0.0100233,
             "drive_id":"1pebPP7pZT1xEv38aLsiaZUgXxbtIVX1j",
             "size_bytes":26865368,
-            "base_memory_mb":null
+            "base_memory_mb":1153
           },
           {
             "cluster_id":3484,
@@ -12336,7 +12336,7 @@
             "weight":0.0104522,
             "drive_id":"1OszCoC5n8YjGsiMHmDxS6O3C0gR0ROOj",
             "size_bytes":20307620,
-            "base_memory_mb":null
+            "base_memory_mb":2246
           },
           {
             "cluster_id":4552,
@@ -12344,7 +12344,7 @@
             "weight":0.0252378,
             "drive_id":"1ErWxakO2lO4lbO5-SkeFaUQ7-Jjsg1Wj",
             "size_bytes":22261071,
-            "base_memory_mb":null
+            "base_memory_mb":1362
           },
           {
             "cluster_id":3947,
@@ -12352,7 +12352,7 @@
             "weight":0.0205836,
             "drive_id":"1sZ5xt4CEP78NqJjl15vkc9-HLl96gCvS",
             "size_bytes":28146713,
-            "base_memory_mb":null
+            "base_memory_mb":1317
           },
           {
             "cluster_id":1764,
@@ -12360,7 +12360,7 @@
             "weight":0.0254231,
             "drive_id":"1LoaqCTd74RjFPcocXVGUrfAECrWndLVJ",
             "size_bytes":23383996,
-            "base_memory_mb":null
+            "base_memory_mb":1417
           },
           {
             "cluster_id":2913,
@@ -12368,7 +12368,7 @@
             "weight":0.013961,
             "drive_id":"1fGLuedpl3Dg4gtQYp4rs3T4fiNuqFGQv",
             "size_bytes":28444746,
-            "base_memory_mb":null
+            "base_memory_mb":1132
           },
           {
             "cluster_id":1591,
@@ -12376,7 +12376,7 @@
             "weight":0.0368737,
             "drive_id":"1aLxYbUkCOd4JZr0fWXjFjX-8isiOb0Js",
             "size_bytes":32669181,
-            "base_memory_mb":null
+            "base_memory_mb":362
           },
           {
             "cluster_id":5556,
@@ -12384,7 +12384,7 @@
             "weight":0.00932635,
             "drive_id":"1Tw3_ubs0iRc3wtiL2iKVcpf8mG5x1O5g",
             "size_bytes":22365028,
-            "base_memory_mb":null
+            "base_memory_mb":1165
           },
           {
             "cluster_id":654,
@@ -12392,7 +12392,7 @@
             "weight":0.0159242,
             "drive_id":"18Yx2Gygr3-88vuhCtfWEGfGtDpehg-tf",
             "size_bytes":31492296,
-            "base_memory_mb":null
+            "base_memory_mb":2591
           },
           {
             "cluster_id":4472,
@@ -12400,7 +12400,7 @@
             "weight":0.0315019,
             "drive_id":"18Zjzi7DmLaT0Uqv7nuvGTwt4cCW3tyfW",
             "size_bytes":28399699,
-            "base_memory_mb":null
+            "base_memory_mb":1256
           },
           {
             "cluster_id":169,
@@ -12408,7 +12408,7 @@
             "weight":0.0338286,
             "drive_id":"1B5ELTVteYn2Y_y-mw8HS2IYFeCuKbmQj",
             "size_bytes":12442491,
-            "base_memory_mb":null
+            "base_memory_mb":99
           },
           {
             "cluster_id":696,
@@ -12416,7 +12416,7 @@
             "weight":0.0345542,
             "drive_id":"16QKk4prHxpV30zeNZPLkOvqN81N16T1-",
             "size_bytes":46345220,
-            "base_memory_mb":null
+            "base_memory_mb":2500
           },
           {
             "cluster_id":4506,
@@ -12424,7 +12424,7 @@
             "weight":0.0157515,
             "drive_id":"1V8L8okyPlbSHeFOMNrpLbN6Ha7P1lFL_",
             "size_bytes":18828998,
-            "base_memory_mb":null
+            "base_memory_mb":1617
           },
           {
             "cluster_id":3003,
@@ -12432,7 +12432,7 @@
             "weight":0.0080555,
             "drive_id":"1A3pGWdAEjjPSmtGf95v2lP_b-ZtTBUtM",
             "size_bytes":24389315,
-            "base_memory_mb":null
+            "base_memory_mb":1807
           },
           {
             "cluster_id":1742,
@@ -12440,7 +12440,7 @@
             "weight":0.0084124,
             "drive_id":"1f6RAdD_FFudd1Y_rKRwbYPygipFBmQzY",
             "size_bytes":21434303,
-            "base_memory_mb":null
+            "base_memory_mb":1175
           },
           {
             "cluster_id":4957,
@@ -12448,7 +12448,7 @@
             "weight":0.00966531,
             "drive_id":"10M1y4MAWYA897zeATw-Em7NSCj9vvwdo",
             "size_bytes":27315488,
-            "base_memory_mb":null
+            "base_memory_mb":1207
           },
           {
             "cluster_id":3077,
@@ -12456,7 +12456,7 @@
             "weight":0.00554899,
             "drive_id":"1FpdWf4LBZQqQQxJdf2LwTAm2kzenhIP_",
             "size_bytes":31105007,
-            "base_memory_mb":null
+            "base_memory_mb":3336
           },
           {
             "cluster_id":1328,
@@ -12464,7 +12464,7 @@
             "weight":0.0357982,
             "drive_id":"1HNE3Yvdr7QgnrCGi887i7l0EnFzKDeQf",
             "size_bytes":23313757,
-            "base_memory_mb":null
+            "base_memory_mb":2883
           },
           {
             "cluster_id":4336,
@@ -12472,7 +12472,7 @@
             "weight":0.015751,
             "drive_id":"1PbtT9ypbzIouZQdxHZ4rU2CBuR44Ys-T",
             "size_bytes":29583717,
-            "base_memory_mb":null
+            "base_memory_mb":1456
           },
           {
             "cluster_id":5035,
@@ -12480,7 +12480,7 @@
             "weight":0.0243423,
             "drive_id":"1l5awYHfCZX2azzWm6tPbA5rO8ShZI2hh",
             "size_bytes":28883813,
-            "base_memory_mb":null
+            "base_memory_mb":1231
           },
           {
             "cluster_id":3958,
@@ -12488,7 +12488,7 @@
             "weight":0.0223734,
             "drive_id":"1_GhkYCMmjWQElN2hbujRCgtjRp2aye87",
             "size_bytes":28703979,
-            "base_memory_mb":null
+            "base_memory_mb":1332
           },
           {
             "cluster_id":3522,
@@ -12496,7 +12496,7 @@
             "weight":0.0168985,
             "drive_id":"1LqQt1EBoIGYUNv49VLIWj1XDuGUQpXH9",
             "size_bytes":21506670,
-            "base_memory_mb":null
+            "base_memory_mb":1565
           },
           {
             "cluster_id":4052,
@@ -12504,7 +12504,7 @@
             "weight":0.00644354,
             "drive_id":"1gFsjTQ5OaWHylZ39UZGzHztohTiVWGY-",
             "size_bytes":28543206,
-            "base_memory_mb":null
+            "base_memory_mb":1360
           },
           {
             "cluster_id":2806,
@@ -12512,7 +12512,7 @@
             "weight":0.0532326,
             "drive_id":"1opVmHZc5tu7fB9Ky7ChBJpz5afBWFsqb",
             "size_bytes":56900771,
-            "base_memory_mb":null
+            "base_memory_mb":3098
           },
           {
             "cluster_id":993,
@@ -12520,7 +12520,7 @@
             "weight":0.0425991,
             "drive_id":"1AuAhu96BUSC8kx57bXz06BlYlEDo3nnr",
             "size_bytes":27848860,
-            "base_memory_mb":null
+            "base_memory_mb":1281
           },
           {
             "cluster_id":1306,
@@ -12528,7 +12528,7 @@
             "weight":0.00447468,
             "drive_id":"1m51AJ98-ww32YD3yI1XgXULvEtZHlj3y",
             "size_bytes":28449530,
-            "base_memory_mb":null
+            "base_memory_mb":1095
           },
           {
             "cluster_id":4554,
@@ -12536,7 +12536,7 @@
             "weight":0.0154155,
             "drive_id":"16CiZYdsrdsp1FHrcszFzhZisKW-YsrJu",
             "size_bytes":22425579,
-            "base_memory_mb":null
+            "base_memory_mb":574
           },
           {
             "cluster_id":2257,
@@ -12544,7 +12544,7 @@
             "weight":0.0486845,
             "drive_id":"1pg7PPu_nmARZf6SxKn0kSAIQfXHbzKWJ",
             "size_bytes":24555476,
-            "base_memory_mb":null
+            "base_memory_mb":1150
           },
           {
             "cluster_id":4902,
@@ -12552,7 +12552,7 @@
             "weight":0.0263111,
             "drive_id":"1j9rEbFrhptqgRknLmpnowCKCYlLLDu4E",
             "size_bytes":27055982,
-            "base_memory_mb":null
+            "base_memory_mb":1322
           },
           {
             "cluster_id":2685,
@@ -12560,7 +12560,7 @@
             "weight":0.0292535,
             "drive_id":"10s7sRTytG2VBSHahjOTvB3Sq2K4jXhGB",
             "size_bytes":48830772,
-            "base_memory_mb":null
+            "base_memory_mb":3507
           }
         ]
       },
@@ -12593,7 +12593,7 @@
             "weight":0.0138881,
             "drive_id":"1gyeYw4xXpHXkxOmypI_i48lm_tmEsbbu",
             "size_bytes":57553633,
-            "base_memory_mb":null
+            "base_memory_mb":4437
           },
           {
             "cluster_id":1743,
@@ -12601,7 +12601,7 @@
             "weight":0.0524952,
             "drive_id":"1NA7kHhQdFDrpnrIT2rpNs38VlIGju1iJ",
             "size_bytes":58066575,
-            "base_memory_mb":null
+            "base_memory_mb":7842
           },
           {
             "cluster_id":3122,
@@ -12609,7 +12609,7 @@
             "weight":0.164666,
             "drive_id":"1LFhrfWBoCp3LnCQWHXA5mH6lvuXtaENR",
             "size_bytes":55317137,
-            "base_memory_mb":null
+            "base_memory_mb":6986
           },
           {
             "cluster_id":1373,
@@ -12617,7 +12617,7 @@
             "weight":0.011007,
             "drive_id":"14YiGRWhlbxq9pj3A_TI4eZA5d4YJ8sIC",
             "size_bytes":43614689,
-            "base_memory_mb":null
+            "base_memory_mb":3698
           },
           {
             "cluster_id":2854,
@@ -12625,7 +12625,7 @@
             "weight":0.0204742,
             "drive_id":"1KbSb-9iot5z8AJuo1H0qwJ1Ex-xeIjgT",
             "size_bytes":48155154,
-            "base_memory_mb":null
+            "base_memory_mb":3431
           },
           {
             "cluster_id":966,
@@ -12633,7 +12633,7 @@
             "weight":0.170948,
             "drive_id":"1JJXPuOoF7bw-fNfkjE2bNKMHH5KZnjM7",
             "size_bytes":59575535,
-            "base_memory_mb":null
+            "base_memory_mb":3945
           },
           {
             "cluster_id":28,
@@ -12641,7 +12641,7 @@
             "weight":0.188839,
             "drive_id":"149VC5ylx_26RDqA_54k1-5mXee5EhoGa",
             "size_bytes":12436556,
-            "base_memory_mb":null
+            "base_memory_mb":124
           },
           {
             "cluster_id":1682,
@@ -12649,7 +12649,7 @@
             "weight":0.185774,
             "drive_id":"1anZL4p2sab5V2gKABaxgZTMGGo1xQvkp",
             "size_bytes":59330190,
-            "base_memory_mb":null
+            "base_memory_mb":4107
           },
           {
             "cluster_id":750,
@@ -12657,7 +12657,7 @@
             "weight":0.0319224,
             "drive_id":"1oxpNV_ETykqy-vO1LQqa88GAlreithpx",
             "size_bytes":77158515,
-            "base_memory_mb":null
+            "base_memory_mb":2905
           },
           {
             "cluster_id":2691,
@@ -12665,7 +12665,7 @@
             "weight":0.159986,
             "drive_id":"1Kp4IqSj7cej3geVzl_M2Pd4fotyUbarF",
             "size_bytes":61885372,
-            "base_memory_mb":null
+            "base_memory_mb":3665
           }
         ]
       },
@@ -12698,7 +12698,7 @@
             "weight":0.15553,
             "drive_id":"1-45Mms2kJItPvcnmGBYsPrxxSgk-Z2qy",
             "size_bytes":48050663,
-            "base_memory_mb":null
+            "base_memory_mb":1870
           },
           {
             "cluster_id":4795,
@@ -12706,7 +12706,7 @@
             "weight":0.0304061,
             "drive_id":"1fZBw0QBwYK9I2klXfvN_U-tpVmt-VYEZ",
             "size_bytes":56790913,
-            "base_memory_mb":null
+            "base_memory_mb":2008
           },
           {
             "cluster_id":515,
@@ -12714,7 +12714,7 @@
             "weight":0.0112928,
             "drive_id":"1pCDwJ4wm04WbPoIaVhArpvl1R8sUoGtj",
             "size_bytes":85965162,
-            "base_memory_mb":null
+            "base_memory_mb":2366
           },
           {
             "cluster_id":1868,
@@ -12722,7 +12722,7 @@
             "weight":0.0221397,
             "drive_id":"1Dp3T1LKUvzTfKOixE4GEBrBH6Pz4J_Sk",
             "size_bytes":56936340,
-            "base_memory_mb":null
+            "base_memory_mb":1715
           },
           {
             "cluster_id":414,
@@ -12730,7 +12730,7 @@
             "weight":0.0217174,
             "drive_id":"11wbULkcVZZ_RwSRSiHHpj0FDlfaM5IJq",
             "size_bytes":57905609,
-            "base_memory_mb":null
+            "base_memory_mb":1952
           },
           {
             "cluster_id":5445,
@@ -12738,7 +12738,7 @@
             "weight":0.0436236,
             "drive_id":"12OG4sQ0xYbWBC5ucv9d6m8TIDzxTmFpQ",
             "size_bytes":57334341,
-            "base_memory_mb":null
+            "base_memory_mb":1963
           },
           {
             "cluster_id":2805,
@@ -12746,7 +12746,7 @@
             "weight":0.0218943,
             "drive_id":"106J_rAJAb0WPSBooB7aSOxlF4H-kGb-X",
             "size_bytes":67900999,
-            "base_memory_mb":null
+            "base_memory_mb":1901
           },
           {
             "cluster_id":199,
@@ -12754,7 +12754,7 @@
             "weight":0.035156,
             "drive_id":"1OUK1y6ek29lFgvbCSxt69FnDFb6pbjla",
             "size_bytes":58218309,
-            "base_memory_mb":null
+            "base_memory_mb":1836
           },
           {
             "cluster_id":3738,
@@ -12762,7 +12762,7 @@
             "weight":0.0382235,
             "drive_id":"19dO3SksOqd2T73N-ID_Mw3sRheDIyCEQ",
             "size_bytes":55257924,
-            "base_memory_mb":null
+            "base_memory_mb":1862
           },
           {
             "cluster_id":181,
@@ -12770,7 +12770,7 @@
             "weight":0.0214759,
             "drive_id":"1bamaKih96-wzb2r0FBiN8mg6aY4ZIn40",
             "size_bytes":74572655,
-            "base_memory_mb":null
+            "base_memory_mb":2223
           },
           {
             "cluster_id":795,
@@ -12778,7 +12778,7 @@
             "weight":0.0303765,
             "drive_id":"1ATT7ERMSAha7u7KdPLU4444JLSovwt-0",
             "size_bytes":82930555,
-            "base_memory_mb":null
+            "base_memory_mb":2380
           },
           {
             "cluster_id":230,
@@ -12786,7 +12786,7 @@
             "weight":0.0202762,
             "drive_id":"10btpMJwMlb1idvmLZf99SSySyMuG2Pgj",
             "size_bytes":67732367,
-            "base_memory_mb":null
+            "base_memory_mb":2057
           },
           {
             "cluster_id":5192,
@@ -12794,7 +12794,7 @@
             "weight":0.0358583,
             "drive_id":"1npzJrZA-WGH4XuC5H4xqQiuhn1sc1Ju8",
             "size_bytes":73430569,
-            "base_memory_mb":null
+            "base_memory_mb":2257
           },
           {
             "cluster_id":4242,
@@ -12802,7 +12802,7 @@
             "weight":0.0162583,
             "drive_id":"1XmOImmlQ6wK-kil_J6eIy1MwP4M4m-es",
             "size_bytes":85896223,
-            "base_memory_mb":null
+            "base_memory_mb":2434
           },
           {
             "cluster_id":2655,
@@ -12810,7 +12810,7 @@
             "weight":0.0259927,
             "drive_id":"1vWvbBodF5RoS7bK-9Sav2b-yodE22_xT",
             "size_bytes":71393129,
-            "base_memory_mb":null
+            "base_memory_mb":2112
           },
           {
             "cluster_id":3985,
@@ -12818,7 +12818,7 @@
             "weight":0.0149937,
             "drive_id":"13v2GOQ6tcFdZppsbSwdIDV8xVTILOHQW",
             "size_bytes":54131156,
-            "base_memory_mb":null
+            "base_memory_mb":1762
           },
           {
             "cluster_id":3606,
@@ -12826,7 +12826,7 @@
             "weight":0.0933892,
             "drive_id":"1KzLNjdruRgnpp35sqhlNF8RZxW168Ncb",
             "size_bytes":88321067,
-            "base_memory_mb":null
+            "base_memory_mb":2316
           },
           {
             "cluster_id":3266,
@@ -12834,7 +12834,7 @@
             "weight":0.0653396,
             "drive_id":"17ou5fCeNgiMAvj48en7M0EjG1Bt238hT",
             "size_bytes":64527270,
-            "base_memory_mb":null
+            "base_memory_mb":1762
           },
           {
             "cluster_id":5391,
@@ -12842,7 +12842,7 @@
             "weight":0.0241522,
             "drive_id":"11XJPAKj5_WB7cFs_JbjPwW6e3uia8wHZ",
             "size_bytes":84607289,
-            "base_memory_mb":null
+            "base_memory_mb":2306
           },
           {
             "cluster_id":5479,
@@ -12850,7 +12850,7 @@
             "weight":0.0188697,
             "drive_id":"1UWN1BXuu9swQEza5799pz_cBMGnNIuTA",
             "size_bytes":67097699,
-            "base_memory_mb":null
+            "base_memory_mb":2153
           },
           {
             "cluster_id":40,
@@ -12858,7 +12858,7 @@
             "weight":0.0124143,
             "drive_id":"1-NW6zxRwNxp5ZBk1Olxk4UD0lO5DAEHu",
             "size_bytes":69872937,
-            "base_memory_mb":null
+            "base_memory_mb":5902
           },
           {
             "cluster_id":96,
@@ -12866,7 +12866,7 @@
             "weight":0.00745951,
             "drive_id":"1pyGazv6_pfO-yLZZH_p3zV77e2FsWjRZ",
             "size_bytes":67617460,
-            "base_memory_mb":null
+            "base_memory_mb":4316
           },
           {
             "cluster_id":2370,
@@ -12874,7 +12874,7 @@
             "weight":0.0338828,
             "drive_id":"1-fIy_wjk4D10d1QeHwKGdb9ldXPQj-Bq",
             "size_bytes":80568033,
-            "base_memory_mb":null
+            "base_memory_mb":2259
           },
           {
             "cluster_id":2601,
@@ -12882,7 +12882,7 @@
             "weight":0.012365,
             "drive_id":"1IGlvMFbDKgrpUh-_kjXAzup_0Zdbkb2E",
             "size_bytes":58664198,
-            "base_memory_mb":null
+            "base_memory_mb":1790
           },
           {
             "cluster_id":3254,
@@ -12890,7 +12890,7 @@
             "weight":0.00616276,
             "drive_id":"1urxi-al3HtmlRKDdxUyQmUJQH9pVjPVM",
             "size_bytes":58955255,
-            "base_memory_mb":null
+            "base_memory_mb":1761
           },
           {
             "cluster_id":5006,
@@ -12898,7 +12898,7 @@
             "weight":0.100745,
             "drive_id":"1WV_DI4K5cSWzRgok-0Igz1EjeBbyrhg-",
             "size_bytes":82793643,
-            "base_memory_mb":null
+            "base_memory_mb":2390
           },
           {
             "cluster_id":3820,
@@ -12906,7 +12906,7 @@
             "weight":0.016421,
             "drive_id":"1MkNO2n7pPNOIM8sA-5iEYt2-InuT-OvD",
             "size_bytes":58374345,
-            "base_memory_mb":null
+            "base_memory_mb":1674
           },
           {
             "cluster_id":2803,
@@ -12914,7 +12914,7 @@
             "weight":0.0282711,
             "drive_id":"1ej3ZyNtrXsplQax8rJ79ox0053FSfIPm",
             "size_bytes":54605058,
-            "base_memory_mb":null
+            "base_memory_mb":1756
           },
           {
             "cluster_id":3187,
@@ -12922,7 +12922,7 @@
             "weight":0.00569365,
             "drive_id":"1llNRbGNOau-L8LrYt789enLJiJ4ulYNc",
             "size_bytes":63107548,
-            "base_memory_mb":null
+            "base_memory_mb":1980
           },
           {
             "cluster_id":3340,
@@ -12930,7 +12930,7 @@
             "weight":0.0162764,
             "drive_id":"1g_5-zpsYNEFmVQz0eWjdfTraSiXxqseR",
             "size_bytes":55549781,
-            "base_memory_mb":null
+            "base_memory_mb":1942
           },
           {
             "cluster_id":986,
@@ -12938,7 +12938,7 @@
             "weight":0.0133432,
             "drive_id":"1bAUR8aYcYGCQnvifAb9oIoKmiPwnDC24",
             "size_bytes":63294848,
-            "base_memory_mb":null
+            "base_memory_mb":1918
           }
         ]
       },
@@ -12971,7 +12971,7 @@
             "weight":0.0146074,
             "drive_id":"1H9xIfLQtr84usxt71H0m5Y620RdVKxR_",
             "size_bytes":25122066,
-            "base_memory_mb":null
+            "base_memory_mb":2426
           },
           {
             "cluster_id":4657,
@@ -12979,7 +12979,7 @@
             "weight":0.00828075,
             "drive_id":"1pXj_TD50Q2lB8M_JPZ5C7FulBwhwY1BK",
             "size_bytes":26294708,
-            "base_memory_mb":null
+            "base_memory_mb":2174
           },
           {
             "cluster_id":5403,
@@ -12987,7 +12987,7 @@
             "weight":0.0313494,
             "drive_id":"1BYuqnIw6HIxJqaQfKwVW56IlY6Qevg6V",
             "size_bytes":34049504,
-            "base_memory_mb":null
+            "base_memory_mb":1533
           },
           {
             "cluster_id":9940,
@@ -12995,7 +12995,7 @@
             "weight":0.0285705,
             "drive_id":"16YeAlNcHPy4hP_-IQOU-bm4acbsSFe8I",
             "size_bytes":36511545,
-            "base_memory_mb":null
+            "base_memory_mb":1290
           },
           {
             "cluster_id":5021,
@@ -13003,7 +13003,7 @@
             "weight":0.0326523,
             "drive_id":"18OG1hmY3G9D5qA9YIEr21V7zQfYvCQ-V",
             "size_bytes":37330360,
-            "base_memory_mb":null
+            "base_memory_mb":1820
           },
           {
             "cluster_id":3937,
@@ -13011,7 +13011,7 @@
             "weight":0.0512358,
             "drive_id":"1E0m-xib9WTLXQm4GlzGHmviLeGzc0xI7",
             "size_bytes":34915335,
-            "base_memory_mb":null
+            "base_memory_mb":1629
           },
           {
             "cluster_id":10018,
@@ -13019,7 +13019,7 @@
             "weight":0.0895324,
             "drive_id":"1mp3SPl43gdkfEI23031zlKIbgGvS8coS",
             "size_bytes":33496323,
-            "base_memory_mb":null
+            "base_memory_mb":1955
           },
           {
             "cluster_id":11386,
@@ -13027,7 +13027,7 @@
             "weight":0.00993544,
             "drive_id":"1MtXJtoTmLwz3C09sikPnHPlLNdR3dZcW",
             "size_bytes":25318929,
-            "base_memory_mb":null
+            "base_memory_mb":2493
           },
           {
             "cluster_id":5802,
@@ -13035,7 +13035,7 @@
             "weight":0.0719038,
             "drive_id":"1AArlZpFBD0t8unjCm5BN4TLEFrgotKoj",
             "size_bytes":31480315,
-            "base_memory_mb":null
+            "base_memory_mb":2040
           },
           {
             "cluster_id":8699,
@@ -13043,7 +13043,7 @@
             "weight":0.0067396,
             "drive_id":"1Y4sCZZCB3kPMcXKwzPl67TOQ1oaVuUEh",
             "size_bytes":26211669,
-            "base_memory_mb":null
+            "base_memory_mb":2633
           },
           {
             "cluster_id":6535,
@@ -13051,7 +13051,7 @@
             "weight":0.00703856,
             "drive_id":"19KvRvwFFS45lYgFmiXRWTu9ZV2REe1uZ",
             "size_bytes":27268589,
-            "base_memory_mb":null
+            "base_memory_mb":2519
           },
           {
             "cluster_id":9074,
@@ -13059,7 +13059,7 @@
             "weight":0.00648986,
             "drive_id":"1GEppRTd-3v-dWT8i3ASKvoaKGXNhyENW",
             "size_bytes":31271347,
-            "base_memory_mb":null
+            "base_memory_mb":1873
           },
           {
             "cluster_id":8843,
@@ -13067,7 +13067,7 @@
             "weight":0.0156142,
             "drive_id":"1KCdzUOnarbUZsWzZXphatfmvcU_OyM3u",
             "size_bytes":32676519,
-            "base_memory_mb":null
+            "base_memory_mb":1799
           },
           {
             "cluster_id":1675,
@@ -13075,7 +13075,7 @@
             "weight":0.00720797,
             "drive_id":"11UpPtcZ4WkNrn_nd6bQNhTSg-XVeS0uG",
             "size_bytes":31895454,
-            "base_memory_mb":null
+            "base_memory_mb":1705
           },
           {
             "cluster_id":11175,
@@ -13083,7 +13083,7 @@
             "weight":0.0129903,
             "drive_id":"1OyThGi4YkonkWrOWcjwxn3ZqBIzdqjxi",
             "size_bytes":25266281,
-            "base_memory_mb":null
+            "base_memory_mb":2709
           },
           {
             "cluster_id":11238,
@@ -13091,7 +13091,7 @@
             "weight":0.025707,
             "drive_id":"1KlSk3ugKUoZSLZM5_9guki_bQV0DuzZw",
             "size_bytes":23162054,
-            "base_memory_mb":null
+            "base_memory_mb":2384
           },
           {
             "cluster_id":1667,
@@ -13099,7 +13099,7 @@
             "weight":0.00521074,
             "drive_id":"1uR3cOFfENb9gpfOG7ukQO1zaNT_MvDPz",
             "size_bytes":28902273,
-            "base_memory_mb":null
+            "base_memory_mb":1417
           },
           {
             "cluster_id":9667,
@@ -13107,7 +13107,7 @@
             "weight":0.0574883,
             "drive_id":"1kZqeRG73UIex1-FRD_cwy--7gdrOVtt8",
             "size_bytes":29051510,
-            "base_memory_mb":null
+            "base_memory_mb":1351
           },
           {
             "cluster_id":4518,
@@ -13115,7 +13115,7 @@
             "weight":0.0121397,
             "drive_id":"1hO-3c6En-62FC_sgSxaJVUgBLsDudQES",
             "size_bytes":23949540,
-            "base_memory_mb":null
+            "base_memory_mb":2348
           },
           {
             "cluster_id":3135,
@@ -13123,7 +13123,7 @@
             "weight":0.0431597,
             "drive_id":"1yj_xGMMDzI2yyFOUyXjWoy8r6y6pa-aQ",
             "size_bytes":29319977,
-            "base_memory_mb":null
+            "base_memory_mb":1195
           },
           {
             "cluster_id":4248,
@@ -13131,7 +13131,7 @@
             "weight":0.00670513,
             "drive_id":"1SGRQlc36EOxuC5cWmGIhfjNsj7t8XxJi",
             "size_bytes":28371412,
-            "base_memory_mb":null
+            "base_memory_mb":2278
           },
           {
             "cluster_id":8136,
@@ -13139,7 +13139,7 @@
             "weight":0.0109419,
             "drive_id":"12akaMm4cFlaF3ZuXojf0Uf3Bj9wyzbH-",
             "size_bytes":31021559,
-            "base_memory_mb":null
+            "base_memory_mb":1609
           },
           {
             "cluster_id":2585,
@@ -13147,7 +13147,7 @@
             "weight":0.00776458,
             "drive_id":"1rf5v27UidFyQxHjAMJbKgnPkQNiiRF94",
             "size_bytes":22793449,
-            "base_memory_mb":null
+            "base_memory_mb":2729
           },
           {
             "cluster_id":866,
@@ -13155,7 +13155,7 @@
             "weight":0.0144155,
             "drive_id":"1_ZWBfA2Sp0JN0muxjoNavrXl7AdGt6B-",
             "size_bytes":41102757,
-            "base_memory_mb":null
+            "base_memory_mb":1352
           },
           {
             "cluster_id":9743,
@@ -13163,7 +13163,7 @@
             "weight":0.00416866,
             "drive_id":"1QGDazM9ajzbjpSq3D-KkaOwUjtGYIfqH",
             "size_bytes":26109477,
-            "base_memory_mb":null
+            "base_memory_mb":1898
           },
           {
             "cluster_id":2457,
@@ -13171,7 +13171,7 @@
             "weight":0.0215011,
             "drive_id":"1U7GpqG3SSt6Q5UX-J1RhgsH9s2YxIKoo",
             "size_bytes":26546289,
-            "base_memory_mb":null
+            "base_memory_mb":2980
           },
           {
             "cluster_id":6599,
@@ -13179,7 +13179,7 @@
             "weight":0.0184001,
             "drive_id":"1Rh9uabTFj6DEuD2fYgEB7cMLeauW9Rya",
             "size_bytes":19584962,
-            "base_memory_mb":null
+            "base_memory_mb":2427
           },
           {
             "cluster_id":2118,
@@ -13187,7 +13187,7 @@
             "weight":0.0114123,
             "drive_id":"1hfInhDNeVdPeTc0fSInnX7fUYbuNCgpk",
             "size_bytes":18497913,
-            "base_memory_mb":null
+            "base_memory_mb":2516
           },
           {
             "cluster_id":4008,
@@ -13195,7 +13195,7 @@
             "weight":0.0503674,
             "drive_id":"1K65VdeOiA7ylFb3rScfnfxJeY-uO2maA",
             "size_bytes":36759592,
-            "base_memory_mb":null
+            "base_memory_mb":1480
           },
           {
             "cluster_id":4784,
@@ -13203,7 +13203,7 @@
             "weight":0.0166174,
             "drive_id":"1m_nORWFhcZI08bbJC2auFNq3MzM1jety",
             "size_bytes":17488800,
-            "base_memory_mb":null
+            "base_memory_mb":2530
           },
           {
             "cluster_id":9400,
@@ -13211,7 +13211,7 @@
             "weight":0.00929243,
             "drive_id":"1qZW95AdDmkBkWSZvcNZO7nhqODjPO-o-",
             "size_bytes":38868124,
-            "base_memory_mb":null
+            "base_memory_mb":1723
           },
           {
             "cluster_id":10800,
@@ -13219,7 +13219,7 @@
             "weight":0.0223625,
             "drive_id":"13juiMTvw6rA6wDpz85Anr0V4tJy9AzPP",
             "size_bytes":18007086,
-            "base_memory_mb":null
+            "base_memory_mb":2585
           },
           {
             "cluster_id":8792,
@@ -13227,7 +13227,7 @@
             "weight":0.0272612,
             "drive_id":"1o9Xm-TIiKxV9lf-SfYE_FUrVHIiCQ19f",
             "size_bytes":30363316,
-            "base_memory_mb":null
+            "base_memory_mb":2209
           },
           {
             "cluster_id":67,
@@ -13235,7 +13235,7 @@
             "weight":0.0521911,
             "drive_id":"1TeU4N-vD0WNqrbms0iG6N-14neJNrzrQ",
             "size_bytes":12441594,
-            "base_memory_mb":null
+            "base_memory_mb":102
           },
           {
             "cluster_id":4298,
@@ -13243,7 +13243,7 @@
             "weight":0.0273557,
             "drive_id":"1XIMeYW4gDWLVe9ZL6yGYGC6_GcBPR8GU",
             "size_bytes":21212914,
-            "base_memory_mb":null
+            "base_memory_mb":2521
           },
           {
             "cluster_id":3044,
@@ -13251,7 +13251,7 @@
             "weight":0.0224917,
             "drive_id":"1YmXf6ZalXVbVd2-XthZWYgjk76YJ5Yl-",
             "size_bytes":39453770,
-            "base_memory_mb":null
+            "base_memory_mb":1244
           },
           {
             "cluster_id":3964,
@@ -13259,7 +13259,7 @@
             "weight":0.045678,
             "drive_id":"1rJT4e_5mzffO6Y0l-UtSEk3DBSKMAPt7",
             "size_bytes":34981154,
-            "base_memory_mb":null
+            "base_memory_mb":1412
           },
           {
             "cluster_id":7174,
@@ -13267,7 +13267,7 @@
             "weight":0.0355238,
             "drive_id":"1N_kVX-blmtW-4SqYBSIFK5GOQVlfaFgY",
             "size_bytes":16861928,
-            "base_memory_mb":null
+            "base_memory_mb":2213
           },
           {
             "cluster_id":2591,
@@ -13275,7 +13275,7 @@
             "weight":0.0111265,
             "drive_id":"1Hmxv84gOowO8FZxAESFvVqdy8ljs6adZ",
             "size_bytes":19024323,
-            "base_memory_mb":null
+            "base_memory_mb":2578
           },
           {
             "cluster_id":4073,
@@ -13283,7 +13283,7 @@
             "weight":0.014676,
             "drive_id":"1vl7K37PKPOT_ILhaC0QO6JB2Glu4Yq9R",
             "size_bytes":37148156,
-            "base_memory_mb":null
+            "base_memory_mb":1448
           },
           {
             "cluster_id":2634,
@@ -13291,7 +13291,7 @@
             "weight":0.0318935,
             "drive_id":"1DLQXFG0ZNsxqtoYc2-9nX0m15sUN3FI5",
             "size_bytes":28379621,
-            "base_memory_mb":null
+            "base_memory_mb":2292
           }
         ]
       },
@@ -13324,7 +13324,7 @@
             "weight":0.00854241,
             "drive_id":"15Ib7GyWMb6ySxgw1qe2l7c6k8u7o7a_z",
             "size_bytes":25635231,
-            "base_memory_mb":null
+            "base_memory_mb":975
           },
           {
             "cluster_id":612,
@@ -13332,7 +13332,7 @@
             "weight":0.0232172,
             "drive_id":"1mZon4VnXefokXXzgvjZLQp242JIC0Qei",
             "size_bytes":32101246,
-            "base_memory_mb":null
+            "base_memory_mb":3040
           },
           {
             "cluster_id":679,
@@ -13340,7 +13340,7 @@
             "weight":0.0576288,
             "drive_id":"1KpbJoxBFpYvWQ2ETUtFHfq-BMjx_PGOJ",
             "size_bytes":18644197,
-            "base_memory_mb":null
+            "base_memory_mb":1506
           },
           {
             "cluster_id":727,
@@ -13348,7 +13348,7 @@
             "weight":0.0192096,
             "drive_id":"120iS7cn_cWXBol46UIN4BWh2AkBBnPzm",
             "size_bytes":19743547,
-            "base_memory_mb":null
+            "base_memory_mb":1550
           },
           {
             "cluster_id":1043,
@@ -13356,7 +13356,7 @@
             "weight":0.0300545,
             "drive_id":"1oku03Z7RyKDZiKh60hU0AryfRhA3HEcp",
             "size_bytes":19741228,
-            "base_memory_mb":null
+            "base_memory_mb":2110
           },
           {
             "cluster_id":1989,
@@ -13364,7 +13364,7 @@
             "weight":0.0445429,
             "drive_id":"1_yPhJSYT2nuWJYhth6nlIEAwaRAO_e3S",
             "size_bytes":31552598,
-            "base_memory_mb":null
+            "base_memory_mb":2076
           },
           {
             "cluster_id":2287,
@@ -13372,7 +13372,7 @@
             "weight":0.0414074,
             "drive_id":"1no_mlOoWDBPqexkSuQU3ocRgs9ybmit1",
             "size_bytes":31342639,
-            "base_memory_mb":null
+            "base_memory_mb":367
           },
           {
             "cluster_id":1825,
@@ -13380,7 +13380,7 @@
             "weight":0.0158132,
             "drive_id":"13yrQ2sNicNoqs1zgsSWsoFnypMFjKiIW",
             "size_bytes":22080092,
-            "base_memory_mb":null
+            "base_memory_mb":550
           },
           {
             "cluster_id":1889,
@@ -13388,7 +13388,7 @@
             "weight":0.09752,
             "drive_id":"1r72Bp4wPr0CbDhSBKfG1HciCfLBtIWwN",
             "size_bytes":32678024,
-            "base_memory_mb":null
+            "base_memory_mb":357
           },
           {
             "cluster_id":1010,
@@ -13396,7 +13396,7 @@
             "weight":0.055917,
             "drive_id":"1RbPh8GOV1MPjXJCGREqNuIptfhe8xmOd",
             "size_bytes":20264191,
-            "base_memory_mb":null
+            "base_memory_mb":2228
           },
           {
             "cluster_id":767,
@@ -13404,7 +13404,7 @@
             "weight":0.0483304,
             "drive_id":"1fywPybMUezEEKvFmYPnFsfp5Ug8UsqEs",
             "size_bytes":22956068,
-            "base_memory_mb":null
+            "base_memory_mb":856
           },
           {
             "cluster_id":504,
@@ -13412,7 +13412,7 @@
             "weight":0.0243322,
             "drive_id":"1PYt9qYT5fO2pa2JJ2dv0EootzCvAhyZB",
             "size_bytes":12444005,
-            "base_memory_mb":null
+            "base_memory_mb":125
           },
           {
             "cluster_id":200,
@@ -13420,7 +13420,7 @@
             "weight":0.0665933,
             "drive_id":"1NwA5PRlFyzT-7s_q279DXUBdiQb3C2A9",
             "size_bytes":12441963,
-            "base_memory_mb":null
+            "base_memory_mb":123
           },
           {
             "cluster_id":2102,
@@ -13428,7 +13428,7 @@
             "weight":0.0308057,
             "drive_id":"1UanHn0z1oPbCTtJSSOp_N6xCq1w7wSV_",
             "size_bytes":23170949,
-            "base_memory_mb":null
+            "base_memory_mb":970
           },
           {
             "cluster_id":868,
@@ -13436,7 +13436,7 @@
             "weight":0.0896545,
             "drive_id":"1xG6HhKglavNkQhlj_XoAH0HrLj1BNue9",
             "size_bytes":32665079,
-            "base_memory_mb":null
+            "base_memory_mb":420
           },
           {
             "cluster_id":158,
@@ -13444,7 +13444,7 @@
             "weight":0.16563,
             "drive_id":"1Qj7rD0R4KvUXwizFKLn18cPQ-AUw_BYJ",
             "size_bytes":12443206,
-            "base_memory_mb":null
+            "base_memory_mb":127
           },
           {
             "cluster_id":993,
@@ -13452,7 +13452,7 @@
             "weight":0.0128589,
             "drive_id":"1bc_e7zl-VjBujxPh-KK6gBM_6aRg3miH",
             "size_bytes":21795842,
-            "base_memory_mb":null
+            "base_memory_mb":3824
           },
           {
             "cluster_id":1827,
@@ -13460,7 +13460,7 @@
             "weight":0.0312109,
             "drive_id":"11l5bUaJ6tWRwWtHP9g1SrGC4yjvveXC9",
             "size_bytes":21974067,
-            "base_memory_mb":null
+            "base_memory_mb":468
           },
           {
             "cluster_id":1492,
@@ -13468,7 +13468,7 @@
             "weight":0.0960488,
             "drive_id":"1ZBlef6dUWHe6vCCC39Zyg7R-8vC9lq4L",
             "size_bytes":21399050,
-            "base_memory_mb":null
+            "base_memory_mb":943
           },
           {
             "cluster_id":1744,
@@ -13476,7 +13476,7 @@
             "weight":0.0064032,
             "drive_id":"1V-W7C9q5WK_DtrgB90CKRXa0Pp7kWYLc",
             "size_bytes":17738155,
-            "base_memory_mb":null
+            "base_memory_mb":866
           },
           {
             "cluster_id":643,
@@ -13484,7 +13484,7 @@
             "weight":0.00601042,
             "drive_id":"1X96Ptckm02UkI45RfclBIN19SlJvvH9-",
             "size_bytes":25060616,
-            "base_memory_mb":null
+            "base_memory_mb":598
           },
           {
             "cluster_id":1980,
@@ -13492,7 +13492,7 @@
             "weight":0.0282692,
             "drive_id":"1BihqpR89rJtk05m5-yNTgLPF4cvVyGIp",
             "size_bytes":19650481,
-            "base_memory_mb":null
+            "base_memory_mb":967
           }
         ]
       },
@@ -13525,7 +13525,7 @@
             "weight":0.0161665,
             "drive_id":"1aqw2fJjY2LtB0goarFBo7XJe2VAZPGry",
             "size_bytes":32900892,
-            "base_memory_mb":null
+            "base_memory_mb":626
           },
           {
             "cluster_id":2551,
@@ -13533,7 +13533,7 @@
             "weight":0.0373501,
             "drive_id":"17v1KtuBM_jmDdKF64-_tRjXvra2TNM-I",
             "size_bytes":17589752,
-            "base_memory_mb":null
+            "base_memory_mb":386
           },
           {
             "cluster_id":3977,
@@ -13541,7 +13541,7 @@
             "weight":0.0341911,
             "drive_id":"1Xpu44lNktdNwM4jbqw32ARQx1eITqz6E",
             "size_bytes":29836704,
-            "base_memory_mb":null
+            "base_memory_mb":439
           },
           {
             "cluster_id":1182,
@@ -13549,7 +13549,7 @@
             "weight":0.0126358,
             "drive_id":"1OiHdOgp9Dsa-DwjOjpEZt17vZK5XyiyE",
             "size_bytes":33337428,
-            "base_memory_mb":null
+            "base_memory_mb":811
           },
           {
             "cluster_id":4226,
@@ -13557,7 +13557,7 @@
             "weight":0.0349344,
             "drive_id":"1AP4xvj5uWldxmReRYc43awQuVpcxkySm",
             "size_bytes":43607666,
-            "base_memory_mb":null
+            "base_memory_mb":506
           },
           {
             "cluster_id":4606,
@@ -13565,7 +13565,7 @@
             "weight":0.0343769,
             "drive_id":"1mZ6b-rUJEV2WlTFf4a7nKXACG3VYqEUJ",
             "size_bytes":43490871,
-            "base_memory_mb":null
+            "base_memory_mb":562
           },
           {
             "cluster_id":2554,
@@ -13573,7 +13573,7 @@
             "weight":0.15609,
             "drive_id":"1KM4e64kyxEZ4nPcryeVLTOsQMd5dF_f2",
             "size_bytes":43515813,
-            "base_memory_mb":null
+            "base_memory_mb":561
           },
           {
             "cluster_id":2158,
@@ -13581,7 +13581,7 @@
             "weight":0.0371643,
             "drive_id":"1MFM1-RL9y8m6Ysg1jhPMoECYcCm9fha-",
             "size_bytes":21032968,
-            "base_memory_mb":null
+            "base_memory_mb":1408
           },
           {
             "cluster_id":4355,
@@ -13589,7 +13589,7 @@
             "weight":0.0165381,
             "drive_id":"1ssLSMBJO7j_oTEHO8JXWjc1LEfFvvfbu",
             "size_bytes":32375175,
-            "base_memory_mb":null
+            "base_memory_mb":789
           },
           {
             "cluster_id":5209,
@@ -13597,7 +13597,7 @@
             "weight":0.0215553,
             "drive_id":"10KYgxb97MltjgCOD6cApnGjvDysHJ-AV",
             "size_bytes":33149707,
-            "base_memory_mb":null
+            "base_memory_mb":899
           },
           {
             "cluster_id":4048,
@@ -13605,7 +13605,7 @@
             "weight":0.049255,
             "drive_id":"14BLQcPBXFmD0XracDC7E1y9_7jRe43b7",
             "size_bytes":32293866,
-            "base_memory_mb":null
+            "base_memory_mb":1514
           },
           {
             "cluster_id":1280,
@@ -13613,7 +13613,7 @@
             "weight":0.0206262,
             "drive_id":"1hKRi4Y6x-9x8b7oyIOOfFy59GcrgZhhi",
             "size_bytes":32827763,
-            "base_memory_mb":null
+            "base_memory_mb":894
           },
           {
             "cluster_id":734,
@@ -13621,7 +13621,7 @@
             "weight":0.0340053,
             "drive_id":"1ebqH_E2oaSgXTJmymJGNkYpkIxUwj3H4",
             "size_bytes":43148627,
-            "base_memory_mb":null
+            "base_memory_mb":535
           },
           {
             "cluster_id":3031,
@@ -13629,7 +13629,7 @@
             "weight":0.00706121,
             "drive_id":"1aSgH70avHlj01I6hdtScARjcdbeHqzGC",
             "size_bytes":17413437,
-            "base_memory_mb":null
+            "base_memory_mb":351
           },
           {
             "cluster_id":110,
@@ -13637,7 +13637,7 @@
             "weight":0.107962,
             "drive_id":"1oUtafA4Mtfx9Tyl6BCrBcKb6XQUJq6UL",
             "size_bytes":12442851,
-            "base_memory_mb":null
+            "base_memory_mb":104
           },
           {
             "cluster_id":5126,
@@ -13645,7 +13645,7 @@
             "weight":0.00929106,
             "drive_id":"1h_rL-gqrgLSx6x-2Lrag4RH9blio1VDo",
             "size_bytes":29433307,
-            "base_memory_mb":null
+            "base_memory_mb":453
           },
           {
             "cluster_id":3655,
@@ -13653,7 +13653,7 @@
             "weight":0.0670816,
             "drive_id":"1T0bE2BpI06Cz5q82DpjncCTbEg38Olmf",
             "size_bytes":32551938,
-            "base_memory_mb":null
+            "base_memory_mb":1858
           },
           {
             "cluster_id":1273,
@@ -13661,7 +13661,7 @@
             "weight":0.015609,
             "drive_id":"15us_ClO9NWg66HGr27-Ls4x08Tn_qS9d",
             "size_bytes":31722472,
-            "base_memory_mb":null
+            "base_memory_mb":814
           },
           {
             "cluster_id":4655,
@@ -13669,7 +13669,7 @@
             "weight":0.00836196,
             "drive_id":"1xSoLd_SyC9K5r3Y3ybNE-zgh1UYsQI5b",
             "size_bytes":21427684,
-            "base_memory_mb":null
+            "base_memory_mb":794
           },
           {
             "cluster_id":2525,
@@ -13677,7 +13677,7 @@
             "weight":0.0252717,
             "drive_id":"1iI3ErPFIjASm4_CRPcSL4yuzbkOuPGke",
             "size_bytes":33563800,
-            "base_memory_mb":null
+            "base_memory_mb":951
           },
           {
             "cluster_id":1807,
@@ -13685,7 +13685,7 @@
             "weight":0.0631792,
             "drive_id":"150lf_jaDMjL3Se9ldZv1P2k9RJlmiSW5",
             "size_bytes":43640239,
-            "base_memory_mb":null
+            "base_memory_mb":566
           },
           {
             "cluster_id":4564,
@@ -13693,7 +13693,7 @@
             "weight":0.00724703,
             "drive_id":"178xe_tt7mmeXCQNBJlJWB83k98bD6r5w",
             "size_bytes":17516625,
-            "base_memory_mb":null
+            "base_memory_mb":289
           },
           {
             "cluster_id":3373,
@@ -13701,7 +13701,7 @@
             "weight":0.00408933,
             "drive_id":"1cpoQ_FZSQ4c98aAh0Ac8QJMQPKf7H9ML",
             "size_bytes":30620117,
-            "base_memory_mb":null
+            "base_memory_mb":1713
           },
           {
             "cluster_id":916,
@@ -13709,7 +13709,7 @@
             "weight":0.00799031,
             "drive_id":"1k-zuzHm0jT3nTaiLf6SOFIv3DGuCpohL",
             "size_bytes":19568406,
-            "base_memory_mb":null
+            "base_memory_mb":1188
           },
           {
             "cluster_id":2917,
@@ -13717,7 +13717,7 @@
             "weight":0.0152373,
             "drive_id":"131x_SzUcpTdsftQmqOxeOGqltKrEclkv",
             "size_bytes":32627568,
-            "base_memory_mb":null
+            "base_memory_mb":752
           },
           {
             "cluster_id":2529,
@@ -13725,7 +13725,7 @@
             "weight":0.0111493,
             "drive_id":"1ZJtmzJDTdULxGv30IDxLs2SOsOJruwkd",
             "size_bytes":33512155,
-            "base_memory_mb":null
+            "base_memory_mb":785
           },
           {
             "cluster_id":3580,
@@ -13733,7 +13733,7 @@
             "weight":0.00836196,
             "drive_id":"10iTspeq7yKICAC831qgrdN4nOcK-RA7L",
             "size_bytes":33047841,
-            "base_memory_mb":null
+            "base_memory_mb":799
           },
           {
             "cluster_id":629,
@@ -13741,7 +13741,7 @@
             "weight":0.0094236,
             "drive_id":"1kLqziQzp7Cr0F43bvgW1y52PwkTlv4K2",
             "size_bytes":27802067,
-            "base_memory_mb":null
+            "base_memory_mb":1231
           },
           {
             "cluster_id":4017,
@@ -13749,7 +13749,7 @@
             "weight":0.0291739,
             "drive_id":"1pKYXwTMDAXt1MOcgE-HcF1PW1yizkuka",
             "size_bytes":43623290,
-            "base_memory_mb":null
+            "base_memory_mb":499
           },
           {
             "cluster_id":2365,
@@ -13757,7 +13757,7 @@
             "weight":0.0289881,
             "drive_id":"1qpd0yg1c2_v9132EH0ULbBq-6Aebwl5K",
             "size_bytes":43419423,
-            "base_memory_mb":null
+            "base_memory_mb":609
           },
           {
             "cluster_id":1983,
@@ -13765,7 +13765,7 @@
             "weight":0.0419956,
             "drive_id":"1K_3ZCYE-v9yP3WVeuYnAk5A-yRTWpB6g",
             "size_bytes":43302848,
-            "base_memory_mb":null
+            "base_memory_mb":559
           },
           {
             "cluster_id":2991,
@@ -13773,7 +13773,7 @@
             "weight":0.0120784,
             "drive_id":"1iNHKRlOUvsSBTFFJjykXgmxvYvJnUNRY",
             "size_bytes":23747404,
-            "base_memory_mb":null
+            "base_memory_mb":1543
           },
           {
             "cluster_id":4086,
@@ -13781,7 +13781,7 @@
             "weight":0.00371643,
             "drive_id":"1YVF6o8eegdGlsxQN6TsLiMPYEwgJB8au",
             "size_bytes":26833894,
-            "base_memory_mb":null
+            "base_memory_mb":370
           },
           {
             "cluster_id":2924,
@@ -13789,7 +13789,7 @@
             "weight":0.011842,
             "drive_id":"1NjqzLlY8aKUkqdcl-PgOBrmXQBIGbNLJ",
             "size_bytes":25949923,
-            "base_memory_mb":null
+            "base_memory_mb":1092
           }
         ]
       },
@@ -13822,7 +13822,7 @@
             "weight":0.0916888,
             "drive_id":"1FtMEbBSTjwUYUs8MI4ZPJZHVm0l64vBV",
             "size_bytes":48802944,
-            "base_memory_mb":null
+            "base_memory_mb":3045
           },
           {
             "cluster_id":2880,
@@ -13830,7 +13830,7 @@
             "weight":0.0301914,
             "drive_id":"1fSRy60ezpBEUysqUCEUr_gaF3K_kw5pk",
             "size_bytes":25776334,
-            "base_memory_mb":null
+            "base_memory_mb":163
           },
           {
             "cluster_id":3200,
@@ -13838,7 +13838,7 @@
             "weight":0.0187676,
             "drive_id":"1H8DbyNW8lWVfqiwHuKnf3DqMlg23pPkm",
             "size_bytes":20813312,
-            "base_memory_mb":null
+            "base_memory_mb":4558
           },
           {
             "cluster_id":2449,
@@ -13846,7 +13846,7 @@
             "weight":0.0846688,
             "drive_id":"16NXFA4GIOW1DzfwIwMYDQZwa8D6tWzhQ",
             "size_bytes":48745499,
-            "base_memory_mb":null
+            "base_memory_mb":3121
           },
           {
             "cluster_id":3263,
@@ -13854,7 +13854,7 @@
             "weight":0.0513542,
             "drive_id":"1OtIWAWrnXB0dXJvUyYqUKA4JYRLtAHMX",
             "size_bytes":17823828,
-            "base_memory_mb":null
+            "base_memory_mb":1650
           },
           {
             "cluster_id":2858,
@@ -13862,7 +13862,7 @@
             "weight":0.0223036,
             "drive_id":"1Ixl7H9-FQTIoIBWnCUNxFPGAuD0tNTVX",
             "size_bytes":17841986,
-            "base_memory_mb":null
+            "base_memory_mb":995
           },
           {
             "cluster_id":2488,
@@ -13870,7 +13870,7 @@
             "weight":0.0688147,
             "drive_id":"1mJEb3rgqa3cQ_xQ2bjRDK-ldLm4hSJh5",
             "size_bytes":27096572,
-            "base_memory_mb":null
+            "base_memory_mb":1105
           },
           {
             "cluster_id":2058,
@@ -13878,7 +13878,7 @@
             "weight":0.0607305,
             "drive_id":"1B4F2uBCoNByfTxn9uzOooAYgAEpPunqe",
             "size_bytes":25728213,
-            "base_memory_mb":null
+            "base_memory_mb":1806
           },
           {
             "cluster_id":1723,
@@ -13886,7 +13886,7 @@
             "weight":0.0280155,
             "drive_id":"1jXJvkwbZuy_Jw25mZk7wJKSP8g8mF01T",
             "size_bytes":18176575,
-            "base_memory_mb":null
+            "base_memory_mb":966
           },
           {
             "cluster_id":697,
@@ -13894,7 +13894,7 @@
             "weight":0.00652787,
             "drive_id":"1GpB1M_fJpZSN1smNF4fLuaITIrYfwHWP",
             "size_bytes":29153401,
-            "base_memory_mb":null
+            "base_memory_mb":1218
           },
           {
             "cluster_id":3399,
@@ -13902,7 +13902,7 @@
             "weight":0.0163197,
             "drive_id":"1l10B4RjRMr_Bu4LgnkKiY7V7YE5-LuqI",
             "size_bytes":18686771,
-            "base_memory_mb":null
+            "base_memory_mb":950
           },
           {
             "cluster_id":38,
@@ -13910,7 +13910,7 @@
             "weight":0.0625588,
             "drive_id":"1qZYcNyi5sQZEQ3Rhpx5wEb7b5swOtO3U",
             "size_bytes":12440797,
-            "base_memory_mb":null
+            "base_memory_mb":123
           },
           {
             "cluster_id":1576,
@@ -13918,7 +13918,7 @@
             "weight":0.051135,
             "drive_id":"1PYh1cBzOE4_XC5Utz4tKv0rUC-tPhEvl",
             "size_bytes":21514478,
-            "base_memory_mb":null
+            "base_memory_mb":6333
           },
           {
             "cluster_id":1701,
@@ -13926,7 +13926,7 @@
             "weight":0.0203996,
             "drive_id":"1rv1mUiexbvCWwUDmbxdeGoUqB5JTeCUk",
             "size_bytes":16588558,
-            "base_memory_mb":null
+            "base_memory_mb":1054
           },
           {
             "cluster_id":642,
@@ -13934,7 +13934,7 @@
             "weight":0.0296474,
             "drive_id":"1Pq4iyc7_6ntkwOR9ebNrj-VSLbAnHvuL",
             "size_bytes":28322095,
-            "base_memory_mb":null
+            "base_memory_mb":1354
           },
           {
             "cluster_id":253,
@@ -13942,7 +13942,7 @@
             "weight":0.0813264,
             "drive_id":"1g2NscGhP58PHV26NLlEJ1M2wZrVJmmdy",
             "size_bytes":12440799,
-            "base_memory_mb":null
+            "base_memory_mb":104
           },
           {
             "cluster_id":2660,
@@ -13950,7 +13950,7 @@
             "weight":0.00625588,
             "drive_id":"1Qg8v7-kEu0gvjxpl9EXg7SYVSzJ0JZhE",
             "size_bytes":21537125,
-            "base_memory_mb":null
+            "base_memory_mb":6311
           },
           {
             "cluster_id":3393,
@@ -13958,7 +13958,7 @@
             "weight":0.0195836,
             "drive_id":"1CPAW2JXx8Caj24RMNHhl0F8kUCEFYciU",
             "size_bytes":18296453,
-            "base_memory_mb":null
+            "base_memory_mb":1187
           },
           {
             "cluster_id":1044,
@@ -13966,7 +13966,7 @@
             "weight":0.00805889,
             "drive_id":"1tBFvUneBtr0KRzhvyAlBHtzvuqoeiUGx",
             "size_bytes":120508061,
-            "base_memory_mb":null
+            "base_memory_mb":20249
           },
           {
             "cluster_id":1626,
@@ -13974,7 +13974,7 @@
             "weight":0.0425261,
             "drive_id":"1qMi-hTAxsKTj7l9GyLhAZAQSQkbHQd0k",
             "size_bytes":17822701,
-            "base_memory_mb":null
+            "base_memory_mb":1805
           },
           {
             "cluster_id":3312,
@@ -13982,7 +13982,7 @@
             "weight":0.0257762,
             "drive_id":"1N8YLpcTIfWgTNy6zpM8lgDFf6hPG2Twc",
             "size_bytes":21319983,
-            "base_memory_mb":null
+            "base_memory_mb":2387
           },
           {
             "cluster_id":1790,
@@ -13990,7 +13990,7 @@
             "weight":0.0231196,
             "drive_id":"1w-_6icv_hG3fNZrW_k38oriw_N4Ycws0",
             "size_bytes":25770511,
-            "base_memory_mb":null
+            "base_memory_mb":164
           },
           {
             "cluster_id":443,
@@ -13998,7 +13998,7 @@
             "weight":0.0127838,
             "drive_id":"1TAdEUI-t6p31pAVk2h0BWiu13DMhdvL_",
             "size_bytes":12442871,
-            "base_memory_mb":null
+            "base_memory_mb":121
           },
           {
             "cluster_id":3320,
@@ -14006,7 +14006,7 @@
             "weight":0.0223923,
             "drive_id":"1idY1Emm2islcEf60nWAl-9FkKEgLscqG",
             "size_bytes":18430254,
-            "base_memory_mb":null
+            "base_memory_mb":2407
           },
           {
             "cluster_id":2589,
@@ -14014,7 +14014,7 @@
             "weight":0.110702,
             "drive_id":"1Yxt8-Vah5J8QNV6KbP6xR-JmM9p-zmD_",
             "size_bytes":26413743,
-            "base_memory_mb":null
+            "base_memory_mb":1245
           },
           {
             "cluster_id":1262,
@@ -14022,7 +14022,7 @@
             "weight":0.00435192,
             "drive_id":"1IwluCZbRYQkl_ZPOrSTAQblfkCbro1gy",
             "size_bytes":25772924,
-            "base_memory_mb":null
+            "base_memory_mb":163
           }
         ]
       },
@@ -14055,7 +14055,7 @@
             "weight":0.0467937,
             "drive_id":"1udDj-kyOtfPAjRZ7JgGrwyUhUywPt1W-",
             "size_bytes":22459579,
-            "base_memory_mb":null
+            "base_memory_mb":3846
           },
           {
             "cluster_id":1661,
@@ -14063,7 +14063,7 @@
             "weight":0.0755408,
             "drive_id":"1puU1CdmHiRtuW_mnpPbjxfg3lK6sAjf_",
             "size_bytes":15506360,
-            "base_memory_mb":null
+            "base_memory_mb":153
           },
           {
             "cluster_id":2418,
@@ -14071,7 +14071,7 @@
             "weight":0.00484881,
             "drive_id":"1UyMjS0Rkf_Acyjft-UQ-L9OdyQuVoeUu",
             "size_bytes":26987949,
-            "base_memory_mb":null
+            "base_memory_mb":310
           },
           {
             "cluster_id":1482,
@@ -14079,7 +14079,7 @@
             "weight":0.0446783,
             "drive_id":"1pCeCCPAo5U5hFfctnjH0nb8QcXIElvr9",
             "size_bytes":28349657,
-            "base_memory_mb":null
+            "base_memory_mb":172
           },
           {
             "cluster_id":98,
@@ -14087,7 +14087,7 @@
             "weight":0.102518,
             "drive_id":"1xrIR5pjSug7oaSQ15aZiSzx5J5v8sxT9",
             "size_bytes":12440811,
-            "base_memory_mb":null
+            "base_memory_mb":122
           },
           {
             "cluster_id":1824,
@@ -14095,7 +14095,7 @@
             "weight":0.00380978,
             "drive_id":"1RxU6qjrnADBpYkZa178m5ESG35pGAKB_",
             "size_bytes":21216102,
-            "base_memory_mb":null
+            "base_memory_mb":276
           },
           {
             "cluster_id":878,
@@ -14103,7 +14103,7 @@
             "weight":0.0419075,
             "drive_id":"1V0bWI5CS9NmLAiNmMFbqNb-qWqcbxnFy",
             "size_bytes":29208687,
-            "base_memory_mb":null
+            "base_memory_mb":1323
           },
           {
             "cluster_id":2551,
@@ -14111,7 +14111,7 @@
             "weight":0.00692686,
             "drive_id":"1M9VbXeh6V6PeeoEIBFew3In2AgutMM0z",
             "size_bytes":18173522,
-            "base_memory_mb":null
+            "base_memory_mb":408
           },
           {
             "cluster_id":1798,
@@ -14119,7 +14119,7 @@
             "weight":0.00701097,
             "drive_id":"1Yw6KB5vtoKXppKmMMqkRgpU9oGvxl2Qb",
             "size_bytes":16179306,
-            "base_memory_mb":null
+            "base_memory_mb":184
           },
           {
             "cluster_id":1984,
@@ -14127,7 +14127,7 @@
             "weight":0.0249367,
             "drive_id":"13XFTEhI-w3bpmLbyuXB_9d8akTs6U4c_",
             "size_bytes":16070569,
-            "base_memory_mb":null
+            "base_memory_mb":321
           },
           {
             "cluster_id":1972,
@@ -14135,7 +14135,7 @@
             "weight":0.0207806,
             "drive_id":"1R75edaw_NRxEeAbcWmxeowhJslYVvElt",
             "size_bytes":34334548,
-            "base_memory_mb":null
+            "base_memory_mb":547
           },
           {
             "cluster_id":1813,
@@ -14143,7 +14143,7 @@
             "weight":0.0504936,
             "drive_id":"1iI-1771ayM4aMca92eAt40SW85nnD6c8",
             "size_bytes":69892780,
-            "base_memory_mb":null
+            "base_memory_mb":5243
           },
           {
             "cluster_id":2091,
@@ -14151,7 +14151,7 @@
             "weight":0.0523026,
             "drive_id":"1GG7fuhfUANwcgY__8YQC01wtEKOn5RNo",
             "size_bytes":15880912,
-            "base_memory_mb":null
+            "base_memory_mb":308
           },
           {
             "cluster_id":1851,
@@ -14159,7 +14159,7 @@
             "weight":0.0183562,
             "drive_id":"18F5MOY6oswlFQIkeNunFjpVkwr67qFWv",
             "size_bytes":14409287,
-            "base_memory_mb":null
+            "base_memory_mb":347
           },
           {
             "cluster_id":1879,
@@ -14167,7 +14167,7 @@
             "weight":0.0104692,
             "drive_id":"1P9Uy2UsEqVZS1enM76jYsuge-QH7TdLv",
             "size_bytes":169131348,
-            "base_memory_mb":null
+            "base_memory_mb":8711
           },
           {
             "cluster_id":673,
@@ -14175,7 +14175,7 @@
             "weight":0.00473449,
             "drive_id":"1iXaTKJALCC74o1af5PwYDO-_aeRkw6L-",
             "size_bytes":60019211,
-            "base_memory_mb":null
+            "base_memory_mb":9181
           },
           {
             "cluster_id":1934,
@@ -14183,7 +14183,7 @@
             "weight":0.023205,
             "drive_id":"17m5FqJLXPA-dqm9N5Ud_HLrMaNlMO-iq",
             "size_bytes":17219405,
-            "base_memory_mb":null
+            "base_memory_mb":894
           },
           {
             "cluster_id":514,
@@ -14191,7 +14191,7 @@
             "weight":0.0166245,
             "drive_id":"1e_gCIZk0Wrrx3Stx68P5tTBZ_El2zRH5",
             "size_bytes":12442937,
-            "base_memory_mb":null
+            "base_memory_mb":125
           },
           {
             "cluster_id":1395,
@@ -14199,7 +14199,7 @@
             "weight":0.0183562,
             "drive_id":"13w2vwM0UD9E_StCJqKLEa67plu4b4N-p",
             "size_bytes":16500612,
-            "base_memory_mb":null
+            "base_memory_mb":352
           },
           {
             "cluster_id":582,
@@ -14207,7 +14207,7 @@
             "weight":0.00347294,
             "drive_id":"19gc7BAHYfRqmwWyUwRp0fw0et2yDujsU",
             "size_bytes":32788249,
-            "base_memory_mb":null
+            "base_memory_mb":935
           },
           {
             "cluster_id":120,
@@ -14215,7 +14215,7 @@
             "weight":0.0284001,
             "drive_id":"1AsPJa40MLeqG_E4AIJou8esVNZqGW49p",
             "size_bytes":12440813,
-            "base_memory_mb":null
+            "base_memory_mb":105
           },
           {
             "cluster_id":1858,
@@ -14223,7 +14223,7 @@
             "weight":0.101148,
             "drive_id":"1O52zyDT9GI-I-62oSL2QorjzDM3pIgrJ",
             "size_bytes":16384088,
-            "base_memory_mb":null
+            "base_memory_mb":225
           },
           {
             "cluster_id":814,
@@ -14231,7 +14231,7 @@
             "weight":0.00796589,
             "drive_id":"1xjWDmKCZXiuS2yrGfVB-URK-WD_VPDMT",
             "size_bytes":19655275,
-            "base_memory_mb":null
+            "base_memory_mb":368
           },
           {
             "cluster_id":1877,
@@ -14239,7 +14239,7 @@
             "weight":0.0298804,
             "drive_id":"1j8byrku8JiLE9f8zyVQ-fOdt2aVgxSgj",
             "size_bytes":61204319,
-            "base_memory_mb":null
+            "base_memory_mb":1089
           },
           {
             "cluster_id":1246,
@@ -14247,7 +14247,7 @@
             "weight":0.0491807,
             "drive_id":"1JlwsohtEL5XQ1hEKvfm7sa1YdyFEjq-r",
             "size_bytes":52238227,
-            "base_memory_mb":null
+            "base_memory_mb":732
           },
           {
             "cluster_id":2220,
@@ -14255,7 +14255,7 @@
             "weight":0.00598213,
             "drive_id":"1JGCnmYgfBvg7aDF3waqpdhamWjoNWTiH",
             "size_bytes":20209936,
-            "base_memory_mb":null
+            "base_memory_mb":219
           },
           {
             "cluster_id":2283,
@@ -14263,7 +14263,7 @@
             "weight":0.0954273,
             "drive_id":"113DPEFJlN61bSRdktDh1vybu5sT60JFT",
             "size_bytes":17749158,
-            "base_memory_mb":null
+            "base_memory_mb":2234
           },
           {
             "cluster_id":150,
@@ -14271,7 +14271,7 @@
             "weight":0.0498734,
             "drive_id":"1UeBCeHTgMwGzV3475RpmWelcMSnCpptd",
             "size_bytes":12440802,
-            "base_memory_mb":null
+            "base_memory_mb":120
           },
           {
             "cluster_id":870,
@@ -14279,7 +14279,7 @@
             "weight":0.0543759,
             "drive_id":"1QOhgh8QZT4NLgFrM5lbpunTGxQNulzNN",
             "size_bytes":26833314,
-            "base_memory_mb":null
+            "base_memory_mb":1353
           }
         ]
       },
@@ -14312,7 +14312,7 @@
             "weight":0.00917016,
             "drive_id":"1JBqb7CYzo7Q9gU1yvi8_iQZeXy-Pa4Nf",
             "size_bytes":37548881,
-            "base_memory_mb":null
+            "base_memory_mb":2406
           },
           {
             "cluster_id":795,
@@ -14320,7 +14320,7 @@
             "weight":0.0458485,
             "drive_id":"1vB-OJ-hjcUZFfxJtm-t5IQKqF-3tBist",
             "size_bytes":23498953,
-            "base_memory_mb":null
+            "base_memory_mb":1979
           },
           {
             "cluster_id":2934,
@@ -14328,7 +14328,7 @@
             "weight":0.077672,
             "drive_id":"168FLd6vL0aONB04C6b7BiIJwKWL8KVIO",
             "size_bytes":30956902,
-            "base_memory_mb":null
+            "base_memory_mb":1834
           },
           {
             "cluster_id":3707,
@@ -14336,7 +14336,7 @@
             "weight":0.0692348,
             "drive_id":"170kQOWn2Uq79n6BOY_u15BiPIynTXPTz",
             "size_bytes":34288726,
-            "base_memory_mb":null
+            "base_memory_mb":2992
           },
           {
             "cluster_id":576,
@@ -14344,7 +14344,7 @@
             "weight":0.00773583,
             "drive_id":"1IssoeRVI8qqAMJljHx1w8dn6cIFswBCD",
             "size_bytes":22656567,
-            "base_memory_mb":null
+            "base_memory_mb":1125
           },
           {
             "cluster_id":37,
@@ -14352,7 +14352,7 @@
             "weight":0.127054,
             "drive_id":"18yIIwPOUve8IF7ibXEwabnyM8i3Yt2D9",
             "size_bytes":12443358,
-            "base_memory_mb":null
+            "base_memory_mb":124
           },
           {
             "cluster_id":2248,
@@ -14360,7 +14360,7 @@
             "weight":0.0394564,
             "drive_id":"10Vn3T2tdPfgAj4810pNRyh_Mux41f3ZC",
             "size_bytes":38323668,
-            "base_memory_mb":null
+            "base_memory_mb":2019
           },
           {
             "cluster_id":850,
@@ -14368,7 +14368,7 @@
             "weight":0.0393651,
             "drive_id":"1_6MFbKv2uSGKLUINtfXi97B4GAFdPlQd",
             "size_bytes":27181383,
-            "base_memory_mb":null
+            "base_memory_mb":2187
           },
           {
             "cluster_id":2676,
@@ -14376,7 +14376,7 @@
             "weight":0.105713,
             "drive_id":"1N28HoFNoUOCHilGFVSK0tPQx5dRgqHQQ",
             "size_bytes":36266557,
-            "base_memory_mb":null
+            "base_memory_mb":2032
           },
           {
             "cluster_id":1040,
@@ -14384,7 +14384,7 @@
             "weight":0.0568907,
             "drive_id":"1Lpc-G965nKZG-BsfRfKNGx9sTHvddpLK",
             "size_bytes":60513603,
-            "base_memory_mb":null
+            "base_memory_mb":1930
           },
           {
             "cluster_id":1885,
@@ -14392,7 +14392,7 @@
             "weight":0.0349896,
             "drive_id":"1TxpjSZlzWX8f2gt6CI_oVVyZg_e_vP5l",
             "size_bytes":38820451,
-            "base_memory_mb":null
+            "base_memory_mb":2306
           },
           {
             "cluster_id":2486,
@@ -14400,7 +14400,7 @@
             "weight":0.0317636,
             "drive_id":"1zzk-nMPG7Jd17A3425M2vXGjvJTyvD4W",
             "size_bytes":34870554,
-            "base_memory_mb":null
+            "base_memory_mb":2732
           },
           {
             "cluster_id":2211,
@@ -14408,7 +14408,7 @@
             "weight":0.0196041,
             "drive_id":"1Zeaon7rl3abJGPsuyCTeddY15xfOsnL1",
             "size_bytes":38446945,
-            "base_memory_mb":null
+            "base_memory_mb":2233
           },
           {
             "cluster_id":3134,
@@ -14416,7 +14416,7 @@
             "weight":0.0627828,
             "drive_id":"11NA38G0yyjJvFdl31jLRA29dAY-aSNtu",
             "size_bytes":28816218,
-            "base_memory_mb":null
+            "base_memory_mb":2355
           },
           {
             "cluster_id":4022,
@@ -14424,7 +14424,7 @@
             "weight":0.00570576,
             "drive_id":"1YTY_8UCS1F40OKWlT5wPVuAu-nJMe9t7",
             "size_bytes":29540694,
-            "base_memory_mb":null
+            "base_memory_mb":1356
           },
           {
             "cluster_id":3095,
@@ -14432,7 +14432,7 @@
             "weight":0.0248153,
             "drive_id":"1wcY40n6WdOQP_vijGBe91pzeTlMrnGqf",
             "size_bytes":35688918,
-            "base_memory_mb":null
+            "base_memory_mb":2340
           },
           {
             "cluster_id":1285,
@@ -14440,7 +14440,7 @@
             "weight":0.037223,
             "drive_id":"1rfkcR6SF04fEqnnUMTjCOf6cI9ANZhv5",
             "size_bytes":37227671,
-            "base_memory_mb":null
+            "base_memory_mb":1741
           },
           {
             "cluster_id":2350,
@@ -14448,7 +14448,7 @@
             "weight":0.037223,
             "drive_id":"1uAA0MF5q5EMT9W4E65PqcP7QHze8mDXr",
             "size_bytes":32491429,
-            "base_memory_mb":null
+            "base_memory_mb":1638
           },
           {
             "cluster_id":1737,
@@ -14456,7 +14456,7 @@
             "weight":0.109187,
             "drive_id":"1va2AVSJrIoSuNoF6GI-wavH2uugIf3d1",
             "size_bytes":35425800,
-            "base_memory_mb":null
+            "base_memory_mb":1758
           },
           {
             "cluster_id":1580,
@@ -14464,7 +14464,7 @@
             "weight":0.0223338,
             "drive_id":"10IK7aIXGtgaZWhyYWMYETqrEu2i2oWJg",
             "size_bytes":36494776,
-            "base_memory_mb":null
+            "base_memory_mb":2387
           },
           {
             "cluster_id":433,
@@ -14472,7 +14472,7 @@
             "weight":0.0119114,
             "drive_id":"1wK_K_ccgd3l0PePXOSkxiSHzaYOAoUM9",
             "size_bytes":12445397,
-            "base_memory_mb":null
+            "base_memory_mb":114
           },
           {
             "cluster_id":3185,
@@ -14480,7 +14480,7 @@
             "weight":0.024319,
             "drive_id":"14DrXJ6LvFfjL207yCvHnMyL60tNTo3fu",
             "size_bytes":32029097,
-            "base_memory_mb":null
+            "base_memory_mb":2374
           }
         ]
       },
@@ -14513,7 +14513,7 @@
             "weight":0.0656433,
             "drive_id":"1Ly2oZFKsorzFHv4FHT1EwhYnKfwz9keQ",
             "size_bytes":31933906,
-            "base_memory_mb":null
+            "base_memory_mb":1465
           },
           {
             "cluster_id":4594,
@@ -14521,7 +14521,7 @@
             "weight":0.0480337,
             "drive_id":"1hW-jcfcUy7pU2y7IekIH5JjoYEKlHEtH",
             "size_bytes":65801001,
-            "base_memory_mb":null
+            "base_memory_mb":6152
           },
           {
             "cluster_id":3680,
@@ -14529,7 +14529,7 @@
             "weight":0.0127582,
             "drive_id":"1_8btuGI7glVmwLVDCzrVBP9NO4xIO6On",
             "size_bytes":44342469,
-            "base_memory_mb":null
+            "base_memory_mb":3336
           },
           {
             "cluster_id":4687,
@@ -14537,7 +14537,7 @@
             "weight":0.0100668,
             "drive_id":"1Fw_mbjap1m--bgE09s7JQhrnwIDWCwiw",
             "size_bytes":53918125,
-            "base_memory_mb":null
+            "base_memory_mb":2747
           },
           {
             "cluster_id":1895,
@@ -14545,7 +14545,7 @@
             "weight":0.0774012,
             "drive_id":"1bdjBZaX5K1OU-xswJdvFc-YTg5Ey1rk2",
             "size_bytes":22602912,
-            "base_memory_mb":null
+            "base_memory_mb":551
           },
           {
             "cluster_id":4958,
@@ -14553,7 +14553,7 @@
             "weight":0.00570145,
             "drive_id":"112gu6Rfu-aCtsdzBzH4hmT5MOXA7Okg2",
             "size_bytes":26900204,
-            "base_memory_mb":null
+            "base_memory_mb":907
           },
           {
             "cluster_id":4790,
@@ -14561,7 +14561,7 @@
             "weight":0.00728672,
             "drive_id":"1L3yeOrJGk1ynSaMXWS8I4Vxk95E34TGm",
             "size_bytes":24236028,
-            "base_memory_mb":null
+            "base_memory_mb":653
           },
           {
             "cluster_id":1355,
@@ -14569,7 +14569,7 @@
             "weight":0.0116879,
             "drive_id":"1dLBcarUVH6yTfXg-4jG31DgmI4Zbu2u2",
             "size_bytes":24799770,
-            "base_memory_mb":null
+            "base_memory_mb":704
           },
           {
             "cluster_id":4232,
@@ -14577,7 +14577,7 @@
             "weight":0.0277203,
             "drive_id":"1yeiMNVdmnQwGFilRUuRnWlYiYzsgk6rx",
             "size_bytes":53494978,
-            "base_memory_mb":null
+            "base_memory_mb":3860
           },
           {
             "cluster_id":4679,
@@ -14585,7 +14585,7 @@
             "weight":0.013603,
             "drive_id":"1g10jrBCc9_VY5AebAQ9gxkdXQ2dM3MjD",
             "size_bytes":35566115,
-            "base_memory_mb":null
+            "base_memory_mb":2647
           },
           {
             "cluster_id":602,
@@ -14593,7 +14593,7 @@
             "weight":0.026071,
             "drive_id":"1fV6D3qAkT_TjYECqJRGJd7nLPYaAo3Yc",
             "size_bytes":25701218,
-            "base_memory_mb":null
+            "base_memory_mb":873
           },
           {
             "cluster_id":4864,
@@ -14601,7 +14601,7 @@
             "weight":0.0345001,
             "drive_id":"1gSdTrdKP38PoMIGqvFGeudvZRbOHFnHM",
             "size_bytes":34674269,
-            "base_memory_mb":null
+            "base_memory_mb":2600
           },
           {
             "cluster_id":5209,
@@ -14609,7 +14609,7 @@
             "weight":0.08956,
             "drive_id":"1saibu2MSUUb8u68wewzbzYzCJlJYR0Kx",
             "size_bytes":43460435,
-            "base_memory_mb":null
+            "base_memory_mb":1719
           },
           {
             "cluster_id":3930,
@@ -14617,7 +14617,7 @@
             "weight":0.00292021,
             "drive_id":"1_X-tYIFv6PZRETJz51qginm0dP4j5E2H",
             "size_bytes":31085026,
-            "base_memory_mb":null
+            "base_memory_mb":1708
           },
           {
             "cluster_id":3948,
@@ -14625,7 +14625,7 @@
             "weight":0.0317147,
             "drive_id":"1iMP8pzl20HF5bSodIxJQDslwgwJnA72x",
             "size_bytes":64505828,
-            "base_memory_mb":null
+            "base_memory_mb":6286
           },
           {
             "cluster_id":3966,
@@ -14633,7 +14633,7 @@
             "weight":0.0155694,
             "drive_id":"1vAfrU0Xd0-TpDec5PBAOR4xGXFgOIN7m",
             "size_bytes":53478050,
-            "base_memory_mb":null
+            "base_memory_mb":2975
           },
           {
             "cluster_id":4751,
@@ -14641,7 +14641,7 @@
             "weight":0.0653577,
             "drive_id":"1n3ur3u-lrQ3Ck0koFmONbrNpj-C7RHMT",
             "size_bytes":33709747,
-            "base_memory_mb":null
+            "base_memory_mb":1158
           },
           {
             "cluster_id":3294,
@@ -14649,7 +14649,7 @@
             "weight":0.0128024,
             "drive_id":"17TF8LEfudcrt10Cbj9Cz5dQmfKI6hrId",
             "size_bytes":27799265,
-            "base_memory_mb":null
+            "base_memory_mb":1271
           },
           {
             "cluster_id":2465,
@@ -14657,7 +14657,7 @@
             "weight":0.0145874,
             "drive_id":"1GP2HuPaDfZ19_peDaseGRqO4MZrAC7cJ",
             "size_bytes":64473854,
-            "base_memory_mb":null
+            "base_memory_mb":6603
           },
           {
             "cluster_id":1594,
@@ -14665,7 +14665,7 @@
             "weight":0.00343394,
             "drive_id":"1YTnrNJP4u7jhIHxx5ARJLb4RHYhWi0a6",
             "size_bytes":33551489,
-            "base_memory_mb":null
+            "base_memory_mb":1311
           },
           {
             "cluster_id":2580,
@@ -14673,7 +14673,7 @@
             "weight":0.00324247,
             "drive_id":"18H5XhloNeMYGp7ah6Y1ApLV6lULkc5BQ",
             "size_bytes":29240426,
-            "base_memory_mb":null
+            "base_memory_mb":1464
           },
           {
             "cluster_id":3235,
@@ -14681,7 +14681,7 @@
             "weight":0.0170325,
             "drive_id":"15Dlo5B5r9VgqpHYSyV2v5ZkJomIpyD6X",
             "size_bytes":38496148,
-            "base_memory_mb":null
+            "base_memory_mb":2854
           },
           {
             "cluster_id":2123,
@@ -14689,7 +14689,7 @@
             "weight":0.0194681,
             "drive_id":"1Bf4ImMiJFgb5kGo0rvxYXUOoiWF3PeG4",
             "size_bytes":57359240,
-            "base_memory_mb":null
+            "base_memory_mb":3369
           },
           {
             "cluster_id":379,
@@ -14697,7 +14697,7 @@
             "weight":0.0922985,
             "drive_id":"1K9bgNjfXtutXKGphzNEo6LODzyIIj7mf",
             "size_bytes":12442250,
-            "base_memory_mb":null
+            "base_memory_mb":111
           },
           {
             "cluster_id":2859,
@@ -14705,7 +14705,7 @@
             "weight":0.0108375,
             "drive_id":"12XCyK0IEDkLa8GYOr0bgidBMSoC75tVY",
             "size_bytes":55177559,
-            "base_memory_mb":null
+            "base_memory_mb":1863
           },
           {
             "cluster_id":1189,
@@ -14713,7 +14713,7 @@
             "weight":0.0233696,
             "drive_id":"1JFNd8Uty8dBPVDXXBVqPcSHTk6sQa0kF",
             "size_bytes":53045217,
-            "base_memory_mb":null
+            "base_memory_mb":2567
           },
           {
             "cluster_id":2064,
@@ -14721,7 +14721,7 @@
             "weight":0.0652623,
             "drive_id":"1L-pC9qYr2w1boZ10wX1Lw2Fx8EY0-Zbv",
             "size_bytes":16486452,
-            "base_memory_mb":null
+            "base_memory_mb":696
           },
           {
             "cluster_id":5398,
@@ -14729,7 +14729,7 @@
             "weight":0.00312006,
             "drive_id":"1Uj9l0PToY4zpMCSmEAEOwVUkh7OpOpL2",
             "size_bytes":40330395,
-            "base_memory_mb":null
+            "base_memory_mb":1765
           },
           {
             "cluster_id":2041,
@@ -14737,7 +14737,7 @@
             "weight":0.0472873,
             "drive_id":"1yv-Z_tp4SH-JCS7-P_v8DC7sOqwvtDaO",
             "size_bytes":40489275,
-            "base_memory_mb":null
+            "base_memory_mb":3616
           },
           {
             "cluster_id":2151,
@@ -14745,7 +14745,7 @@
             "weight":0.0944765,
             "drive_id":"1ASDp-yjndyCLSw00MX1x7euzAtGgd5CN",
             "size_bytes":46584948,
-            "base_memory_mb":null
+            "base_memory_mb":3934
           },
           {
             "cluster_id":3148,
@@ -14753,7 +14753,7 @@
             "weight":0.00900035,
             "drive_id":"1yh7YqjB-Mt4_YL67leUJFSil8A9AXm3N",
             "size_bytes":41546118,
-            "base_memory_mb":null
+            "base_memory_mb":2582
           },
           {
             "cluster_id":3065,
@@ -14761,7 +14761,7 @@
             "weight":0.0297255,
             "drive_id":"1KAimisZ8JFYzFVbkaYXvxrYhAtTAu9pf",
             "size_bytes":28985490,
-            "base_memory_mb":null
+            "base_memory_mb":2030
           },
           {
             "cluster_id":5233,
@@ -14769,7 +14769,7 @@
             "weight":0.0084597,
             "drive_id":"1kcVQC2AQTyzRaL1Ede-odl-R7NYUVPc1",
             "size_bytes":40306007,
-            "base_memory_mb":null
+            "base_memory_mb":2642
           }
         ]
       }
@@ -14777,7 +14777,7 @@
   },
   "dcperf":{
     "wdl_bench":{
-      "_scarab_sim_githash":null,
+      "_scarab_sim_githash":"98dc727e",
       "concurrent_hash_map_benchmark":{
         "description":{
           "desc":"multiple common operations of the folly::ConcurrentHashMap data structure",
@@ -14976,7 +14976,7 @@
       "lzbench":{}
     },
     "tao_bench":{
-      "_scarab_sim_githash":null,
+      "_scarab_sim_githash":"98dc727e",
       "tao_bench_server":{
         "trace":{
           "dynamorio_args":null,
@@ -15004,37 +15004,37 @@
             "cluster_id":645,
             "segment_id":0,
             "weight":0.0758204,
-            "base_memory_mb":null
+            "base_memory_mb":1981
           },
           {
             "cluster_id":157,
             "segment_id":1,
             "weight":0.33873,
-            "base_memory_mb":null
+            "base_memory_mb":2216
           },
           {
             "cluster_id":1215,
             "segment_id":2,
             "weight":0.159518,
-            "base_memory_mb":null
+            "base_memory_mb":2099
           },
           {
             "cluster_id":1456,
             "segment_id":3,
             "weight":0.120131,
-            "base_memory_mb":null
+            "base_memory_mb":1993
           },
           {
             "cluster_id":2449,
             "segment_id":5,
             "weight":0.3058,
-            "base_memory_mb":null
+            "base_memory_mb":2114
           }
         ]
       }
     },
     "django_bench":{
-      "_scarab_sim_githash":null,
+      "_scarab_sim_githash":"98dc727e",
       "django_bench_server":{
         "trace":{
           "dynamorio_args":null,
@@ -15062,13 +15062,13 @@
             "cluster_id":4144,
             "segment_id":0,
             "weight":0.00641237,
-            "base_memory_mb":null
+            "base_memory_mb":3451
           },
           {
             "cluster_id":1468,
             "segment_id":1,
             "weight":0.210851,
-            "base_memory_mb":null
+            "base_memory_mb":3188
           },
           {
             "cluster_id":21,
@@ -15080,49 +15080,49 @@
             "cluster_id":4164,
             "segment_id":3,
             "weight":0.0763072,
-            "base_memory_mb":null
+            "base_memory_mb":3265
           },
           {
             "cluster_id":2569,
             "segment_id":4,
             "weight":0.0440316,
-            "base_memory_mb":null
+            "base_memory_mb":3503
           },
           {
             "cluster_id":1322,
             "segment_id":5,
             "weight":0.152614,
-            "base_memory_mb":null
+            "base_memory_mb":3477
           },
           {
             "cluster_id":4277,
             "segment_id":7,
             "weight":0.0607038,
-            "base_memory_mb":null
+            "base_memory_mb":3451
           },
           {
             "cluster_id":168,
             "segment_id":11,
             "weight":0.0335581,
-            "base_memory_mb":null
+            "base_memory_mb":3556
           },
           {
             "cluster_id":1355,
             "segment_id":12,
             "weight":0.190661,
-            "base_memory_mb":null
+            "base_memory_mb":3383
           },
           {
             "cluster_id":3459,
             "segment_id":13,
             "weight":0.106659,
-            "base_memory_mb":null
+            "base_memory_mb":3519
           },
           {
             "cluster_id":3058,
             "segment_id":16,
             "weight":0.102812,
-            "base_memory_mb":null
+            "base_memory_mb":3297
           }
         ]
       }


### PR DESCRIPTION
Added default memory values to the workload database for all datacenter workloads. Default values were collected using empty parameter values, and the latest scarab
The following simpoints were not collected:
dcperf/django_bench/django_bench_server 21 - Missing instruction (see scarab #464)
dcperf/wdl_bench/fibers_benchmark 2,4,54,76,92,141,151,158,198,229 - Missing traces
dcperf/wdl_bench/random_benchmark 10,65,87,190,220,243,289,325,332 - Missing traces