### PR TITLE
Perf pipeline v2: automated top-down collection + container hardening

### DIFF
--- a/common/scripts/perf_entrypoint.sh
+++ b/common/scripts/perf_entrypoint.sh
@@ -1,8 +1,39 @@
 #!/bin/bash
 #set -x #echo on
 
-cd $tmpdir
-apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r`
-sudo ln -s "$(find /usr/lib/linux-tools/*/perf | head -1)" /usr/local/bin/perf
-alias perf=$(find /usr/lib/linux-tools/*/perf | head -1)
-cd $tmpdir && git clone https://github.com/andikleen/pmu-tools.git
+set -e
+
+cd "${tmpdir:-/tmp_home}"
+export DEBIAN_FRONTEND=noninteractive
+
+apt_package_exists() {
+  apt-cache show "$1" >/dev/null 2>&1
+}
+
+install_if_available() {
+  if apt_package_exists "$1"; then
+    apt-get install -y "$1"
+  fi
+}
+
+apt-get update
+install_if_available linux-tools-common
+install_if_available linux-tools-generic
+install_if_available "linux-tools-$(uname -r)"
+install_if_available "linux-cloud-tools-$(uname -r)"
+install_if_available linux-cloud-tools-generic
+install_if_available linux-perf
+
+perf_bin="$(find /usr/lib/linux-tools /usr/lib -path '*/perf' -type f 2>/dev/null | grep 'linux-tools' | head -1)"
+if [ -z "$perf_bin" ] && command -v perf >/dev/null 2>&1; then
+  perf_bin="$(command -v perf)"
+fi
+if [ -n "$perf_bin" ]; then
+  ln -sf "$perf_bin" /usr/local/bin/perf
+fi
+
+if [ ! -d pmu-tools/.git ]; then
+  if [ ! -d pmu-tools ]; then
+    git clone https://github.com/andikleen/pmu-tools.git
+  fi
+fi

--- a/common/scripts/root_entrypoint.sh
+++ b/common/scripts/root_entrypoint.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
 #set -x #echo on
 
-# Check if the user exists, and if not, create it without the home directory
-if ! id -u "$username" &>/dev/null; then
-  useradd -u "$user_id" -M "$username"
+if [ -n "$username" ] && [ -n "$group_id" ]; then
+  if ! getent group "$username" &>/dev/null; then
+    groupadd -g "$group_id" "$username"
+  fi
 fi
 
-# Check if the group exists, and if not, modify it
-if ! getent group "$username" &>/dev/null; then
-  groupmod -g "$group_id" "$username"
+if [ -n "$username" ] && [ -n "$user_id" ]; then
+  if ! id -u "$username" &>/dev/null; then
+    if getent group "$username" &>/dev/null; then
+      useradd -u "$user_id" -g "$username" -M "$username"
+    else
+      useradd -u "$user_id" -M "$username"
+    fi
+  fi
 fi
 
 if [ -f "/usr/local/bin/workload_root_entrypoint.sh" ]; then
   bash /usr/local/bin/workload_root_entrypoint.sh $APPNAME
 fi
 
-chmod 777 $DYNAMORIO_HOME/lib64/release/libdynamorio.so
+if [ -n "$DYNAMORIO_HOME" ] && [ -f "$DYNAMORIO_HOME/lib64/release/libdynamorio.so" ]; then
+  chmod 777 "$DYNAMORIO_HOME/lib64/release/libdynamorio.so"
+fi

--- a/docs/README.perf.md
+++ b/docs/README.perf.md
@@ -1,141 +1,164 @@
-# Collecting Microarch Metrics for Performance Analysis
-This README describes all the steps to collect system or microarchitectural metrics of an arbitrary application and to collect memtraces by using DynamoRIO.
-By following the steps, a user will be able to do top-down analysis with Intel Perf tool to identify performance bottlenecks (frontend/backend/bad speculation/retiring), and extract the region of interest of execution traces with DynamoRIO and SimPoint methodology. The steps described in this README do not start with the complete diff of adding an application, instead, it starts with an incomplete one and revise it step by step.
+# Collecting Performance Metrics with `./sci --perf`
+
+This document describes how to collect microarchitectural performance metrics
+(top-down analysis, execution time, peak RSS) for workloads running inside
+Docker containers.
+
+## Overview
+
+`./sci --perf <descriptor>` runs each workload configuration defined in a JSON
+descriptor, collects Intel top-down L1 metrics via `pmu-tools/toplev`, measures
+execution time via `perf stat`, and records peak RSS. Results are written to
+`workloads/workloads_db.json` and consumed downstream by `./sci --trace` for
+Slurm memory sizing.
+
+`./sci --perf-interactive <descriptor>` opens an interactive shell in a
+perf-ready container for manual debugging or ad-hoc measurement.
 
 ## Requirements
-Prepare new applications/benchmarks where you want to measure performance. We use [DCPerf from Meta](https://github.com/facebookresearch/DCPerf) here as an example.
-Make sure the PMU counters readable on your host system (outside of docker container).
+
+PMU counters must be readable on the host:
 ```
-sudo su
-echo -1 > /proc/sys/kernel/perf_event_paranoid
+sudo sh -c 'echo -1 > /proc/sys/kernel/perf_event_paranoid'
 ```
 
-## Prepare the Dockerfile to build a docker image as described in [README.trace.md](docs/README.trace.md)
-Make sure the perf is installed.
-When you run an interactive shell, scarab-infra will install perf and pmu-tools, but you can manually build an image by making sure to include the following lines inside the dockerfile.
-
-We use `pmu-tools` for an effective top-down analysis where it internally runs perf.
-```
+The Docker image should include `perf` and `pmu-tools`. When using
+`--perf-interactive`, the entrypoint installs them automatically; for
+pre-built images, include:
+```dockerfile
 USER root
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    linux-tools-common \
-    linux-tools-generic \
-    linux-tools-`uname -r`
-```
-and
-```
-RUN alias perf=$(find /usr/lib/linux-tools/*/perf | head -1)
-```
-to address kernel mismatch for Perf.
-Also,
-```
+    linux-tools-common linux-tools-generic
 RUN cd $tmpdir && git clone https://github.com/andikleen/pmu-tools.git
 ```
-to install the pmu-tools.
 
-## Run an interactive shell of a docker container where you can run Perf
-After building a docker image, run an interactive shell of a docker container running on the image by using the perf JSON descriptor.
+## Descriptor JSON
+
+Create a perf descriptor (e.g., `json/perf.json`):
+
+```json
+{
+  "descriptor_type": "perf",
+  "user": "root",
+  "root_dir": "/home/$USER",
+  "image_name": "dcperf",
+  "perf_configurations": [
+    {
+      "workload": "fibers_benchmark",
+      "suite": "dcperf",
+      "subsuite": "wdlbench",
+      "binary_cmd": "$tmpdir/DCPerf/benchmarks/wdl_bench/fibers_benchmark",
+      "env_vars": null
+    }
+  ]
+}
 ```
+
+| Field | Description |
+|-------|-------------|
+| `user` | Container user (`root` or a regular username) |
+| `root_dir` | Host directory bind-mounted as the container home |
+| `image_name` | Docker image name (built via `./sci --build-image`) |
+| `perf_configurations[]` | Array of workload configs to measure |
+
+Each `perf_configurations` entry specifies:
+- `workload`, `suite`, `subsuite`: keys for `workloads_db.json`
+- `binary_cmd`: the command to execute inside the container
+- `env_vars`: optional space-separated `KEY=VALUE` string
+
+## Pipeline
+
+### 1. Container setup
+A privileged Docker container is created from the workload image. Support
+scripts (`root_entrypoint.sh`, `perf_entrypoint.sh`, `user_entrypoint.sh`,
+`utilities.sh`, plus optional per-image `workload_*_entrypoint.sh`) are
+`docker cp`'d in on every run so iterating on host scripts does not require
+an image rebuild. A `/tmp_home/.scarab_perf_ready` sentinel ensures the root
++ perf entrypoints execute exactly once per container lifetime.
+
+### 2. Warmup run
+The binary command runs once via `taskset -c 10` (pinned to a single core).
+Peak RSS of the process tree is captured via Python's
+`resource.RUSAGE_CHILDREN` and persisted to `workloads_db.json`.
+
+### 3. Adaptive repeat scaling
+The number of measurement repeats is computed from the warmup wall time so
+total measurement targets ~600 seconds:
+```
+repeat_count = max(1, min(15, int(600 / single_run_seconds)))
+```
+Fast workloads get more repeats for noise reduction; slow workloads run
+fewer times to keep wall clock bounded.
+
+### 4. Top-down L1 analysis
+```
+taskset -c 10 python3 /tmp_home/pmu-tools/toplev.py -l1 --single-thread -- <binary_cmd>
+```
+The output is parsed for the four L1 categories — **Frontend Bound**,
+**Backend Bound**, **Bad Speculation**, **Retiring** — and stored under
+`performance.topdown`.
+
+### 5. Execution time
+```
+perf stat -C 10 -- taskset -c 10 <repeat_script>
+```
+Elapsed time per run is extracted from `perf stat` stderr and stored under
+`performance.execution_time` as `{min, sec}`.
+
+### 6. Results storage
+Results are written to `workloads/workloads_db.json`, indexed by
+`suite/subsuite/workload`:
+```json
+{
+  "dcperf": {
+    "wdlbench": {
+      "fibers_benchmark": {
+        "performance": {
+          "topdown": {
+            "retiring": 19.3,
+            "bad_speculation": 4.2,
+            "frontend_bound": 26.9,
+            "backend_bound": 47.7
+          },
+          "execution_time": { "min": 0, "sec": 5.12 },
+          "peak_rss_mb": 1240
+        }
+      }
+    }
+  }
+}
+```
+
+## Usage
+
+```bash
+# Run automated perf collection for every entry in perf_configurations
 ./sci --perf perf
-```
-This reads `json/perf.json`. To use a different perf descriptor, run `./sci --perf <descriptor>`.
 
-## Run a workload
-### Binary command
-A binary command will be eventually used to collect traces of the region of interest. Playing around with the binary command is completely application-dependent.
-
-Note that the following steps are only for `feedsim` of `DCPerf`. You should figure out a way to run your new benchmark by playing around with different commands with different options to reproduce the real-world application performance.
-
-Running a binary command does not necessarily require root user, but DCPerf requires root user to have the benchmark running. You can specify the username in the JSON despcriotor.
-
-If your new benchmark is not a server-client application, you need a single the binary command. If it is a server-client application, the binary command should be the one to run a server because we are interested in the performance of the server on a server-client application.
-
-Based on [`wdlbench` README](https://github.com/facebookresearch/DCPerf/blob/main/packages/wdl_bench/README.md), we have installed the benchmark suite. The command `./benchpress_cli.py -b wdl run folly_individual -i '{"name": "fibers_benchmark"}` is used to run an application. To make the command work with DynamoRIO and Perf, try to extract the binary instruction that is executed last. By hacking the scripts, the binary command to execute `fibers_benchmark` of suite `dcperf` and subsuite `wdlbench` is `$tmpdir/DCPerf/benchmarks/wdl_bench/fibers_benchmark`.
-
-### Run with Perf
-To simply get the number of cycles and instructions of the application, run
-```
-perf stat -e cpu-cycles, instruction -a $BINARY_COMMAND
+# Open an interactive shell in a perf-ready container
+./sci --perf-interactive perf
 ```
 
-To collect performance metrics of a single core application accurately, you need to pin the workload to a single core by using UNIX command `taskset`.
-Additionally, to get the top-down analysis, run the pmu-tools by pinning the workload to a specific core.
+## Multi-threaded workloads
+
+All measurements pin the workload to a single core (`taskset -c 10`). For
+multi-threaded workloads (e.g., Python with torch/numpy worker threads), set
+`OMP_NUM_THREADS=1`, `MKL_NUM_THREADS=1`, and `OPENBLAS_NUM_THREADS=1` in the
+Docker image or via `env_vars` to keep execution single-threaded for accurate
+per-core measurement.
+
+Peak RSS captures the entire process tree's memory, including helper
+threads. This value is consumed by `./sci --trace` to size Slurm memory
+requests for the trace pipeline.
+
+## Single-user container reuse
+
+The container is named `<image_name>_perf_collect_<user>`. Re-running
+`./sci --perf` against the same descriptor reuses the container and skips
+the root/perf bootstrap (the `.scarab_perf_ready` sentinel signals it has
+already been initialised), so subsequent iterations are fast.
+
+To force a fresh container, remove it manually:
 ```
-python3 ../pmu-tools/toplev.py --core S0-C0 -l3 -v --no-desc taskset -c 0 ./benchmarks/wdl_bench/fibers_benchmark
-```
-The benchmark output looks like the following.
-```
-[...]folly/fibers/test/FibersBenchmark.cpp     relative  time/iter   iters/s
------------------------------------------
-FiberManagerBasicOneAwait                                 420.43ns     2.38M
-FiberManagerBasicOneAwaitLogged                             1.19us   838.00K
-FiberManagerBasicFiveAwaits                                 1.18us   844.22K
-FiberManagerBasicFiveAwaitsLogged                           4.24us   236.07K
-FiberManagerGet                                             8.81ns   113.49M
-FiberManagerCreateDestroy                                  25.48us    39.25K
-FiberManagerAllocateDeallocatePattern                       2.77ms    360.37
-FiberManagerAllocateLargeChunk                             23.87ms     41.90
-FiberManagerCancelledTimeouts_Single_300                   21.22ms     47.13
-FiberManagerCancelledTimeouts_Five                         21.20ms     47.16
-FiberManagerCancelledTimeouts_TenThousand                  21.05ms     47.50
-```
-and the top-down results will follow. This workload shows 30% of frontend boundness, 5.4% of bad speculation, 22.8% of backend boundness, and 42.1% of retiring. You can find the deeper top-down performance results.
-```
-# 4.8-full-perf on Intel(R) Xeon(R) Gold 6242R CPU @ 3.10GHz [clx/skylake]                                                                                                                                               05:00:27 [250/2648]    
-S0-C0    FE               Frontend_Bound                                        % Slots                       30.0    [ 3.3%]   
-S0-C0    BAD              Bad_Speculation.Branch_Mispredicts.Other_Mispredicts  % Slots                        0.6  < [ 3.3%]   
-S0-C0    BAD              Bad_Speculation.Machine_Clears.Other_Nukes            % Slots                        0.1  < [ 3.3%]   
-S0-C0    BAD              Bad_Speculation                                       % Slots                        5.4  < [ 3.3%]   
-S0-C0    BE               Backend_Bound                                         % Slots                       22.8    [ 3.3%]   
-S0-C0    RET              Retiring                                              % Slots                       42.1  < [ 3.3%]   
-S0-C0    FE               Frontend_Bound.Fetch_Latency                          % Slots                       13.7    [ 3.3%]<==    
-S0-C0    FE               Frontend_Bound.Fetch_Bandwidth                        % Slots                       16.2  < [ 3.3%]   
-S0-C0    BAD              Bad_Speculation.Branch_Mispredicts                    % Slots                        5.2  < [ 3.3%]   
-S0-C0    BAD              Bad_Speculation.Machine_Clears                        % Slots                        0.2  < [ 3.3%]   
-S0-C0    BE/Mem           Backend_Bound.Memory_Bound                            % Slots                        7.2  < [ 3.3%]   
-S0-C0    BE/Core          Backend_Bound.Core_Bound                              % Slots                       15.6    [ 3.3%]   
-S0-C0    RET              Retiring.Light_Operations                             % Slots                       33.2  < [ 3.3%]   
-S0-C0    RET              Retiring.Heavy_Operations                             % Slots                        8.9  < [ 3.3%]   
-S0-C0    RET              Retiring.Light_Operations.Memory_Operations           % Slots                       14.6  < [ 3.3%]   
-S0-C0    RET              Retiring.Light_Operations.Fused_Instructions          % Slots                        3.3  < [ 3.3%]   
-S0-C0    RET              Retiring.Light_Operations.Non_Fused_Branches          % Slots                        2.9  < [ 3.3%]   
-S0-C0    RET              Retiring.Light_Operations.Other_Light_Ops             % Slots                       12.3  < [ 3.3%]   
-S0-C0    RET              Retiring.Heavy_Operations.Few_Uops_Instructions       % Slots                        3.5  < [ 3.3%]   
-S0-C0    RET              Retiring.Heavy_Operations.Microcode_Sequencer         % Slots                        5.4  < [ 3.3%]   
-S0-C0-T0 FE               Frontend_Bound.Fetch_Latency.ICache_Misses            % Clocks                       2.1  < [ 3.3%]   
-S0-C0-T0 FE               Frontend_Bound.Fetch_Latency.ITLB_Misses              % Clocks                       3.6  < [ 3.3%]   
-S0-C0-T0 FE               Frontend_Bound.Fetch_Latency.Branch_Resteers          % Clocks                       4.3  < [ 3.3%]   
-S0-C0-T0 FE               Frontend_Bound.Fetch_Latency.MS_Switches              % Clocks_est                   4.6  < [ 3.3%]   
-S0-C0-T0 FE               Frontend_Bound.Fetch_Latency.LCP                      % Clocks                       0.1  < [ 3.3%]   
-S0-C0-T0 FE               Frontend_Bound.Fetch_Latency.DSB_Switches             % Clocks                       3.8  < [ 3.3%]   
-S0-C0-T0 FE               Frontend_Bound.Fetch_Bandwidth.MITE                   % Slots_est                   28.6  < [ 3.3%]   
-S0-C0-T0 FE               Frontend_Bound.Fetch_Bandwidth.DSB                    % Slots_est                    8.8  < [ 3.3%]   
-S0-C0-T0 BE/Mem           Backend_Bound.Memory_Bound.L1_Bound                   % Stalls                      11.3  < [ 3.3%]   
-S0-C0-T0 BE/Mem           Backend_Bound.Memory_Bound.L2_Bound                   % Stalls                       1.2  < [ 3.3%]   
-S0-C0-T0 BE/Mem           Backend_Bound.Memory_Bound.L3_Bound                   % Stalls                       0.8  < [ 3.3%]   
-S0-C0-T0 BE/Mem           Backend_Bound.Memory_Bound.DRAM_Bound                 % Stalls                       1.5  < [ 3.3%]   
-S0-C0-T0 BE/Mem           Backend_Bound.Memory_Bound.PMM_Bound                  % Stalls                       0.0  <   
-S0-C0-T0 BE/Mem           Backend_Bound.Memory_Bound.Store_Bound                % Stalls                       3.0  < [ 3.3%]   
-S0-C0-T0 BE/Core          Backend_Bound.Core_Bound.Divider                      % Clocks                       1.7  < [ 3.3%]   
-S0-C0-T0 BE/Core          Backend_Bound.Core_Bound.Serializing_Operation        % Clocks                       9.3  < [ 3.3%]   
-S0-C0-T0 BE/Core          Backend_Bound.Core_Bound.Ports_Utilization            % Clocks                      35.9    [ 3.3%]   
-S0-C0-T0 RET              Retiring.Light_Operations.FP_Arith                    % Uops                         0.0  < [ 3.3%]   
-S0-C0-T0 MUX                                                                    %                              3.32 
-S0-C0-T1 FE               Frontend_Bound.Fetch_Latency.ICache_Misses            % Clocks                      13.5    [ 3.3%]   
-S0-C0-T1 FE               Frontend_Bound.Fetch_Latency.ITLB_Misses              % Clocks                       2.8  < [ 3.3%]   
-S0-C0-T1 FE               Frontend_Bound.Fetch_Latency.Branch_Resteers          % Clocks                      14.0    [ 3.3%]   
-S0-C0-T1 FE               Frontend_Bound.Fetch_Latency.MS_Switches              % Clocks_est                   9.2    [ 3.3%]   
-S0-C0-T1 FE               Frontend_Bound.Fetch_Latency.LCP                      % Clocks                       0.0  < [ 3.3%]   
-S0-C0-T1 FE               Frontend_Bound.Fetch_Latency.DSB_Switches             % Clocks                       0.0  < [ 3.3%]   
-S0-C0-T1 FE               Frontend_Bound.Fetch_Bandwidth.MITE                   % Slots_est                    0.1  < [ 3.3%]   
-S0-C0-T1 FE               Frontend_Bound.Fetch_Bandwidth.DSB                    % Slots_est                    0.0  < [ 3.3%]   
-S0-C0-T1 BE/Mem           Backend_Bound.Memory_Bound.L1_Bound                   % Stalls                      15.3    [ 3.3%]   
-S0-C0-T1 BE/Mem           Backend_Bound.Memory_Bound.L2_Bound                   % Stalls                       1.9  < [ 3.3%]   
-S0-C0-T1 BE/Mem           Backend_Bound.Memory_Bound.L3_Bound                   % Stalls                       6.4  < [ 3.3%]   
-S0-C0-T1 BE/Mem           Backend_Bound.Memory_Bound.DRAM_Bound                 % Stalls                       1.2  < [ 3.3%]   
-S0-C0-T1 BE/Mem           Backend_Bound.Memory_Bound.PMM_Bound                  % Stalls                       0.0  <   
-S0-C0-T1 BE/Mem           Backend_Bound.Memory_Bound.Store_Bound                % Stalls                       0.5  < [ 3.3%]   
-S0-C0-T1 BE/Core          Backend_Bound.Core_Bound.Divider                      % Clocks                       0.2  < [ 3.3%]   
-S0-C0-T1 BE/Core          Backend_Bound.Core_Bound.Serializing_Operation        % Clocks                      42.7    [ 3.3%]   
-S0-C0-T1 BE/Core          Backend_Bound.Core_Bound.Ports_Utilization            % Clocks                      19.8    [ 3.3%]   
+docker rm -f <image_name>_perf_collect_<user>
 ```

--- a/sci
+++ b/sci
@@ -514,10 +514,10 @@ def handle_descriptor_action(descriptor_name: str, action: str, dbg_override: Op
         return
 
     if dtype == "perf":
-        if action != "launch":
-            raise StepError("Perf descriptors only support interactive launch")
+        if action not in ("launch", "collect"):
+            raise StepError(f"Unsupported action '{action}' for perf descriptors (use 'launch' or 'collect')")
         perf_module = import_repo_module("scripts.run_perf")
-        perf_module.run_perf_command(str(path), "launch", dbg_lvl=resolve_dbg(3), infra_dir=infra_dir)
+        perf_module.run_perf_command(str(path), action, dbg_lvl=resolve_dbg(3), infra_dir=infra_dir)
         return
 
     raise StepError(f"Unsupported descriptor type '{dtype}' for action '{action}'")
@@ -4328,7 +4328,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--perf",
         metavar="DESCRIPTOR",
-        help="Open a perf container defined in json/<DESCRIPTOR>.json.",
+        help="Run automated perf top-down collection for json/<DESCRIPTOR>.json.",
+    )
+    parser.add_argument(
+        "--perf-interactive",
+        dest="perf_interactive",
+        metavar="DESCRIPTOR",
+        help="Open an interactive perf container defined in json/<DESCRIPTOR>.json.",
     )
     parser.add_argument(
         "--visualize",
@@ -4509,7 +4515,14 @@ def main() -> int:
             return 1
     if args.perf:
         try:
-            handle_descriptor_action(args.perf, "launch", dbg_override=args.debug_level)
+            handle_descriptor_action(args.perf, "collect", dbg_override=args.debug_level)
+            return 0
+        except (StepError, RuntimeError) as exc:
+            print(exc)
+            return 1
+    if args.perf_interactive:
+        try:
+            handle_descriptor_action(args.perf_interactive, "launch", dbg_override=args.debug_level)
             return 0
         except (StepError, RuntimeError) as exc:
             print(exc)

--- a/scripts/run_perf.py
+++ b/scripts/run_perf.py
@@ -3,6 +3,8 @@
 # 02/17/2025 | Surim Oh | run_perf.py
 # An entrypoint script that run clustering and tracing on Slurm clusters using docker containers or on local
 
+import json
+import re
 import subprocess
 import argparse
 import os
@@ -13,14 +15,60 @@ from .utilities import (
     info,
     err,
     read_descriptor_from_json,
+    write_json_descriptor,
     is_container_running,
     count_interactive_shells
 )
 
 client = docker.from_env()
 
+def sync_perf_support_files(docker_container_name, image_name, infra_dir):
+    common_files = [
+        (f"{infra_dir}/scripts/utilities.sh", "/usr/local/bin"),
+        (f"{infra_dir}/common/scripts/root_entrypoint.sh", "/usr/local/bin"),
+        (f"{infra_dir}/common/scripts/user_entrypoint.sh", "/usr/local/bin"),
+        (f"{infra_dir}/common/scripts/perf_entrypoint.sh", "/usr/local/bin"),
+    ]
+    for src, dst in common_files:
+        subprocess.run(["docker", "cp", src, f"{docker_container_name}:{dst}"], check=True)
+
+    for script in ("workload_root_entrypoint.sh", "workload_user_entrypoint.sh"):
+        src = f"{infra_dir}/workloads/{image_name}/{script}"
+        if os.path.exists(src):
+            subprocess.run(["docker", "cp", src, f"{docker_container_name}:/usr/local/bin"], check=True)
+
+
+def perf_container_initialized(docker_container_name):
+    result = subprocess.run(
+        ["docker", "exec", docker_container_name, "test", "-f", "/tmp_home/.scarab_perf_ready"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def bootstrap_perf_container(docker_container_name):
+    subprocess.run(
+        ["docker", "exec", "--privileged", docker_container_name, "/bin/bash", "-c", "/usr/local/bin/root_entrypoint.sh"],
+        check=True,
+    )
+    subprocess.run(
+        ["docker", "exec", "--privileged", docker_container_name, "/bin/bash", "-c", "/usr/local/bin/perf_entrypoint.sh"],
+        check=True,
+    )
+    subprocess.run(
+        ["docker", "exec", "--privileged", docker_container_name, "/bin/bash", "-c", "touch /tmp_home/.scarab_perf_ready"],
+        check=True,
+    )
+
+
 def open_interactive_shell(user, docker_home, image_name, infra_dir, dbg_lvl = 1):
     try:
+        local_uid = os.getuid()
+        local_gid = os.getgid()
+        container_home = "/tmp_home" if user == "root" else f"/home/{user}"
+
         # Get GitHash
         try:
             githash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("utf-8").strip()
@@ -32,11 +80,20 @@ def open_interactive_shell(user, docker_home, image_name, infra_dir, dbg_lvl = 1
 
         docker_container_name = f"{image_name}_perf_{user}"
         try:
+            shell_cmd = f"export HOME={container_home}; source /usr/local/bin/user_entrypoint.sh >/dev/null 2>&1 || true; exec /bin/bash"
+            needs_bootstrap = False
             if is_container_running(docker_container_name, dbg_lvl):
-                subprocess.run(["docker", "exec", "-it", f"--user={user}", f"--workdir=/tmp_home", docker_container_name, "/bin/bash"])
+                sync_perf_support_files(docker_container_name, image_name, infra_dir)
+                needs_bootstrap = not perf_container_initialized(docker_container_name)
             else:
                 info(f"Create a new container for the interactive mode", dbg_lvl)
                 command = f"docker run --privileged \
+                        -e user_id={local_uid} \
+                        -e group_id={local_gid} \
+                        -e username={user} \
+                        -e HOME={container_home} \
+                        -e APP_GROUPNAME={image_name} \
+                        -e APPNAME={image_name} \
                         -dit \
                         --name {docker_container_name} \
                         --mount type=bind,source={docker_home},target=/home/{user},readonly=false \
@@ -44,12 +101,14 @@ def open_interactive_shell(user, docker_home, image_name, infra_dir, dbg_lvl = 1
                         /bin/bash"
                 print(command)
                 os.system(command)
-                os.system(f"docker cp {infra_dir}/scripts/utilities.sh {docker_container_name}:/usr/local/bin")
-                os.system(f"docker cp {infra_dir}/common/scripts/root_entrypoint.sh {docker_container_name}:/usr/local/bin")
-                os.system(f"docker cp {infra_dir}/common/scripts/perf_entrypoint.sh {docker_container_name}:/usr/local/bin")
-                os.system(f"docker exec --privileged {docker_container_name} /bin/bash -c '/usr/local/bin/root_entrypoint.sh'")
-                os.system(f"docker exec --privileged {docker_container_name} /bin/bash -c '/usr/local/bin/perf_entrypoint.sh'")
-                subprocess.run(["docker", "exec", "-it", f"--user={user}", f"--workdir=/tmp_home", docker_container_name, "/bin/bash"])
+                sync_perf_support_files(docker_container_name, image_name, infra_dir)
+                needs_bootstrap = True
+            if needs_bootstrap:
+                bootstrap_perf_container(docker_container_name)
+            subprocess.run([
+                "docker", "exec", "-it", f"--user={user}", f"--workdir=/tmp_home",
+                docker_container_name, "/bin/bash", "-c", shell_cmd
+            ])
         except KeyboardInterrupt:
             if count_interactive_shells(docker_container_name, dbg_lvl) == 1:
                 os.system(f"docker rm -f {docker_container_name}")
@@ -63,6 +122,327 @@ def open_interactive_shell(user, docker_home, image_name, infra_dir, dbg_lvl = 1
                 print(f"Container {docker_container_name} not found.")
     except Exception as e:
         raise e
+
+
+# ---------------------------------------------------------------------------
+# Automated perf collection helpers
+# ---------------------------------------------------------------------------
+
+def parse_toplev_output(stdout, stderr):
+    """Parse toplev.py -l1 human-readable output for top-down L1 percentages.
+
+    The --single-thread stderr format has lines like:
+        FE               Frontend_Bound   % Slots                       35.1   [50.0%]<==
+        BAD              Bad_Speculation  % Slots                       16.6   [50.0%]
+        RET              Retiring         % Slots                       28.5   [50.0%]
+        BE               Backend_Bound    % Slots                       19.8   [50.0%]
+
+    Only categories exceeding their threshold are printed; missing ones get None.
+    """
+    key_map = {
+        "frontend_bound": "frontend_bound",
+        "backend_bound": "backend_bound",
+        "bad_speculation": "bad_speculation",
+        "retiring": "retiring",
+    }
+
+    combined = (stdout or "") + "\n" + (stderr or "")
+
+    # Match: MetricName <whitespace> % Slots <whitespace> VALUE
+    pattern = re.compile(
+        r'(Frontend_Bound|Backend_Bound|Bad_Speculation|Retiring)\s+%\s*Slots\s+([\d.]+)',
+        re.IGNORECASE,
+    )
+
+    topdown = {}
+    for m in pattern.finditer(combined):
+        metric = m.group(1).lower()
+        value = float(m.group(2))
+        db_key = key_map.get(metric)
+        if db_key:
+            topdown[db_key] = round(value, 1)
+
+    # The four L1 categories sum to ~100%. Infer missing ones from the rest.
+    all_keys = ["retiring", "bad_speculation", "frontend_bound", "backend_bound"]
+    present = {k: v for k, v in topdown.items() if k in all_keys}
+    missing = [k for k in all_keys if k not in present]
+    if 1 <= len(missing) <= 2 and len(present) >= 2:
+        remainder = round(100.0 - sum(present.values()), 1)
+        if len(missing) == 1:
+            topdown[missing[0]] = remainder
+        # If 2 are missing we can't split them; leave as None
+
+    return topdown
+
+
+def parse_perf_stat_time(stderr_text):
+    """Parse perf stat stderr for elapsed seconds.
+
+    Looks for a line like:
+        1.234567890 seconds time elapsed
+    """
+    if not stderr_text:
+        return None
+    match = re.search(r"([\d]+\.[\d]+)\s+seconds\s+time\s+elapsed", stderr_text)
+    if match:
+        return float(match.group(1))
+    return None
+
+
+def _parse_peak_rss_mb(stderr_text):
+    """Parse warmup stderr for peak RSS (MB int) or None.
+
+    Two formats are supported:
+      1. Our python3 RUSAGE_CHILDREN wrapper (default; see run_perf_for_descriptor):
+             PEAK_RSS_KB=<n>
+      2. GNU `/usr/bin/time -v` (legacy; only if `time` package is installed in
+         the container):
+             Maximum resident set size (kbytes): <n>
+    Both report kB from getrusage(RUSAGE_CHILDREN).ru_maxrss, i.e. the
+    high-water mark of the workload's RSS (VmHWM).
+    """
+    if not stderr_text:
+        return None
+    match = re.search(r"PEAK_RSS_KB=(\d+)", stderr_text)
+    if not match:
+        match = re.search(r"Maximum resident set size \(kbytes\):\s+(\d+)", stderr_text)
+    if not match:
+        return None
+    kb = int(match.group(1))
+    return int(round(kb / 1024))
+
+
+TOPLEV_PATH = "/tmp_home/pmu-tools/toplev.py"
+PERF_CORE = 10  # Pin workloads to a high-numbered core to reduce interference
+PERF_REPEAT_DEFAULT = 15  # Re-run the entire workload binary this many times per measurement
+PERF_TARGET_SECONDS = 600  # Target total measurement time; scale repeats to stay near this
+
+
+PERF_SCRIPT = "/tmp/_perf_repeat.sh"
+
+
+
+def _write_repeat_script(container_name, binary_cmd, repeat_count=None):
+    """Write a repeat-loop script into the container to avoid quoting issues."""
+    n = repeat_count if repeat_count is not None else PERF_REPEAT_DEFAULT
+    script = f"#!/bin/bash\nfor i in $(seq 1 {n}); do\n  {binary_cmd}\ndone\n"
+    subprocess.run(
+        ["docker", "exec", container_name, "/bin/bash", "-c",
+         f"cat > {PERF_SCRIPT} << 'PERF_EOF'\n{script}PERF_EOF\nchmod +x {PERF_SCRIPT}"],
+        check=True, capture_output=True,
+    )
+
+
+def run_toplev_for_config(container_name, config, repeat_count=None):
+    """Run toplev.py -l1 --single-thread on a pinned core via docker exec --privileged."""
+    binary_cmd = config["binary_cmd"]
+    _write_repeat_script(container_name, binary_cmd, repeat_count)
+    env_str = ""
+    if config.get("env_vars"):
+        env_str = " ".join(f"{k}={v}" for k, v in config["env_vars"].items()) + " "
+    cmd = [
+        "docker", "exec", "--privileged", container_name,
+        "/bin/bash", "-c",
+        f"{env_str}taskset -c {PERF_CORE} python3 {TOPLEV_PATH} -l1 --single-thread --core C{PERF_CORE}"
+        f" --no-desc --verbose"
+        f" -- taskset -c {PERF_CORE} {PERF_SCRIPT}"
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=1800)
+    if result.returncode != 0:
+        print(f"    [toplev] returncode={result.returncode}")
+        if result.stderr:
+            for line in result.stderr.strip().splitlines()[-5:]:
+                print(f"    [toplev stderr] {line}")
+    topdown = parse_toplev_output(result.stdout, result.stderr)
+    if not topdown:
+        print(f"    [toplev] WARNING: no top-down metrics parsed")
+    return topdown
+
+
+def run_perf_stat_for_config(container_name, config, repeat_count=None):
+    """Run perf stat on a pinned core via docker exec --privileged."""
+    binary_cmd = config["binary_cmd"]
+    _write_repeat_script(container_name, binary_cmd, repeat_count)
+    env_str = ""
+    if config.get("env_vars"):
+        env_str = " ".join(f"{k}={v}" for k, v in config["env_vars"].items()) + " "
+    cmd = [
+        "docker", "exec", "--privileged", container_name,
+        "/bin/bash", "-c",
+        f"{env_str}perf stat -C {PERF_CORE} -- taskset -c {PERF_CORE} {PERF_SCRIPT}"
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=1800)
+    if result.returncode != 0:
+        print(f"    [perf stat] returncode={result.returncode}")
+        if result.stderr:
+            for line in result.stderr.strip().splitlines()[-5:]:
+                print(f"    [perf stat stderr] {line}")
+    elapsed = parse_perf_stat_time(result.stderr)
+    if elapsed is None:
+        print(f"    [perf stat] WARNING: could not parse elapsed time")
+    return elapsed
+
+
+def collect_perf_data(user, root_dir, image_name, infra_dir, perf_configs, dbg_lvl=2):
+    """Orchestrator: create/reuse container, run toplev + perf stat for each config,
+    write results to workloads_db.json."""
+    local_uid = os.getuid()
+    local_gid = os.getgid()
+    container_home = "/tmp_home" if user == "root" else f"/home/{user}"
+
+    try:
+        githash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("utf-8").strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        raise RuntimeError("Cannot determine git hash for docker image tag")
+
+    docker_container_name = f"{image_name}_perf_collect_{user}"
+    created_container = False
+
+    try:
+        # Create or reuse container
+        if is_container_running(docker_container_name, dbg_lvl):
+            sync_perf_support_files(docker_container_name, image_name, infra_dir)
+            if not perf_container_initialized(docker_container_name):
+                bootstrap_perf_container(docker_container_name)
+        else:
+            info(f"Creating container for perf collection: {docker_container_name}", dbg_lvl)
+            command = (
+                f"docker run --privileged "
+                f"-e user_id={local_uid} "
+                f"-e group_id={local_gid} "
+                f"-e username={user} "
+                f"-e HOME={container_home} "
+                f"-e APP_GROUPNAME={image_name} "
+                f"-e APPNAME={image_name} "
+                f"-dit "
+                f"--name {docker_container_name} "
+                f"--mount type=bind,source={root_dir},target=/home/{user},readonly=false "
+                f"{image_name}:{githash} "
+                f"/bin/bash"
+            )
+            info(command, dbg_lvl)
+            os.system(command)
+            created_container = True
+            sync_perf_support_files(docker_container_name, image_name, infra_dir)
+            bootstrap_perf_container(docker_container_name)
+
+        # Validate that the pinned core exists inside the container
+        core_check = subprocess.run(
+            ["docker", "exec", docker_container_name, "/bin/bash", "-c",
+             f"taskset -c {PERF_CORE} true"],
+            capture_output=True, text=True,
+        )
+        if core_check.returncode != 0:
+            raise RuntimeError(
+                f"Core {PERF_CORE} is not available in container. "
+                f"Check PERF_CORE setting or container --cpuset-cpus. "
+                f"stderr: {core_check.stderr.strip()}"
+            )
+        print(f"  Pinning all workloads to core {PERF_CORE}, target ~{PERF_TARGET_SECONDS}s per measurement")
+
+        # Load workloads_db.json
+        workload_db_path = os.path.join(infra_dir, "workloads", "workloads_db.json")
+        workload_db = read_descriptor_from_json(workload_db_path, dbg_lvl)
+        if workload_db is None:
+            workload_db = {}
+
+        # Run toplev + perf stat for each config
+        for config in perf_configs:
+            workload = config["workload"]
+            suite = config["suite"]
+            subsuite = config["subsuite"]
+            print(f"  Collecting perf data for {workload}...")
+
+            # Warmup: run once to populate FS cache, shared libs, bytecode
+            # caches. We also capture the workload's peak RSS (ru_maxrss) via
+            # a small python3 wrapper that execs taskset+binary_cmd as a child
+            # and then reads RUSAGE_CHILDREN. Prints a PEAK_RSS_KB=<n> sentinel
+            # on its own line to stderr. We avoid GNU time (`/usr/bin/time -v`)
+            # so we don't depend on the `time` apt package being present in
+            # every workload image. The captured value is stored in
+            # workloads_db.json under performance.peak_rss_mb and later
+            # consumed by slurm_runner.estimate_trace_mem_mb() to size `--mem`
+            # for sbatch trace jobs. Effectively free: this run already happens.
+            binary_cmd = config["binary_cmd"]
+            rss_wrapper = (
+                "python3 -c '"
+                "import os,sys,subprocess,resource;"
+                "cmd=sys.argv[1];"
+                "r=subprocess.run([\"/bin/bash\",\"-c\",cmd],"
+                "stdout=subprocess.DEVNULL);"
+                "u=resource.getrusage(resource.RUSAGE_CHILDREN);"
+                "sys.stderr.write(f\"PEAK_RSS_KB={u.ru_maxrss}\\n\");"
+                "sys.exit(r.returncode)' "
+                f'"taskset -c {PERF_CORE} {binary_cmd}"'
+            )
+            import time as _time
+            warmup_t0 = _time.monotonic()
+            warmup_res = subprocess.run(
+                ["docker", "exec", "--privileged", docker_container_name,
+                 "/bin/bash", "-c", rss_wrapper],
+                capture_output=True, text=True, timeout=3600,
+            )
+            warmup_secs = _time.monotonic() - warmup_t0
+            peak_rss_mb = _parse_peak_rss_mb(warmup_res.stderr)
+
+            # Scale repeat count so total measurement time stays near PERF_TARGET_SECONDS
+            single_run = max(1.0, warmup_secs)
+            repeat_count = max(1, min(PERF_REPEAT_DEFAULT, int(PERF_TARGET_SECONDS / single_run)))
+            print(f"    single-run ~{single_run:.0f}s, using {repeat_count}x repeats")
+
+            topdown = run_toplev_for_config(docker_container_name, config, repeat_count)
+            elapsed = run_perf_stat_for_config(docker_container_name, config, repeat_count)
+
+            # Convert total elapsed to per-run average
+            if elapsed is not None:
+                elapsed = round(elapsed / repeat_count, 2)
+            elapsed_min = 0
+            elapsed_sec = elapsed
+            if elapsed is not None and elapsed >= 60:
+                elapsed_min = int(elapsed // 60)
+                elapsed_sec = round(elapsed % 60, 2)
+
+            performance = {
+                "topdown": {
+                    "retiring": topdown.get("retiring"),
+                    "bad_speculation": topdown.get("bad_speculation"),
+                    "frontend_bound": topdown.get("frontend_bound"),
+                    "backend_bound": topdown.get("backend_bound"),
+                },
+                "execution_time": {
+                    "min": elapsed_min,
+                    "sec": elapsed_sec,
+                },
+                "peak_rss_mb": peak_rss_mb,
+            }
+
+            # Write to workloads_db at [suite][subsuite][workload]["performance"]
+            if suite not in workload_db:
+                workload_db[suite] = {}
+            if subsuite not in workload_db[suite]:
+                workload_db[suite][subsuite] = {}
+            if workload not in workload_db[suite][subsuite]:
+                workload_db[suite][subsuite][workload] = {}
+            workload_db[suite][subsuite][workload]["performance"] = performance
+
+            print(f"    topdown: {topdown}")
+            print(f"    elapsed: {elapsed}s")
+            if peak_rss_mb is not None:
+                print(f"    peak_rss: {peak_rss_mb} MB")
+            else:
+                print(f"    peak_rss: (not captured)")
+
+        write_json_descriptor(workload_db_path, workload_db, dbg_lvl)
+        print(f"Results written to {workload_db_path}")
+
+    finally:
+        # Cleanup container if we created it
+        if created_container:
+            try:
+                client.containers.get(docker_container_name).remove(force=True)
+                print(f"Container {docker_container_name} removed.")
+            except docker.errors.NotFound:
+                pass
 
 
 def run_perf_command(descriptor_path, action, dbg_lvl=2, infra_dir=None):
@@ -81,6 +461,13 @@ def run_perf_command(descriptor_path, action, dbg_lvl=2, infra_dir=None):
         open_interactive_shell(user, root_dir, image_name, infra_dir, dbg_lvl)
         return 0
 
+    if action == "collect":
+        perf_configs = descriptor_data.get("perf_configurations")
+        if not perf_configs:
+            raise RuntimeError("Descriptor has no perf_configurations for collection")
+        collect_perf_data(user, root_dir, image_name, infra_dir, perf_configs, dbg_lvl)
+        return 0
+
     raise RuntimeError(f"Unsupported perf action: {action}")
 
 
@@ -89,6 +476,7 @@ def main():
 
     parser.add_argument('-d','--descriptor_name', required=True, help='Perf descriptor name. Usage: -d perf.json')
     parser.add_argument('-l','--launch', required=False, default=False, action=argparse.BooleanOptionalAction, help='Launch a docker container for perf descriptor.')
+    parser.add_argument('-c','--collect', required=False, default=False, action=argparse.BooleanOptionalAction, help='Run automated perf collection for all configurations.')
     parser.add_argument('-dbg','--debug', required=False, type=int, default=2, help='1 for errors, 2 for warnings, 3 for info')
     parser.add_argument('-si','--scarab_infra', required=False, default=None, help='Path to scarab infra repo to launch new containers')
 
@@ -97,7 +485,10 @@ def main():
     dbg_lvl = args.debug
     infra_dir = args.scarab_infra
 
-    action = "launch" if args.launch else "launch"
+    if args.collect:
+        action = "collect"
+    else:
+        action = "launch"
     return run_perf_command(descriptor_path, action, dbg_lvl=dbg_lvl, infra_dir=infra_dir)
 
 


### PR DESCRIPTION
## Summary

Turns `./sci --perf` into an automated collection pipeline (top-down L1, execution time, peak RSS) instead of an interactive shell, and hardens the supporting container entrypoints.

**Breaking change**: `./sci --perf <descriptor>` now triggers automated collection. The previous interactive-shell behaviour is preserved verbatim under the new `./sci --perf-interactive <descriptor>` flag. Discussed: no existing automated consumers of the old `--perf` behaviour.

Independent of #394 and #395 — different files, different scope. Can land in any order.

### `scripts/run_perf.py` (399 net new lines)

- **Adaptive repeat scaling**: target ~600s total measurement, `max(1, min(15, int(600 / single_run_seconds)))`. Replaces fixed-N which over-measured fast workloads and under-measured slow ones.
- **Peak RSS capture** during warmup via Python's `resource.RUSAGE_CHILDREN`. Persisted to `workloads_db.json` under `performance.peak_rss_mb` and consumed by `./sci --trace` for Slurm memory sizing.
- **Container bootstrap sentinel**: `/tmp_home/.scarab_perf_ready` ensures `root_entrypoint.sh` + `perf_entrypoint.sh` run exactly once per container lifetime. `sync_perf_support_files()` `docker cp`'s the latest scripts (`utilities.sh`, `root_entrypoint.sh`, `user_entrypoint.sh`, `perf_entrypoint.sh`, plus optional per-image `workload_*_entrypoint.sh`) into the container on each run so iterating on the host scripts does not require an image rebuild.
- **Top-down L1 + execution time + workloads_db.json output**: run `pmu-tools/toplev` with `-l1 --single-thread`, pin via `taskset -c 10`, parse Frontend/Backend/BadSpec/Retiring; measure execution time via `perf stat -C 10` with adaptive repeats.
- **Root-user hardening**: compute `HOME` based on user (`/tmp_home` for root, `/home/<user>` otherwise); pass `user_id` / `group_id` / `username` / `HOME` / `APP_GROUPNAME` / `APPNAME` env on `docker run` so the entrypoint runs cleanly as either root or a regular user.
- **Single-core pinning + thread-limit env**: all measurement commands pin to core 10 via taskset and inherit `PYTHONHASHSEED` + `OMP/MKL/OPENBLAS/NUMEXPR/TOKENIZERS` thread limits from the Docker image so multi-threaded workloads measure as single-threaded on the measured core.

### `common/scripts/perf_entrypoint.sh` (41 lines)

- Each `apt-get install` guarded by an `apt-cache` existence check so containers without `linux-tools-$(uname -r)` (common on minimal cloud images) don't fail the install step. Also probe `linux-cloud-tools-*` and `linux-perf` as alternates.
- After install, look for the perf binary under `/usr/lib/linux-tools` first, then fall back to PATH (`command -v perf`). Symlink to `/usr/local/bin/perf` only if found.
- pmu-tools clone is now idempotent: skipped if the `.git` directory or the `pmu-tools` dir already exists.
- `set -e` so any unguarded failure surfaces.

### \`common/scripts/root_entrypoint.sh\` (22 lines)

- `groupadd` / `useradd` are now guarded by `id` / `getent` checks so the entrypoint can be re-run on a container where the user is already set up.
- Skip the user-creation block entirely when `username` / `user_id` / `group_id` env vars are not set (root-user descriptors).
- `chmod` on `libdynamorio.so` guarded by an existence check so images built without DynamoRIO (perf-only descriptors) don't error.

### \`sci\` CLI

- `--perf <descriptor>` → action `collect` (was: action `launch`)
- New `--perf-interactive <descriptor>` → action `launch` (the previous `--perf` behaviour)
- `dtype == \"perf\"` guard updated to accept both `launch` and `collect`.

### `docs/README.perf.md`

Replace the original step-by-step tutorial (\"install perf, run feedsim, here's the top-down output\") with a structured reference: descriptor schema, 6-stage pipeline, results storage schema, multi-threaded guidance, container-reuse behaviour. DCPerf `fibers_benchmark` from `json/perf.json` used as the inline example.
