### PR TITLE
Enable new lint-scarab option to run linter on scarab

### DIFF
--- a/common/Dockerfile.common
+++ b/common/Dockerfile.common
@@ -24,7 +24,10 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
     linux-tools-generic \
     gdb \
     graphviz \
-    curl
+    curl \
+    clang-tidy-18 \
+ && update-alternatives --install /usr/bin/clang-tidy clang-tidy \
+      /usr/bin/clang-tidy-18 100
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
 RUN apt install -y nodejs

--- a/sci
+++ b/sci
@@ -1693,23 +1693,24 @@ def run_build_scarab(descriptor_name: str) -> int:
 
 
 def run_lint_scarab(descriptor_name: str) -> int:
-    """Build scarab and then run clang-tidy inside the same container image.
+    """Run clang-tidy inside the scarab container against an existing build.
 
-    Rationale: clang-tidy needs the full set of -I/-D flags used by the real
-    build to parse every TU. The scarab build container already has PIN's
-    XED, boost, gtest, etc. installed, and produces
-    build/<mode>/compile_commands.json (via
-    `set(CMAKE_EXPORT_COMPILE_COMMANDS ON)` in src/CMakeLists.txt).
-    We reuse that exact environment so CI and local lint runs produce
-    identical diagnostics.
+    This command does NOT build scarab; run `./sci --build-scarab <descriptor>`
+    first (or as a prior CI step). We deliberately keep the two commands
+    separate so linting does not redundantly re-validate / re-link artifacts
+    on every invocation.
+
+    Prereqs:
+      - `build/<mode>/compile_commands.json` exists under scarab_path/src
+        (enabled by `set(CMAKE_EXPORT_COMPILE_COMMANDS ON)` in
+        src/CMakeLists.txt). Produced by --build-scarab.
+      - The docker image tagged `<prefix>:<scarab-infra-githash>` is already
+        available locally (also guaranteed by --build-scarab).
+
+    If the compile DB is missing the container-side script fails fast with
+    a clear error; if the image is missing docker run will fail. Both error
+    paths explicitly point the user at `--build-scarab`.
     """
-    # Step 1: run the normal build, producing compile_commands.json.
-    rc = run_build_scarab(descriptor_name)
-    if rc != 0:
-        return rc
-
-    # Step 2: resolve descriptor fields needed to start a container with the
-    # same image.
     infra_utils = load_infra_utilities()
     descriptor_path, descriptor = read_descriptor(descriptor_name)
     if descriptor.get("descriptor_type") != "simulation":

--- a/sci
+++ b/sci
@@ -1692,6 +1692,91 @@ def run_build_scarab(descriptor_name: str) -> int:
     return 0
 
 
+def run_lint_scarab(descriptor_name: str) -> int:
+    """Build scarab and then run clang-tidy inside the same container image.
+
+    Rationale: clang-tidy needs the full set of -I/-D flags used by the real
+    build to parse every TU. The scarab build container already has PIN's
+    XED, boost, gtest, etc. installed, and produces
+    build/<mode>/compile_commands.json (via
+    `set(CMAKE_EXPORT_COMPILE_COMMANDS ON)` in src/CMakeLists.txt).
+    We reuse that exact environment so CI and local lint runs produce
+    identical diagnostics.
+    """
+    # Step 1: run the normal build, producing compile_commands.json.
+    rc = run_build_scarab(descriptor_name)
+    if rc != 0:
+        return rc
+
+    # Step 2: resolve descriptor fields needed to start a container with the
+    # same image.
+    infra_utils = load_infra_utilities()
+    descriptor_path, descriptor = read_descriptor(descriptor_name)
+    if descriptor.get("descriptor_type") != "simulation":
+        raise StepError("`--lint-scarab` currently supports simulation descriptors only.")
+
+    scarab_path = descriptor.get("scarab_path")
+    if not scarab_path or not Path(scarab_path).exists():
+        raise StepError(f"scarab_path '{scarab_path}' does not exist.")
+    docker_home = descriptor.get("root_dir")
+    if not docker_home or not Path(docker_home).exists():
+        raise StepError(f"root_dir '{docker_home}' does not exist.")
+
+    simulations = descriptor.get("simulations") or []
+    if not simulations:
+        raise StepError("Descriptor contains no simulations to derive docker image.")
+    workloads_path = REPO_ROOT / "workloads" / "workloads_db.json"
+    workloads = infra_utils.read_descriptor_from_json(str(workloads_path))
+    if workloads is None:
+        raise StepError("Failed to read workloads/workloads_db.json.")
+    docker_prefix_list = infra_utils.get_image_list(simulations, workloads)
+    if not docker_prefix_list:
+        raise StepError("Unable to determine docker image from descriptor simulations.")
+    docker_prefix = docker_prefix_list[0]
+
+    build_mode: str = descriptor.get("scarab_build") or "opt"
+
+    try:
+        githash = run_command(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture=True, check=True, input_data=None,
+        )
+    except StepError as exc:
+        raise StepError("Failed to obtain scarab-infra git hash.") from exc
+    if githash is None:
+        raise StepError("Git hash query returned no output.")
+    githash = githash.strip()
+
+    user = getpass.getuser()
+
+    print_heading("Lint Scarab")
+    info(f"Descriptor: {descriptor_path.name}")
+    info(f"Image: {docker_prefix}:{githash}")
+    info(f"Build mode: {build_mode}")
+    info(f"Scarab path: {scarab_path}")
+
+    try:
+        infra_utils.lint_scarab_binary(
+            user, scarab_path, build_mode, docker_home, docker_prefix,
+            githash, str(REPO_ROOT), dbg_lvl=2,
+        )
+    except RuntimeError as exc:
+        # lint_scarab_binary raises RuntimeError when findings exist or the
+        # docker workflow fails; surface a clean exit code rather than a
+        # traceback.
+        info(str(exc))
+        return 1
+    except subprocess.CalledProcessError as exc:
+        raise StepError(
+            f"clang-tidy lint failed (exit {exc.returncode}).\nSTDOUT:{exc.stdout}\nSTDERR:{exc.stderr}"
+        ) from exc
+    except Exception as exc:  # noqa: BLE001
+        raise StepError(f"clang-tidy lint failed: {exc}") from exc
+
+    info("clang-tidy lint completed successfully.")
+    return 0
+
+
 def run_build_image(workload_group: str) -> int:
     if not workload_group:
         raise StepError("Provide a workload group name (see ./sci --list).")
@@ -4205,6 +4290,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Build scarab sources defined in json/<DESCRIPTOR>.json.",
     )
     parser.add_argument(
+        "--lint-scarab",
+        dest="lint_scarab",
+        metavar="DESCRIPTOR",
+        help="Build scarab and run clang-tidy against the resulting "
+             "compile_commands.json inside the same container image. "
+             "Exits non-zero on any enabled-check finding.",
+    )
+    parser.add_argument(
         "--build-image",
         dest="build_image",
         metavar="WORKLOAD_GROUP",
@@ -4292,6 +4385,7 @@ def main() -> int:
         bool(args.init),
         bool(args.ci_init),
         bool(args.build_scarab),
+        bool(args.lint_scarab),
         bool(args.build_image),
         bool(args.list),
         bool(args.interactive),
@@ -4312,6 +4406,7 @@ def main() -> int:
 
     needs_env = any([
         args.build_scarab,
+        args.lint_scarab,
         args.build_image,
         args.interactive,
         args.trace,
@@ -4331,6 +4426,12 @@ def main() -> int:
     if args.build_scarab:
         try:
             return run_build_scarab(args.build_scarab)
+        except StepError as exc:
+            print(exc)
+            return 1
+    if args.lint_scarab:
+        try:
+            return run_lint_scarab(args.lint_scarab)
         except StepError as exc:
             print(exc)
             return 1

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -434,6 +434,137 @@ def build_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_pre
         raise exception
 
 
+def lint_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_prefix, githash, infra_dir, dbg_lvl=1):
+    """Run clang-tidy inside the scarab build container against the compile DB
+    produced by the latest scarab build.
+
+    Enabled checks, excluded directories, and the clang-tidy version itself
+    are defined here so every caller (CI, local dev) sees identical results.
+
+    Prerequisites:
+    - The caller has already built scarab (e.g. via build_scarab_binary), so
+      {scarab_path}/src/build/{scarab_build}/compile_commands.json exists.
+      This is guaranteed when src/CMakeLists.txt contains
+      `set(CMAKE_EXPORT_COMPILE_COMMANDS ON)`.
+
+    Returns: 0 on clean, 1 on any finding or infra failure.
+    """
+    local_uid = os.getuid()
+    local_gid = os.getgid()
+    build_mode = scarab_build if scarab_build else "opt"
+    docker_container_name = f"{docker_prefix}_{user}_scarab_lint"
+
+    # Keep the enabled check set narrow. Expand intentionally by editing this
+    # list; every consumer of --lint-scarab picks up the change automatically.
+    checks = "-*,cppcoreguidelines-pro-type-member-init"
+    # Directories we never lint (vendored third-party / external toolchain).
+    exclude_re = r"^(deps|ramulator|pin)/"
+    # Same regex, expressed so that paths from clang-tidy diagnostics (which
+    # are absolute, e.g. /scarab/src/ramulator/...) are also filtered out
+    # when they leak in via transitive #includes.
+    diag_exclude_re = r"/(deps|ramulator|pin)/"
+
+    lint_script = (
+        "set -o pipefail\n"
+        "cd /scarab/src\n"
+        "\n"
+        "# Fail fast if the image doesn't have clang-tidy: otherwise xargs\n"
+        "# silently emits 'command not found' for every TU and the grep for\n"
+        "# findings yields zero results, making the step appear green when in\n"
+        "# reality no linting ran.\n"
+        "if ! command -v clang-tidy >/dev/null 2>&1; then\n"
+        "  echo 'ERROR: clang-tidy not available in this container image.' >&2\n"
+        "  echo 'Rebuild the scarab-infra docker image (e.g. remove the cached' >&2\n"
+        "  echo 'tag and rerun --build-scarab) so the Dockerfile.common changes' >&2\n"
+        "  echo 'that install clang-tidy-18 take effect.' >&2\n"
+        "  exit 127\n"
+        "fi\n"
+        "\n"
+        f"BUILD_DIR=build/{build_mode}\n"
+        "if [ ! -f \"$BUILD_DIR/compile_commands.json\" ]; then\n"
+        "  echo \"ERROR: $BUILD_DIR/compile_commands.json missing; ensure CMakeLists.txt has set(CMAKE_EXPORT_COMPILE_COMMANDS ON)\" >&2\n"
+        "  exit 2\n"
+        "fi\n"
+        "\n"
+        "LOG=/tmp/clang-tidy.log\n"
+        "FINDINGS=/tmp/clang-tidy-findings.txt\n"
+        ": > \"$LOG\"\n"
+        "\n"
+        f"mapfile -t FILES < <(git ls-files '*.cc' | grep -vE '{exclude_re}' | sort)\n"
+        "echo \"Linting ${#FILES[@]} translation units with $(clang-tidy --version | head -n1)...\"\n"
+        "\n"
+        "printf '%s\\n' \"${FILES[@]}\" \\\n"
+        "  | xargs -P \"$(nproc)\" -I{} -n 1 \\\n"
+        "      clang-tidy \\\n"
+        "        -p \"$BUILD_DIR\" \\\n"
+        "        -quiet \\\n"
+        f"        -checks='{checks}' \\\n"
+        "        --header-filter='.*' \\\n"
+        "        {} 2>&1 | tee -a \"$LOG\" || true\n"
+        "\n"
+        "{ grep -E 'warning:.*\\[cppcoreguidelines-pro-type-member-init\\]' \"$LOG\" \\\n"
+        f"    | grep -vE '{diag_exclude_re}' \\\n"
+        "    | sort -u; } > \"$FINDINGS\" || true\n"
+        "\n"
+        "echo '=== member-init findings (post-filter) ==='\n"
+        "if [ -s \"$FINDINGS\" ]; then\n"
+        "  cat \"$FINDINGS\"\n"
+        "  echo '=========================================='\n"
+        "  exit 1\n"
+        "fi\n"
+        "echo '<none>'\n"
+        "echo '=========================================='\n"
+        "echo 'clang-tidy clean.'\n"
+    )
+
+    info(f"Linting scarab with image {docker_prefix}:{githash}...", dbg_lvl)
+    exception = None
+    try:
+        subprocess.run(
+            ["docker", "run",
+             "-e", f"user_id={local_uid}",
+             "-e", f"group_id={local_gid}",
+             "-e", f"username={user}",
+             "-dit", "--name", f"{docker_container_name}",
+             "--mount", f"type=bind,source={docker_home},target=/home/{user},readonly=false",
+             "--mount", f"type=bind,source={scarab_path},target=/scarab,readonly=false",
+             f"{docker_prefix}:{githash}", "/bin/bash"],
+            check=True, capture_output=True, text=True)
+        subprocess.run(
+            ["docker", "cp", f"{infra_dir}/common/scripts/root_entrypoint.sh",
+             f"{docker_container_name}:/usr/local/bin"],
+            check=True, capture_output=True, text=True)
+        subprocess.run(
+            ["docker", "cp", f"{infra_dir}/common/scripts/user_entrypoint.sh",
+             f"{docker_container_name}:/usr/local/bin"],
+            check=True, capture_output=True, text=True)
+        subprocess.run(
+            ["docker", "exec", "--privileged", f"{docker_container_name}",
+             "/bin/bash", "-c", "/usr/local/bin/root_entrypoint.sh"],
+            check=True, capture_output=True, text=True)
+
+        # Stream output so the step log reflects progress in real time.
+        lint_result = subprocess.run(
+            ["docker", "exec",
+             f"--user={user}", f"--workdir=/home/{user}",
+             f"{docker_container_name}",
+             "/bin/bash", "-c", lint_script],
+            text=True)
+        if lint_result.returncode != 0:
+            exception = RuntimeError(
+                f"clang-tidy lint failed (exit {lint_result.returncode})"
+            )
+    except Exception as e:
+        exception = e
+    finally:
+        subprocess.run(
+            ["docker", "rm", "-f", f"{docker_container_name}"],
+            check=False, capture_output=True, text=True)
+
+    if exception is not None:
+        raise exception
+
+
 def _scarab_repo_clean(scarab_path: str) -> bool:
     try:
         status_output = subprocess.check_output(

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -482,7 +482,9 @@ def lint_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_pref
         "\n"
         f"BUILD_DIR=build/{build_mode}\n"
         "if [ ! -f \"$BUILD_DIR/compile_commands.json\" ]; then\n"
-        "  echo \"ERROR: $BUILD_DIR/compile_commands.json missing; ensure CMakeLists.txt has set(CMAKE_EXPORT_COMPILE_COMMANDS ON)\" >&2\n"
+        "  echo \"ERROR: $BUILD_DIR/compile_commands.json missing.\" >&2\n"
+        "  echo 'Run `./sci --build-scarab <descriptor>` first; CMakeLists.txt has' >&2\n"
+        "  echo 'CMAKE_EXPORT_COMPILE_COMMANDS ON so any build emits the compile DB.' >&2\n"
         "  exit 2\n"
         "fi\n"
         "\n"
@@ -517,7 +519,19 @@ def lint_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_pref
         "echo 'clang-tidy clean.'\n"
     )
 
-    info(f"Linting scarab with image {docker_prefix}:{githash}...", dbg_lvl)
+    # Preflight: if the image isn't present we want a clear message pointing
+    # at --build-scarab, not a cryptic `docker run` failure. We deliberately
+    # do NOT rebuild the image here: --lint-scarab is supposed to be a fast
+    # linter, not a stealth image builder.
+    image_ref = f"{docker_prefix}:{githash}"
+    if not image_exist(image_ref):
+        raise RuntimeError(
+            f"Docker image '{image_ref}' not found locally. "
+            "Run `./sci --build-scarab <descriptor>` first to build scarab "
+            "and prepare this image."
+        )
+
+    info(f"Linting scarab with image {image_ref}...", dbg_lvl)
     exception = None
     try:
         subprocess.run(
@@ -528,7 +542,7 @@ def lint_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_pref
              "-dit", "--name", f"{docker_container_name}",
              "--mount", f"type=bind,source={docker_home},target=/home/{user},readonly=false",
              "--mount", f"type=bind,source={scarab_path},target=/scarab,readonly=false",
-             f"{docker_prefix}:{githash}", "/bin/bash"],
+             image_ref, "/bin/bash"],
             check=True, capture_output=True, text=True)
         subprocess.run(
             ["docker", "cp", f"{infra_dir}/common/scripts/root_entrypoint.sh",


### PR DESCRIPTION
perform linting in docker container to address environment/versioning mismatch. Can be run locally or via git workflow (./sci --lint-scarab exp.json)