### PR TITLE
Fix job submission scalability issue

### DIFF
--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -24,6 +24,7 @@ from .utilities import (
         get_weight_by_cluster_id,
         image_exist,
         check_can_skip,
+        get_old_job_logs,
         remove_old_job_logs,
         print_simulation_status_summary,
         normalize_simulations,
@@ -144,8 +145,10 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
     max_processes = int(available_cores * 0.9)
     processes = set()
     process_logs = {}
-    tmp_files = []
-    log_files = []
+    tmp_files = set()
+    remove_jobs = set()
+    log_dir = os.path.join(docker_home, "simulations", experiment_name, "logs")
+    log_files = set()
     log_index = 0
 
     dont_collect = True
@@ -203,7 +206,7 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                     # Create temp file with run command and run it
                     filename = f"{docker_container_name}_tmp_run.sh"
 
-                    if check_can_skip(descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, sim_mode, user, dbg_lvl=dbg_lvl):
+                    if check_can_skip(descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, dbg_lvl=dbg_lvl):
                         info(f"Skipping {workload} with config {config_key} and cluster id {cluster_id}", dbg_lvl)
                         continue
 
@@ -213,17 +216,16 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                                                  docker_home, githash, config_key, config, sim_mode, scarab_binary,
                                                  seg_size, architecture, cluster_id, warmup, trace_warmup, trace_type,
                                                  trace_file, env_vars, bincmd, client_bincmd, filename, infra_dir, application_dir)
-                    tmp_files.append(filename)
+                    tmp_files.add(filename)
                     command = '/bin/bash ' + filename
-                    _log_dir = os.path.join(docker_home, "simulations", experiment_name, "logs")
-                    remove_old_job_logs(_log_dir, config_key, suite, subsuite, workload, cluster_id)
+                    remove_jobs.add((config_key, suite, subsuite, workload, cluster_id))
                     log_path = os.path.join(
-                        _log_dir,
+                        log_dir,
                         f"job_{log_index}.out",
                     )
                     log_index += 1
                     log_handle = open(log_path, "w")
-                    log_files.append(log_handle)
+                    log_files.add(log_handle)
                     process = subprocess.Popen(
                         "exec " + command,
                         stdout=log_handle,

--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -276,6 +276,10 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
             return
         os.makedirs(os.path.join(docker_home, "simulations", experiment_name, "logs"), exist_ok=True)
 
+        # Collect old job logs before submitting new jobs
+        experiment_dir = f"{descriptor_data['root_dir']}/simulations/{experiment_name}"
+        old_job_logs = get_old_job_logs(f"{experiment_dir}/logs")
+
         print("Submitting jobs...")
         # Iterate over each workload and config combo
         simulations = normalize_simulations(simulations)
@@ -341,6 +345,8 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
             info(f"Removing temporary run script {tmp}", dbg_lvl)
             os.remove(tmp)
 
+        remove_old_job_logs(old_job_logs, remove_jobs, dbg_lvl)
+
         finish_simulation(user, docker_home, descriptor_path, descriptor_data['root_dir'], experiment_name, image_tag_list, [], dont_collect=dont_collect)
 
     except Exception as e:
@@ -356,6 +362,8 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
         for tmp in tmp_files:
             info(f"Removing temporary run script {tmp}", dbg_lvl)
             os.remove(tmp)
+
+        remove_old_job_logs(old_job_logs, remove_jobs, dbg_lvl)
 
         infra_dir = subprocess.check_output(["pwd"]).decode("utf-8").split("\n")[0]
         print(infra_dir)
@@ -379,8 +387,8 @@ def run_tracing(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl = 2)
     available_cores = os.cpu_count()
     max_processes = int(available_cores * 0.9)
     processes = set()
-    tmp_files = []
-    log_files = []
+    tmp_files = set()
+    log_files = set()
 
     def run_single_trace(workload, image_name, trace_name, env_vars, binary_cmd, client_bincmd, trace_type, drio_args, clustering_k, infra_dir, application_dir):
         try:
@@ -399,14 +407,14 @@ def run_tracing(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl = 2)
                                                workload, image_name, trace_name, traces_dir, docker_home,
                                                env_vars, binary_cmd, client_bincmd, simpoint_mode, drio_args,
                                                clustering_k, filename, infra_dir, application_dir)
-            tmp_files.append(filename)
+            tmp_files.add(filename)
             command = '/bin/bash ' + filename
             subprocess.run(["mkdir", "-p", f"{docker_home}/simpoint_flow/{trace_name}/{workload}"], check=True, capture_output=True, text=True)
             log_out = f"{docker_home}/simpoint_flow/{trace_name}/{workload}/log.out"
             log_err = f"{docker_home}/simpoint_flow/{trace_name}/{workload}/log.err"
             out = open(log_out, "w")
             err = open(log_err, "w")
-            log_files.append((out, err))
+            log_files.add((out, err))
             process = subprocess.Popen(command, stdout=out, stderr=err, shell=True, preexec_fn=os.setsid)
             processes.add(process)
             info(f"Running command '{command}'", dbg_lvl)

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -32,6 +32,7 @@ from .utilities import (
         get_weight_by_cluster_id,
         image_exist,
         check_can_skip,
+        get_old_job_logs,
         remove_old_job_logs,
         print_simulation_status_summary,
         run_on_node,
@@ -486,6 +487,14 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
     total_sims = 0
     docker_prefix_list = get_image_list(simulations, workloads_data)
 
+    slurm_running_sims = check_slurm_task_queued_or_running(docker_prefix_list, experiment_name, user, dbg_lvl)
+    running_sims = set()
+    for node_list in slurm_running_sims.values():
+        running_sims |= set(node_list)
+
+    tmp_files = set()
+    remove_jobs = set()
+
     def run_single_workload(suite, subsuite, workload, exp_cluster_id, sim_mode, warmup):
         try:
             docker_prefix = get_docker_prefix(sim_mode, workloads_data[suite][subsuite][workload]["simulation"])
@@ -539,6 +548,18 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
 
                     docker_container_name = f"{docker_prefix}_{suite}_{subsuite}_{workload}_{experiment_name}_{config_key.replace("/", "-")}_{cluster_id}_{sim_mode}_{user}"
 
+                    if docker_container_name in running_sims:
+                        # Job is in the queue, it will be run shortly.
+                        info(f"Job for {config_key} for workload {workload} is in the queue. Other script will run it.", dbg_lvl)
+                        continue
+
+                    # Create temp file with run command and run it
+                    filename = f"{docker_container_name}_tmp_run.sh"
+
+                    if check_can_skip(descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, dbg_lvl=dbg_lvl):
+                        info(f"Skipping {workload} with config {config_key} and cluster id {cluster_id}", dbg_lvl)
+                        continue
+
                     # TODO: Notification when a run fails, point to output file and command that caused failure
                     # Add help (?)
                     # Look into squeue -o https://slurm.schedmd.com/squeue.html
@@ -569,17 +590,6 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
 
                     sbatch_cmd = generate_sbatch_command(experiment_dir, slurm_options=slurm_options, mem_mb=mem_mb)
 
-                    # Create temp file with run command and run it
-                    filename = f"{docker_container_name}_tmp_run.sh"
-                    slurm_running_sims = check_slurm_task_queued_or_running(docker_prefix_list, experiment_name, user, dbg_lvl)
-                    running_sims = []
-                    for node_list in slurm_running_sims.values():
-                        running_sims += node_list
-
-                    if check_can_skip(descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, sim_mode, user, slurm_queue=running_sims, dbg_lvl=dbg_lvl):
-                        info(f"Skipping {workload} with config {config_key} and cluster id {cluster_id}", dbg_lvl)
-                        continue
-
                     if fallback_mb is not None:
                         print(f"WARN: no base_memory_mb_by_mode entry for {suite}/{subsuite}/{workload} cluster={cluster_id} sim_mode={sim_mode} config={config_key}, using fallback={fallback_mb}MB + overhead={overhead_mb}MB = {mem_mb}MB")
 
@@ -589,9 +599,9 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                                                  docker_home, githash, config_key, config, sim_mode, binary_name,
                                                  seg_size, architecture, cluster_id, warmup, trace_warmup, trace_type,
                                                  trace_file, env_vars, bincmd, client_bincmd, filename, infra_dir, application_dir, slurm=True)
-                    tmp_files.append(filename)
+                    tmp_files.add(filename)
 
-                    remove_old_job_logs(f"{experiment_dir}/logs", config_key, suite, subsuite, workload, cluster_id)
+                    remove_jobs.add((config_key, suite, subsuite, workload, cluster_id))
 
                     result = subprocess.run(["touch", f"{experiment_dir}/logs/job_%j.out"], capture_output=True, text=True, check=True)
                     result = subprocess.run((sbatch_cmd + filename).split(" "), capture_output=True, text=True)
@@ -605,7 +615,6 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
             print(f"Error running workload {workload}: {e}")
             raise e
 
-    tmp_files = []
     try:
         # Get user for commands
         user = subprocess.check_output("whoami").decode('utf-8')[:-1]
@@ -649,10 +658,12 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
         except Exception:
             memory_db = workloads_data
 
+        # Collect old job logs before submitting new jobs
+        old_job_logs = get_old_job_logs(f"{experiment_dir}/logs")
+
         print("Submitting jobs...")
         # Iterate over each workload and config combo
         simulations = normalize_simulations(simulations)
-        tmp_files = []
         for simulation in simulations:
             suite = simulation["suite"]
             subsuite = simulation["subsuite"]
@@ -712,6 +723,8 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
             info(f"Removing temporary run script {tmp}", dbg_lvl)
             os.remove(tmp)
 
+        remove_old_job_logs(old_job_logs, remove_jobs, dbg_lvl)
+
         #finish_simulation(user, docker_home, descriptor_path, descriptor_data['root_dir'], experiment_name, image_tag_list, slurm_ids)
 
         # TODO: check resource capping policies, add kill/info options
@@ -725,6 +738,8 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
         for tmp in tmp_files:
             info(f"Removing temporary run script {tmp}", dbg_lvl)
             os.remove(tmp)
+
+        remove_old_job_logs(old_job_logs, remove_jobs, dbg_lvl)
 
         kill_jobs(user, experiment_name, docker_prefix_list, dbg_lvl)
 
@@ -743,7 +758,7 @@ def run_tracing(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl = 2)
         if image_name not in docker_prefix_list:
             docker_prefix_list.append(image_name)
 
-    tmp_files = []
+    tmp_files = set()
 
     def run_single_trace(workload, image_name, trace_name, env_vars, binary_cmd, client_bincmd, trace_type, drio_args, clustering_k, application_dir, slurm_options):
         try:
@@ -764,7 +779,7 @@ def run_tracing(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl = 2)
                                                workload, image_name, trace_name, traces_dir, docker_home,
                                                env_vars, binary_cmd, client_bincmd, simpoint_mode, drio_args,
                                                clustering_k, filename, infra_dir, application_dir, slurm=True)
-            tmp_files.append(filename)
+            tmp_files.add(filename)
 
             result = subprocess.run((sbatch_cmd + filename).split(" "), capture_output=True, text=True)
             _print_sbatch_output(result)

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1957,29 +1957,44 @@ def parse_job_log_header(first_line: str) -> Optional[Tuple[str, str, str, str, 
     suite, subsuite, workload = path_parts
     return (config, suite, subsuite, workload, cluster_id_str)
 
-
-def remove_old_job_logs(log_dir: str, config_key: str, suite: str, subsuite: str, workload: str, cluster_id) -> int:
-    """Remove old job log files matching the given (config, workload, simpoint).
-
-    Scans ``log_dir`` for ``job_*.out`` files whose header matches the target
-    key and deletes them so that stale logs don't inflate counts in --status.
-
-    Returns the number of removed files.
+def get_old_job_logs(log_dir: str) -> dict[Tuple[str, str, str, str, str], list[Path]]:
+    """
+    Returns ``job_*.out`` files that can be passed to ``remove_old_job_logs``
+    as a dictionary mapping (config, suite, subsuite, workload, cluster_id) to file paths.
     """
     log_path = Path(log_dir)
     if not log_path.is_dir():
-        return 0
-    target_key = (config_key, suite, subsuite, workload, str(cluster_id))
-    removed = 0
+        return {}
+    old_job_logs = {}
     for old_log in log_path.glob("job_*.out"):
         try:
             with old_log.open(encoding="utf-8", errors="replace") as fh:
                 hdr = parse_job_log_header(fh.readline().strip())
-            if hdr == target_key:
-                old_log.unlink()
-                removed += 1
+                old_job_logs.setdefault(hdr, []).append(old_log)
         except OSError:
             pass
+    return old_job_logs
+
+def remove_old_job_logs(
+        old_job_logs: dict[Tuple[str, str, str, str, str], list[Path]],
+        target_jobs: set[Tuple[str, str, str, str, str]], dbg_lvl = 1) -> int:
+    """Remove old job log files matching the given target jobs.
+
+    Scans given old ``job_*.out`` files whose header matches the target
+    key and deletes them so that stale logs don't inflate counts in --status.
+
+    Returns the number of removed files.
+    """
+    assert isinstance(old_job_logs, dict)
+    info("Removing old job logs", dbg_lvl)
+    removed = 0
+    for target in target_jobs:
+        for old_log in old_job_logs.get(target, []):
+            try:
+                old_log.unlink()
+                removed += 1
+            except OSError:
+                pass
     return removed
 
 
@@ -2810,7 +2825,7 @@ def clean_failed_run (descriptor_data, config_key, suite, subsuite, workload, ex
     patterns_to_clean = ["*.csv", "*.out", "*.in", "*.csv.warmup", "*.out.warmup", "sim.log"]
 
     try:
-        if experiment_path.exists():
+        if experiment_path.is_dir():
             for pattern in patterns_to_clean:
                 for target in experiment_path.glob(pattern):
                     if target.is_file() or target.is_symlink():
@@ -2819,44 +2834,28 @@ def clean_failed_run (descriptor_data, config_key, suite, subsuite, workload, ex
         err(f"Error cleaning files in {experiment_dir}: {e}", 1)
 
     # Wipe log file
-    log_dir =  f"{descriptor_data['root_dir']}/simulations/{descriptor_data['experiment']}/logs/"
-    log_files = os.listdir(log_dir)
+    log_dir =  Path(f"{descriptor_data['root_dir']}/simulations/{descriptor_data['experiment']}/logs/")
+    log_files = log_dir.glob("log_*.out")
     for file in log_files:
-        full_path = os.path.join(log_dir, file)
-        with open(full_path, 'r') as f:
+        with open(file, 'r') as f:
             lines = f.readlines()
 
             # Logfile will have {config} {suite}/{subsuite}/{workload} {simpoint} as header
             header = f"Running {config_key} {suite}/{subsuite}/{workload} {exp_cluster_id}\n"
             if header in lines:
                 info(f"Removing log entry for failed run: {header.strip()}", dbg_lvl)
-                os.remove(full_path)
+                file.unlink()
 
 # Check if run was already successful, and thus skippable
 # Please use as follows:
 # if check_can_skip(...):
 #     continue
-def check_can_skip (descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, sim_mode, user, slurm_queue=None, dbg_lvl=1):
+def check_can_skip (descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, dbg_lvl=1):
     # Check if it is about to be run
     if os.path.exists(filename):
         # Run script has generated run file, it will be run shortly.
         info(f"Run script for {config_key} for workload {workload} exists. Other script will run it.", dbg_lvl)
         return True
-
-    # If using slurm, check queue too
-    if not slurm_queue is None:
-        # Check each entry
-        for entry in slurm_queue:
-            # Check for following identifier. Should be of form <docker_prefix>_...as below..._<sim_mode>_<user>
-            # Docker prefix and username checked in slurm_runner
-            identifier = (
-                f"{suite}_{subsuite}_{workload}_{descriptor_data['experiment']}"
-                f"_{config_key.replace('/', '-')}_{cluster_id}_{sim_mode}_{user}"
-            )
-            if identifier in entry:
-                # Job is in the queue, it will be run shortly.
-                info(f"Job for {config_key} for workload {workload} is in the queue. Other script will run it.", dbg_lvl)
-                return True
 
     # If CSV files don't exist, clean up failed run and re-run (can skip = False)
     if check_sp_failed(descriptor_data, config_key, suite, subsuite, workload, cluster_id):


### PR DESCRIPTION
Previously, it scanned the contents of all log files for every single job to find stale logs, resulting in extremely redundant file reads. Likewise, it also swept the slurm queue for every single job. Furthermore, it checked memory allocation info for all jobs, even when a job can be skipped and that info is not used. As a result, for example, when an experiment had thousands of completed logs, it needed to spend one hour just to submit 300 jobs. This PR addresses this scalability issue by consolidating file reads and checks across all jobs into single, global operations.