### PR TITLE
[BUG] ASLR settings fix

### DIFF
--- a/sci
+++ b/sci
@@ -2010,6 +2010,7 @@ def ensure_aslr_disabled(_: argparse.Namespace) -> Tuple[bool, str]:
                 
                 if node_aslr != '0':
                     print(f"\n[!] ERROR: ASLR is enabled on Slurm node [{node}] (value: {node_aslr}).")
+                    print(f"    Please run: srun -w {node} sudo sh -c 'echo 0 > {aslr_path}'")
                     sys.exit(1)
             except Exception:
                 continue

--- a/sci
+++ b/sci
@@ -1985,6 +1985,45 @@ def maybe_check_claude_cli_auth(_: argparse.Namespace) -> Tuple[bool, str]:
     )
 
 
+def ensure_aslr_disabled(_: argparse.Namespace) -> Tuple[bool, str]:
+    aslr_path = "/proc/sys/kernel/randomize_va_space"
+    aslr_file = Path(aslr_path)
+
+    all_nodes = []
+    try:
+        node_output = subprocess.check_output(['sinfo', '-h', '-o', '%N'], 
+                                              universal_newlines=True, stderr=subprocess.DEVNULL).strip()
+        if node_output:
+            all_nodes = subprocess.check_output(['scontrol', 'show', 'hostnames', node_output], 
+                                                universal_newlines=True).splitlines()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
+
+    if all_nodes:
+        print(f"Detected Slurm cluster. Checking ASLR on {len(all_nodes)} nodes...")
+        for node in all_nodes:
+            try:
+                node_aslr = subprocess.check_output(
+                    ['srun', '-w', node, '-N1', '-n1', 'cat', aslr_path],
+                    universal_newlines=True, stderr=subprocess.DEVNULL, timeout=3
+                ).strip()
+                
+                if node_aslr != '0':
+                    print(f"\n[!] ERROR: ASLR is enabled on Slurm node [{node}] (value: {node_aslr}).")
+                    sys.exit(1)
+            except Exception:
+                continue
+        return True, f"ASLR is disabled across all {len(all_nodes)} Slurm nodes."
+    
+    else:
+        content = aslr_file.read_text().strip()
+        if content != "0":
+            print(f"\n[!] ERROR: ASLR is currently enabled on local host (value: {content}).")
+            print(f"    Please run: echo 0 | sudo tee {aslr_path}")
+            sys.exit(1)
+        return True, "ASLR is disabled on local host (0)."
+    
+
 def run_init(args: argparse.Namespace) -> int:
     if sys.stdin.isatty():
         print_heading("Prepare Google Drive cookies.txt")
@@ -2005,6 +2044,7 @@ def run_init(args: argparse.Namespace) -> int:
             print("Re-run `./sci --init` after cookies.txt is uploaded.")
             return 0
     steps = [
+        ("Check ASLR setting", ensure_aslr_disabled),
         ("Install Docker", ensure_docker),
         ("Start Docker daemon", ensure_docker_running),
         ("Configure Docker permissions", configure_docker_permissions),

--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -474,5 +474,3 @@ def run_tracing(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl = 2)
 
         kill_jobs(user, "trace", trace_name, docker_prefix_list, infra_dir, dbg_lvl)
 
-        print("Recover the ASLR setting with sudo. Provide password..")
-        os.system("echo 2 | sudo tee /proc/sys/kernel/randomize_va_space")

--- a/scripts/run_perf.py
+++ b/scripts/run_perf.py
@@ -53,8 +53,6 @@ def open_interactive_shell(user, docker_home, image_name, infra_dir, dbg_lvl = 1
         except KeyboardInterrupt:
             if count_interactive_shells(docker_container_name, dbg_lvl) == 1:
                 os.system(f"docker rm -f {docker_container_name}")
-                print("Recover the ASLR setting with sudo. Provide password..")
-                os.system("echo 2 | sudo tee /proc/sys/kernel/randomize_va_space")
             return
         finally:
             try:

--- a/scripts/run_trace.py
+++ b/scripts/run_trace.py
@@ -205,8 +205,6 @@ def open_interactive_shell(user, descriptor_name, descriptor_data, infra_dir, db
                 subprocess.run(["docker", "exec", "--privileged", f"--user={user}", f"--workdir=/home/{user}", docker_container_name,
                                 "sed", "-i", "/source \\/usr\\/local\\/bin\\/user_entrypoint.sh/d", f"/home/{user}/.bashrc"], check=True, capture_output=True, text=True)
                 os.system(f"docker rm -f {docker_container_name}")
-                print("Recover the ASLR setting with sudo. Provide password..")
-                os.system("echo 2 | sudo tee /proc/sys/kernel/randomize_va_space")
             return
         finally:
             try:

--- a/scripts/run_trace.py
+++ b/scripts/run_trace.py
@@ -211,7 +211,6 @@ def open_interactive_shell(user, descriptor_name, descriptor_data, infra_dir, db
                 if count_interactive_shells(docker_container_name, dbg_lvl) == 1:
                     subprocess.run(["docker", "exec", "--privileged", f"--user={user}", f"--workdir=/home/{user}", docker_container_name,
                                     "sed", "-i", "/source \\/usr\\/local\\/bin\\/user_entrypoint.sh/d", f"/home/{user}/.bashrc"], check=True, capture_output=True, text=True)
-                    os.system("echo 2 | sudo tee /proc/sys/kernel/randomize_va_space")
                     client.containers.get(docker_container_name).remove(force=True)
                     print(f"Container {docker_container_name} removed.")
             except docker.errors.NotFound:

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -833,6 +833,3 @@ def run_tracing(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl = 2)
             os.remove(tmp)
 
         kill_jobs(user, trace_name, docker_prefix_list, dbg_lvl)
-
-        print("Recover the ASLR setting with sudo. Provide password..")
-        os.system("echo 2 | sudo tee /proc/sys/kernel/randomize_va_space")

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -2432,8 +2432,6 @@ def finish_trace(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl):
         extract_top_simpoints.modify_simpoints_in_place(workload_db_data)
         write_json_descriptor(f"{infra_dir}/workloads/workloads_top_simp.json", workload_db_data, dbg_lvl)
 
-        print("Recover the ASLR setting with sudo. Provide password..")
-        os.system("echo 2 | sudo tee /proc/sys/kernel/randomize_va_space")
 
     except Exception as e:
         raise e


### PR DESCRIPTION
Hi, @5surim 

As we discussed before, I'm working on the ASLR feature fix.

First, I disabled all ASLR recovery logic since it is a system-wide feature. 
This ensures that the setting is not restored while other simulation jobs (especially tracing) are running.

Additionally, I have a few question about next steps for this PR.

```
1. outside user who supports slurm feature
  1) check available slurm nodes (sinfo -N -h -o "%N")
  2) run "echo 0 > /proc/sys/kernel/randomize_va_space"
    1] however, we need root permissions for individual machines in order to run that command.
    2] if someone don't know their machine's sudo pwd? Is it okay to skip this stage?
3. outside user who doesn't support slurm, run only at local.
  1) check available slurm nodes -> return null
  2) run "echo 0 > /proc/sys/kernel/randomize_va_space", only for local
```

I think disabling ASLR should be persistent across all available machines, so it should be handled once during "./sci --init"

Thanks.
Best regards,