### PR TITLE
"_scarab_sim_githash" has been parsing as one of workloads, so it ret…

### DIFF
--- a/scarab_stats/scarab_stats.py
+++ b/scarab_stats/scarab_stats.py
@@ -845,12 +845,16 @@ class stat_aggregator:
                 elif found_subsuite != None:
                     assert found_suite is not None, "Suite cannot be None when subsuite is specified"
                     for workload in list(workloads_data[found_suite][found_subsuite].keys()):
+                        if not isinstance(workloads_data[found_suite][found_subsuite][workload], dict):
+                            continue
                         for cid in self.get_cluster_ids(workload, found_suite, found_subsuite, top_simpoint_only, workloads_data=workloads_data):
                             tasks.append((config, found_suite, found_subsuite, workload, str(cid)))
 
                 else:
                     for subsuite in list(workloads_data[found_suite].keys()):
                         for workload in list(workloads_data[found_suite][subsuite].keys()):
+                            if not isinstance(workloads_data[found_suite][subsuite][workload], dict):
+                                continue
                             for cid in self.get_cluster_ids(workload, found_suite, subsuite, top_simpoint_only, workloads_data=workloads_data):
                                 tasks.append((config, found_suite, subsuite, workload, str(cid)))
 


### PR DESCRIPTION
Hi, @5surim 

The newly added "_scarab_sim_githash" has been parsing like workload name.
So, I could see an error with "sci --visualize".

```c++
mkim293@bohr1:~/seop/scarab-infra$ python3 -c "
import json
with open('workloads/workloads_db.json') as f:
    data = json.load(f)
print(list(data['spec2017']['rate_int_v2'].keys())[:5])
"
['_scarab_sim_githash', 'perlbench_r', 'perlbench_r_2', 'perlbench_r_3', 'gcc_r']
``` 

I’ve introduced a few lines to prevent issues where a simple string(_scarab_sim_githash) is treated as a workload instance.

Thanks.