### PR TITLE
Fix --status crash on list workloads

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1875,7 +1875,7 @@ def get_simulation_jobs(descriptor_data, workloads_data, docker_prefix, user, db
 def get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl = 1):
     experiment_name = descriptor_data["experiment"]
     configs = descriptor_data["configurations"]
-    simulations = descriptor_data["simulations"]
+    simulations = normalize_simulations(descriptor_data["simulations"])
 
     def get_simpoints_wrapper(suite, subsuite, workload, exp_cluster_id, sim_mode):
         if "simpoints" not in workloads_data[suite][subsuite][workload].keys():


### PR DESCRIPTION

  - get_simulation_job_identifiers in scripts/utilities.py iterated descriptor_data["simulations"] directly and crashed with TypeError: unhashable type: 'list' when a descriptor's workload field was a list (e.g., a sweep across multiple
  workloads in a single simulation entry).
  - Other callers — validate_simulation, get_simulation_jobs, get_image_list, local_runner, slurm_runner — already call normalize_simulations() to expand list-workload entries into individual entries. get_simulation_job_identifiers was
  the only outlier. Applying the same normalization here makes --status consistent with --sim.