### PR TITLE
Changed spec exec workloads to use allbench image

### DIFF
--- a/workloads/allbench_traces/Dockerfile
+++ b/workloads/allbench_traces/Dockerfile
@@ -5,5 +5,11 @@ FROM ubuntu:focal
 
 INCLUDE+ ./common/Dockerfile.common
 
+# For running Spec 2017 workloads
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    gfortran \
+    lsb-release \
+    software-properties-common
+
 # Start your application
 CMD ["/bin/bash"]

--- a/workloads/workloads_db.json
+++ b/workloads/workloads_db.json
@@ -1139,7 +1139,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/cpu2017/benchspec/CPU/compile-538-clang.sh 538.imagick_r_train",
@@ -1524,7 +1524,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"/bin/bash \\$tmpdir/cpu2017/bin/runcpu --config=memtrace --action=build 538.imagick_r",
@@ -8260,7 +8260,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/perlbench_r_base.memtrace-m64 -I\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/lib \\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/checkspam.pl 2500 5 25 11 150 1 1 1 1",
@@ -8318,7 +8318,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/perlbench_r_base.memtrace-m64 -I\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/lib \\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/diffmail.pl 4 800 10 17 19 300",
@@ -8376,7 +8376,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/perlbench_r_base.memtrace-m64 -I\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/lib \\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/splitmail.pl 6400 12 26 16 100 0",
@@ -8434,7 +8434,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/cpugcc_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-pp.c -O3 -finline-limit=0 -fif-conversion -fif-conversion2 -o \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-pp.opts-O3_-finline-limit_0_-fif-conversion_-fif-conversion2.s",
@@ -8668,7 +8668,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/cpugcc_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-pp.c -O2 -finline-limit=36000 -fpic -o \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-pp.opts-O2_-finline-limit_36000_-fpic.s",
@@ -8902,7 +8902,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/cpugcc_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-smaller.c -O3 -fipa-pta -o \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-smaller.opts-O3_-fipa-pta.s",
@@ -9136,7 +9136,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/cpugcc_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/ref32.c -O5 -o \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/ref32.opts-O5.s",
@@ -9381,7 +9381,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/cpugcc_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/ref32.c -O3 -fselective-scheduling -fselective-scheduling2 -o \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/ref32.opts-O3_-fselective-scheduling_-fselective-scheduling2.s",
@@ -9615,7 +9615,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/505.mcf_r/run/run_base_refrate_memtrace-m64.0000/mcf_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/505.mcf_r/run/run_base_refrate_memtrace-m64.0000/inp.in",
@@ -9684,7 +9684,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/520.omnetpp_r/run/run_base_refrate_memtrace-m64.0000/omnetpp_r_base.memtrace-m64 -c General -r 0",
@@ -9731,7 +9731,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/523.xalancbmk_r/run/run_base_refrate_memtrace-m64.0000/cpuxalan_r_base.memtrace-m64 -v \\$tmpdir/application/cpu2017/benchspec/CPU/523.xalancbmk_r/run/run_base_refrate_memtrace-m64.0000/t5.xml \\$tmpdir/application/cpu2017/benchspec/CPU/523.xalancbmk_r/run/run_base_refrate_memtrace-m64.0000/xalanc.xsl",
@@ -9888,7 +9888,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/x264_r_base.memtrace-m64 --pass 1 --stats \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/x264_stats.log --bitrate 1000 --frames 1000 -o \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny_New.264 \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny.yuv 1280x720",
@@ -9968,7 +9968,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/x264_r_base.memtrace-m64 --pass 2 --stats \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/x264_stats.log --bitrate 1000 --dumpyuv 200 --frames 1000 -o \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny_New.264 \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny.yuv 1280x720",
@@ -10026,7 +10026,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/x264_r_base.memtrace-m64 --seek 500 --dumpyuv 200 --frames 1250 -o \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny_New.264 \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny.yuv 1280x720",
@@ -10084,7 +10084,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/531.deepsjeng_r/run/run_base_refrate_memtrace-m64.0000/deepsjeng_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/531.deepsjeng_r/run/run_base_refrate_memtrace-m64.0000/ref.txt",
@@ -10142,7 +10142,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/541.leela_r/run/run_base_refrate_memtrace-m64.0000/leela_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/541.leela_r/run/run_base_refrate_memtrace-m64.0000/ref.sgf",
@@ -10200,7 +10200,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/548.exchange2_r/run/run_base_refrate_memtrace-m64.0000/exchange2_r_base.memtrace-m64 6",
@@ -10258,7 +10258,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/xz_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/cld.tar.xz 160 19cf30ae51eddcbefda78dd06014b4b96281456e078ca7c13e1c0c9e6aaea8dff3efb4ad6b0456697718cede6bd5454852652806a657bb56e07d61128434b474 59796407 61004416 6",
@@ -10316,7 +10316,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/xz_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/input.combined.xz 250 a841f68f38572a49d86226b7ff5baeb31bd19dc637a922a972b2e6d1257a890f6a544ecab967c313e370478c74f760eb229d4eef8a8d2836d233d3e9dd1430bf 40401484 41217675 7",
@@ -10396,7 +10396,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/xz_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/cpu2006docs.tar.xz 250 055ce243071129412e9dd0b3b69a21654033a9b723d874b2015c774fac1553d9713be561ca86f74e4f16f22e664fc17a79f30caa5ad2c04fbc447549c2810fae 23047774 23513385 6e",
@@ -10479,7 +10479,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_1 < \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_1.in",
@@ -10625,7 +10625,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_2 < \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_2.in",
@@ -10749,7 +10749,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_3 < \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_3.in",
@@ -10884,7 +10884,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_4 < \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_4.in",
@@ -11030,7 +11030,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/507.cactuBSSN_r/run/run_base_refrate_memtrace-m64.0000/cactusBSSN_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/507.cactuBSSN_r/run/run_base_refrate_memtrace-m64.0000/spec_ref.par",
@@ -11121,7 +11121,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/508.namd_r/run/run_base_refrate_memtrace-m64.0000/namd_r_base.memtrace-m64 --input \\$tmpdir/application/cpu2017/benchspec/CPU/508.namd_r/run/run_base_refrate_memtrace-m64.0000/apoa1.input --output \\$tmpdir/application/cpu2017/benchspec/CPU/508.namd_r/run/run_base_refrate_memtrace-m64.0000/apoa1.ref.output --iterations 65",
@@ -11355,7 +11355,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/510.parest_r/run/run_base_refrate_memtrace-m64.0000/parest_r_base.memtrace-m64 ref.prm",
@@ -11501,7 +11501,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/511.povray_r/run/run_base_refrate_memtrace-m64.0000/povray_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/511.povray_r/run/run_base_refrate_memtrace-m64.0000/SPEC-benchmark-ref.ini",
@@ -11559,7 +11559,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/519.lbm_r/run/run_base_refrate_memtrace-m64.0000/lbm_r_base.memtrace-m64 3000 \\$tmpdir/application/cpu2017/benchspec/CPU/519.lbm_r/run/run_base_refrate_memtrace-m64.0000/reference.dat 0 0 100_100_130_ldc.of",
@@ -11606,7 +11606,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/521.wrf_r/run/run_base_refrate_memtrace-m64.0000/wrf_r_base.memtrace-m64",
@@ -11851,7 +11851,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/526.blender_r/run/run_base_refrate_memtrace-m64.0000/blender_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/526.blender_r/run/run_base_refrate_memtrace-m64.0000/sh3_no_char.blend --render-output \\$tmpdir/application/cpu2017/benchspec/CPU/526.blender_r/run/run_base_refrate_memtrace-m64.0000/sh3_no_char_ --threads 1 -b -F RAWTGA -s 849 -e 849 -a",
@@ -11909,7 +11909,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/527.cam4_r/run/run_base_refrate_memtrace-m64.0000/cam4_r_base.memtrace-m64",
@@ -12143,7 +12143,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/538.imagick_r/run/run_base_refrate_memtrace-m64.0000/imagick_r_base.memtrace-m64 -limit disk 0 \\$tmpdir/application/cpu2017/benchspec/CPU/538.imagick_r/run/run_base_refrate_memtrace-m64.0000/refrate_input.tga -edge 41 -resample 181% -emboss 31 -colorspace YUV -mean-shift 19x19+15% -resize 30% \\$tmpdir/application/cpu2017/benchspec/CPU/538.imagick_r/run/run_base_refrate_memtrace-m64.0000/refrate_output.tga",
@@ -12223,7 +12223,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/544.nab_r/run/run_base_refrate_memtrace-m64.0000/nab_r_base.memtrace-m64 1am0 1122214447 122",
@@ -12303,7 +12303,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/549.fotonik3d_r/run/run_base_refrate_memtrace-m64.0000/fotonik3d_r_base.memtrace-m64",
@@ -12449,7 +12449,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/554.roms_r/run/run_base_refrate_memtrace-m64.0000/roms_r_base.memtrace-m64 < \\$tmpdir/application/cpu2017/benchspec/CPU/554.roms_r/run/run_base_refrate_memtrace-m64.0000/ocean_benchmark2.in.x",

--- a/workloads/workloads_top_simp.json
+++ b/workloads/workloads_top_simp.json
@@ -357,7 +357,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/cpu2017/benchspec/CPU/compile-538-clang.sh 538.imagick_r_train",
@@ -409,7 +409,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"/bin/bash \\$tmpdir/cpu2017/bin/runcpu --config=memtrace --action=build 538.imagick_r",
@@ -3021,7 +3021,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/perlbench_r_base.memtrace-m64 -I\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/lib \\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/checkspam.pl 2500 5 25 11 150 1 1 1 1",
@@ -3061,7 +3061,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/perlbench_r_base.memtrace-m64 -I\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/lib \\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/diffmail.pl 4 800 10 17 19 300",
@@ -3101,7 +3101,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/perlbench_r_base.memtrace-m64 -I\\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/lib \\$tmpdir/application/cpu2017/benchspec/CPU/500.perlbench_r/run/run_base_refrate_memtrace-m64.0000/splitmail.pl 6400 12 26 16 100 0",
@@ -3141,7 +3141,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/cpugcc_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-pp.c -O3 -finline-limit=0 -fif-conversion -fif-conversion2 -o \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-pp.opts-O3_-finline-limit_0_-fif-conversion_-fif-conversion2.s",
@@ -3181,7 +3181,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/cpugcc_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-pp.c -O2 -finline-limit=36000 -fpic -o \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-pp.opts-O2_-finline-limit_36000_-fpic.s",
@@ -3221,7 +3221,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/cpugcc_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-smaller.c -O3 -fipa-pta -o \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/gcc-smaller.opts-O3_-fipa-pta.s",
@@ -3261,7 +3261,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/cpugcc_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/ref32.c -O5 -o \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/ref32.opts-O5.s",
@@ -3301,7 +3301,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/cpugcc_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/ref32.c -O3 -fselective-scheduling -fselective-scheduling2 -o \\$tmpdir/application/cpu2017/benchspec/CPU/502.gcc_r/run/run_base_refrate_memtrace-m64.0000/ref32.opts-O3_-fselective-scheduling_-fselective-scheduling2.s",
@@ -3341,7 +3341,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/505.mcf_r/run/run_base_refrate_memtrace-m64.0000/mcf_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/505.mcf_r/run/run_base_refrate_memtrace-m64.0000/inp.in",
@@ -3381,7 +3381,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/520.omnetpp_r/run/run_base_refrate_memtrace-m64.0000/omnetpp_r_base.memtrace-m64 -c General -r 0",
@@ -3416,7 +3416,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/523.xalancbmk_r/run/run_base_refrate_memtrace-m64.0000/cpuxalan_r_base.memtrace-m64 -v \\$tmpdir/application/cpu2017/benchspec/CPU/523.xalancbmk_r/run/run_base_refrate_memtrace-m64.0000/t5.xml \\$tmpdir/application/cpu2017/benchspec/CPU/523.xalancbmk_r/run/run_base_refrate_memtrace-m64.0000/xalanc.xsl",
@@ -3456,7 +3456,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/x264_r_base.memtrace-m64 --pass 1 --stats \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/x264_stats.log --bitrate 1000 --frames 1000 -o \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny_New.264 \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny.yuv 1280x720",
@@ -3496,7 +3496,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/x264_r_base.memtrace-m64 --pass 2 --stats \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/x264_stats.log --bitrate 1000 --dumpyuv 200 --frames 1000 -o \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny_New.264 \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny.yuv 1280x720",
@@ -3536,7 +3536,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/x264_r_base.memtrace-m64 --seek 500 --dumpyuv 200 --frames 1250 -o \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny_New.264 \\$tmpdir/application/cpu2017/benchspec/CPU/525.x264_r/run/run_base_refrate_memtrace-m64.0000/BuckBunny.yuv 1280x720",
@@ -3576,7 +3576,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/531.deepsjeng_r/run/run_base_refrate_memtrace-m64.0000/deepsjeng_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/531.deepsjeng_r/run/run_base_refrate_memtrace-m64.0000/ref.txt",
@@ -3616,7 +3616,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/541.leela_r/run/run_base_refrate_memtrace-m64.0000/leela_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/541.leela_r/run/run_base_refrate_memtrace-m64.0000/ref.sgf",
@@ -3656,7 +3656,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/548.exchange2_r/run/run_base_refrate_memtrace-m64.0000/exchange2_r_base.memtrace-m64 6",
@@ -3696,7 +3696,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/xz_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/cld.tar.xz 160 19cf30ae51eddcbefda78dd06014b4b96281456e078ca7c13e1c0c9e6aaea8dff3efb4ad6b0456697718cede6bd5454852652806a657bb56e07d61128434b474 59796407 61004416 6",
@@ -3736,7 +3736,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/xz_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/cpu2006docs.tar.xz 250 055ce243071129412e9dd0b3b69a21654033a9b723d874b2015c774fac1553d9713be561ca86f74e4f16f22e664fc17a79f30caa5ad2c04fbc447549c2810fae 23047774 23513385 6e",
@@ -3776,7 +3776,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/xz_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/557.xz_r/run/run_base_refrate_memtrace-m64.0000/input.combined.xz 250 a841f68f38572a49d86226b7ff5baeb31bd19dc637a922a972b2e6d1257a890f6a544ecab967c313e370478c74f760eb229d4eef8a8d2836d233d3e9dd1430bf 40401484 41217675 7",
@@ -3818,7 +3818,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_1 < \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_1.in",
@@ -3858,7 +3858,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_2 < \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_2.in",
@@ -3898,7 +3898,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_3 < \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_3.in",
@@ -3938,7 +3938,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_4 < \\$tmpdir/application/cpu2017/benchspec/CPU/503.bwaves_r/run/run_base_refrate_memtrace-m64.0000/bwaves_4.in",
@@ -3978,7 +3978,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/507.cactuBSSN_r/run/run_base_refrate_memtrace-m64.0000/cactusBSSN_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/507.cactuBSSN_r/run/run_base_refrate_memtrace-m64.0000/spec_ref.par",
@@ -4018,7 +4018,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/508.namd_r/run/run_base_refrate_memtrace-m64.0000/namd_r_base.memtrace-m64 --input \\$tmpdir/application/cpu2017/benchspec/CPU/508.namd_r/run/run_base_refrate_memtrace-m64.0000/apoa1.input --output \\$tmpdir/application/cpu2017/benchspec/CPU/508.namd_r/run/run_base_refrate_memtrace-m64.0000/apoa1.ref.output --iterations 65",
@@ -4058,7 +4058,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/510.parest_r/run/run_base_refrate_memtrace-m64.0000/parest_r_base.memtrace-m64 ref.prm",
@@ -4098,7 +4098,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/511.povray_r/run/run_base_refrate_memtrace-m64.0000/povray_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/511.povray_r/run/run_base_refrate_memtrace-m64.0000/SPEC-benchmark-ref.ini",
@@ -4138,7 +4138,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/519.lbm_r/run/run_base_refrate_memtrace-m64.0000/lbm_r_base.memtrace-m64 3000 \\$tmpdir/application/cpu2017/benchspec/CPU/519.lbm_r/run/run_base_refrate_memtrace-m64.0000/reference.dat 0 0 100_100_130_ldc.of",
@@ -4173,7 +4173,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/521.wrf_r/run/run_base_refrate_memtrace-m64.0000/wrf_r_base.memtrace-m64",
@@ -4213,7 +4213,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/526.blender_r/run/run_base_refrate_memtrace-m64.0000/blender_r_base.memtrace-m64 \\$tmpdir/application/cpu2017/benchspec/CPU/526.blender_r/run/run_base_refrate_memtrace-m64.0000/sh3_no_char.blend --render-output \\$tmpdir/application/cpu2017/benchspec/CPU/526.blender_r/run/run_base_refrate_memtrace-m64.0000/sh3_no_char_ --threads 1 -b -F RAWTGA -s 849 -e 849 -a",
@@ -4253,7 +4253,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/527.cam4_r/run/run_base_refrate_memtrace-m64.0000/cam4_r_base.memtrace-m64",
@@ -4293,7 +4293,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/538.imagick_r/run/run_base_refrate_memtrace-m64.0000/imagick_r_base.memtrace-m64 -limit disk 0 \\$tmpdir/application/cpu2017/benchspec/CPU/538.imagick_r/run/run_base_refrate_memtrace-m64.0000/refrate_input.tga -edge 41 -resample 181% -emboss 31 -colorspace YUV -mean-shift 19x19+15% -resize 30% \\$tmpdir/application/cpu2017/benchspec/CPU/538.imagick_r/run/run_base_refrate_memtrace-m64.0000/refrate_output.tga",
@@ -4333,7 +4333,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/544.nab_r/run/run_base_refrate_memtrace-m64.0000/nab_r_base.memtrace-m64 1am0 1122214447 122",
@@ -4373,7 +4373,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/549.fotonik3d_r/run/run_base_refrate_memtrace-m64.0000/fotonik3d_r_base.memtrace-m64",
@@ -4413,7 +4413,7 @@
         "simulation":{
           "prioritized_mode":"memtrace",
           "exec":{
-            "image_name":"spec2017",
+            "image_name":"allbench_traces",
             "segment_size":10000000,
             "env_vars":null,
             "binary_cmd":"\\$tmpdir/application/cpu2017/benchspec/CPU/554.roms_r/run/run_base_refrate_memtrace-m64.0000/roms_r_base.memtrace-m64 < \\$tmpdir/application/cpu2017/benchspec/CPU/554.roms_r/run/run_base_refrate_memtrace-m64.0000/ocean_benchmark2.in.x",


### PR DESCRIPTION
Uses the allbench_traces docker image for execution-driven spec workloads. This will allow the git CI tests to work on images which we already automatically generate. Spec workloads are mounted into the docker container, so we don't need to compile them into the image anyways.

### Testing
Execution driven spec workloads with this commit work as well as they do with the spec image in the most recent version of scarab infra. 
There is an unrelated issue with some exec-driven spec workloads I have not been able to run successfully on the most recent scarab-infra (using spec image), but I am working with Moon to resolve this issue.