### PR TITLE
Remove deprecated fuzzy option for gdown

### DIFF
--- a/sci
+++ b/sci
@@ -645,7 +645,6 @@ def build_gdown_command(file_id: str, output_path: Path, *, use_conda: bool) -> 
     else:
         cmd.append("gdown")
 
-    cmd.append("--fuzzy")
     cmd.extend([url, "-O", str(output_path)])
     return cmd
 


### PR DESCRIPTION
The workflow fails because the option is not longer available. It should no longer be needed