### PR TITLE
State accounting

### DIFF
--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -69,9 +69,7 @@ def print_status(user, job_name, docker_prefix_list, descriptor_data=None, workl
         docker_running,
         [],
         dbg_lvl=dbg_lvl,
-        log_file_count_buffer=0,
         strict_log_count=False,
-        log_count_offset=0,
         prep_failed_label="Failed - Prep",
     )
 
@@ -214,7 +212,7 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                         continue
 
                     workload_home = f"{suite}/{subsuite}/{workload}"
-                    write_docker_command_to_file(user, local_uid, local_gid, workload, workload_home, experiment_name,
+                    write_docker_command_to_file(user, local_uid, local_gid, suite, subsuite, workload, experiment_name,
                                                  docker_prefix, docker_container_name, traces_dir,
                                                  docker_home, githash, config_key, config, sim_mode, scarab_binary,
                                                  seg_size, architecture, cluster_id, warmup, trace_warmup, trace_type,

--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -200,7 +200,7 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
 
                 for cluster_id, weight in simpoints.items():
                     info(f"cluster_id: {cluster_id}, weight: {weight}", dbg_lvl)
-                    
+
                     dont_collect = False
 
                     docker_container_name = f"{docker_prefix}_{suite}_{subsuite}_{workload}_{experiment_name}_{config_key.replace("/", "-")}_{cluster_id}_{sim_mode}_{user}"

--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -28,6 +28,7 @@ from .utilities import (
         remove_old_job_logs,
         print_simulation_status_summary,
         normalize_simulations,
+        update_statefile
         )
 
 # Check if a container is running on local
@@ -151,6 +152,8 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
     log_files = set()
     log_index = 0
 
+    experiment_dir = f"{descriptor_data['root_dir']}/simulations/{experiment_name}"
+
     dont_collect = True
 
     def run_single_workload(suite, subsuite, workload, exp_cluster_id, sim_mode, warmup):
@@ -206,7 +209,7 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                     # Create temp file with run command and run it
                     filename = f"{docker_container_name}_tmp_run.sh"
 
-                    if check_can_skip(descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, dbg_lvl=dbg_lvl):
+                    if check_can_skip(experiment_dir, config_key, suite, subsuite, workload, cluster_id, filename, dbg_lvl=dbg_lvl):
                         info(f"Skipping {workload} with config {config_key} and cluster id {cluster_id}", dbg_lvl)
                         continue
 
@@ -226,6 +229,7 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                     log_index += 1
                     log_handle = open(log_path, "w")
                     log_files.add(log_handle)
+                    update_statefile(experiment_dir, config_key, suite, subsuite, workload, cluster_id, f"Job PENDING - Local")
                     process = subprocess.Popen(
                         "exec " + command,
                         stdout=log_handle,
@@ -277,7 +281,6 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
         os.makedirs(os.path.join(docker_home, "simulations", experiment_name, "logs"), exist_ok=True)
 
         # Collect old job logs before submitting new jobs
-        experiment_dir = f"{descriptor_data['root_dir']}/simulations/{experiment_name}"
         old_job_logs = get_old_job_logs(f"{experiment_dir}/logs")
 
         print("Submitting jobs...")

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -323,9 +323,8 @@ def print_status(user, job_name, docker_prefix_list, descriptor_data, workloads_
         queued_sims,
         dbg_lvl=dbg_lvl,
         all_nodes=all_nodes,
-        log_file_count_buffer=1,
+        state_file_count_buffer=0,
         strict_log_count=True,
-        log_count_offset=1,
         prep_failed_label="Failed - Slurm",
     )
 
@@ -597,7 +596,7 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                         print(f"WARN: no base_memory_mb_by_mode entry for {suite}/{subsuite}/{workload} cluster={cluster_id} sim_mode={sim_mode} config={config_key}, using fallback={fallback_mb}MB + overhead={overhead_mb}MB = {mem_mb}MB")
 
                     workload_home = f"{suite}/{subsuite}/{workload}"
-                    write_docker_command_to_file(user, local_uid, local_gid, workload, workload_home, experiment_name,
+                    write_docker_command_to_file(user, local_uid, local_gid, suite, subsuite, workload, experiment_name,
                                                  docker_prefix, docker_container_name, traces_dir,
                                                  docker_home, githash, config_key, config, sim_mode, binary_name,
                                                  seg_size, architecture, cluster_id, warmup, trace_warmup, trace_type,

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -600,7 +600,7 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                                                  docker_prefix, docker_container_name, traces_dir,
                                                  docker_home, githash, config_key, config, sim_mode, binary_name,
                                                  seg_size, architecture, cluster_id, warmup, trace_warmup, trace_type,
-                                                 trace_file, env_vars, bincmd, client_bincmd, filename, infra_dir, application_dir, slurm=True)
+                                                 trace_file, env_vars, bincmd, client_bincmd, filename, infra_dir, application_dir, mem_mb, slurm=True)
                     tmp_files.add(filename)
 
                     remove_jobs.add((config_key, suite, subsuite, workload, cluster_id))

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -37,6 +37,7 @@ from .utilities import (
         print_simulation_status_summary,
         run_on_node,
         normalize_simulations,
+        update_statefile
         )
 
 # Check if the docker image exists on available slurm nodes
@@ -605,8 +606,10 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
 
                     result = subprocess.run(["touch", f"{experiment_dir}/logs/job_%j.out"], capture_output=True, text=True, check=True)
                     result = subprocess.run((sbatch_cmd + filename).split(" "), capture_output=True, text=True)
-                    _print_sbatch_output(result)
                     job_id = result.stdout.split(" ")[-1].strip()
+                    update_statefile(experiment_dir, config_key, suite, subsuite, workload, cluster_id, f"Job PENDING - Slurm: {job_id}")
+
+                    _print_sbatch_output(result)
                     slurm_ids.append(job_id)
                     run_single_workload.submitted += 1
                 print("\rSubmitting jobs: "+str(run_single_workload.submitted), end=' ', flush=True)
@@ -720,8 +723,8 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
         print("\nSubmitted all jobs")
         # Clean up temp files
         for tmp in tmp_files:
-            info(f"Removing temporary run script {tmp}", dbg_lvl)
-            os.remove(tmp)
+            info(f"Moving temporary run script {tmp}", dbg_lvl)
+            os.system(f"mv {tmp} {experiment_dir}/logs/launch_scripts")
 
         remove_old_job_logs(old_job_logs, remove_jobs, dbg_lvl)
 
@@ -736,8 +739,8 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
 
         # Clean up temp files
         for tmp in tmp_files:
-            info(f"Removing temporary run script {tmp}", dbg_lvl)
-            os.remove(tmp)
+            info(f"Moving temporary run script {tmp}", dbg_lvl)
+            os.system(f"mv {tmp} {experiment_dir}/logs/launch_scripts")
 
         remove_old_job_logs(old_job_logs, remove_jobs, dbg_lvl)
 

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -488,6 +488,8 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
     total_sims = 0
     docker_prefix_list = get_image_list(simulations, workloads_data)
 
+    experiment_dir = f"{descriptor_data['root_dir']}/simulations/{experiment_name}"
+
     slurm_running_sims = check_slurm_task_queued_or_running(docker_prefix_list, experiment_name, user, dbg_lvl)
     running_sims = set()
     for node_list in slurm_running_sims.values():
@@ -557,7 +559,7 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                     # Create temp file with run command and run it
                     filename = f"{docker_container_name}_tmp_run.sh"
 
-                    if check_can_skip(descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, dbg_lvl=dbg_lvl):
+                    if check_can_skip(experiment_dir, config_key, suite, subsuite, workload, cluster_id, filename, dbg_lvl=dbg_lvl):
                         info(f"Skipping {workload} with config {config_key} and cluster id {cluster_id}", dbg_lvl)
                         continue
 
@@ -644,7 +646,6 @@ def run_simulation(user, descriptor_data, workloads_data, infra_dir, descriptor_
                     scarab_binaries.append(scarab_binary)
 
         # Generate commands for executing in users docker and sbatching to nodes with containers
-        experiment_dir = f"{descriptor_data['root_dir']}/simulations/{experiment_name}"
 
         try:
             scarab_githash, image_tag_list = prepare_simulation(user, scarab_path, scarab_build, descriptor_data['root_dir'], experiment_name, architecture, docker_prefix_list, githash, infra_dir, scarab_binaries, False, dbg_lvl)

--- a/scripts/slurm_runner.py
+++ b/scripts/slurm_runner.py
@@ -840,7 +840,7 @@ def run_tracing(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl = 2)
         # Clean up temp files
         for tmp in tmp_files:
             info(f"Removing temporary run script {tmp}", dbg_lvl)
-            os.remove(tmp)
+            os.system(f"mv {tmp} {trace_dir}/logs/launch_scripts")
 
         finish_trace(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl)
     except Exception as e:
@@ -850,6 +850,6 @@ def run_tracing(user, descriptor_data, workload_db_path, infra_dir, dbg_lvl = 2)
         # Clean up temp files
         for tmp in tmp_files:
             info(f"Removing temporary run script {tmp}", dbg_lvl)
-            os.remove(tmp)
+            os.system(f"mv {tmp} {trace_dir}/logs/launch_scripts")
 
         kill_jobs(user, trace_name, docker_prefix_list, dbg_lvl)

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1668,7 +1668,10 @@ def write_docker_command_to_file(user, local_uid, local_gid, suite, subsuite, wo
             f.write("docker exec --privileged $CONTAINER_NAME /bin/bash -c '/usr/local/bin/root_entrypoint.sh'\n")
             f.write(f"docker exec --user={user} $CONTAINER_NAME /bin/bash -c \"source /usr/local/bin/user_entrypoint.sh && {scarab_cmd}\" \n")
             f.write("SCARAB_EXIT=$?\n")
-            f.write("if [ $SCARAB_EXIT -ne 0 ]; then\n")
+            f.write(f"ls {docker_home}/simulations/{experiment_name}/{config_key}/{workload_home}/{cluster_id} | grep csv$ > /dev/null\n")
+            f.write("STAT_FILE_CHECK=$?\n")
+            f.write("echo $STAT_FILE_CHECK\n")
+            f.write("if [[ $SCARAB_EXIT -ne 0 || $STAT_FILE_CHECK -ne 0 ]]; then\n")
             f.write("    echo \"Scarab error detected\"\n")
             f.write("    echo \"Job FAILED - Scarab\" >> $STATEFILE\n")
             f.write("else\n")
@@ -2712,9 +2715,10 @@ def check_sp_failed (experiment_dir, config_key, suite, subsuite, workload, exp_
     statefile = f"{experiment_dir}/logs/statefiles/{get_statefile_name(config_key, suite, subsuite, workload, exp_cluster_id)}.log"
     try:
         with open(statefile, "r") as f:
-            return "Job FAILED" in f.readlines()
+            contents = ''.join(f.readlines())
+            return "Job FAILED" in contents
     except Exception as e:
-        warn(f"Statefile did not exist during check. Existance should have been checked previously: {e}", dbg_lvl)
+        warn(f"Statefile did not exist during check. Existance should have been checked previously: {e}", 3) #dbg_lvl)
         return True
 
 # Clean up failed run

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1621,7 +1621,6 @@ def write_docker_command_to_file(user, local_uid, local_gid, suite, subsuite, wo
                 f.write(f"docker run --privileged\
                 --memory={memory_mb}m \
                 --memory-swap={memory_mb}m \
-                --memory-swappiness=0 \
                 -e user_id={local_uid} \
                 -e group_id={local_gid} \
                 -e username={user} \
@@ -2309,11 +2308,10 @@ def print_simulation_status_summary(
         error_list = sorted(error_runs)
         print(f"\033[31mErroneous Jobs: {len(error_list)}\033[0m")
         print(f"\033[31mErrors found in {len(error_list)}/{total_logfiles} latest log files.")
-        print("First 5 error runs:\n", "\n".join(error_list[:5]), "\033[0m", sep='')
+        print("First 5 error runs:\n", "\n".join(list(map(str, error_list))[:5]), "\033[0m", sep='')
         first_error_log = error_list[0]
         print()
         print(f"\033[94mTail of the first error ({first_error_log}):")
-        fallback_log = sim_log_to_job_log.get(first_error_log)
         try:
             with open(first_error_log, "r", errors="replace") as first_error_log_file:
                 tail_lines = list(deque(first_error_log_file, maxlen=20))
@@ -2321,6 +2319,7 @@ def print_simulation_status_summary(
                 print("".join(tail_lines).rstrip("\n"))
             elif fallback_log:
                 print(f"<empty log file; showing runner log fallback: {fallback_log}>")
+                fallback_log = sim_log_to_job_log.get(first_error_log)
                 try:
                     with open(fallback_log, "r", errors="replace") as fallback_log_file:
                         fallback_tail_lines = list(deque(fallback_log_file, maxlen=20))

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1894,6 +1894,10 @@ def get_simulation_jobs(descriptor_data, workloads_data, docker_prefix, user, db
             ]
 
     return set(all_jobs)
+# Perform input sanitization, so names with _ aren't messed up in statefile names
+def sanitize(config, suite, subsuite, workload, cluster_id):
+    return (config.replace("_", '-'), suite.replace("_", '-'), subsuite.replace("_", '-'),
+                workload.replace("_", '-'), cluster_id)
 
 # Returns (config, suite, subsuite, workload_, cluster_id) for all jobs in config
 def get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl = 1):
@@ -1912,11 +1916,6 @@ def get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl = 1)
         return [0]
 
     all_jobs = []
-
-    # Perform input sanitization, so names with _ aren't messed up in statefile names
-    def sanitize(config, suite, subsuite, workload, cluster_id):
-        return (config.replace("_", '-'), suite.replace("_", '-'), subsuite.replace("_", '-'),
-                workload.replace("_", '-'), cluster_id)
 
     for simulation in simulations:
         suite = simulation["suite"]
@@ -1965,7 +1964,7 @@ def get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl = 1)
 
     return all_jobs
 
-def parse_job_log_header(first_line: str) -> Optional[Tuple[str, str, str, str, str]]:
+def parse_job_log_header(first_line: str, sanitize_result=False) -> Optional[Tuple[str, str, str, str, str]]:
     """Parse the first line of a Slurm job log.
 
     Expected format: ``Running {config} {suite}/{subsuite}/{workload} {cluster_id}``
@@ -1984,7 +1983,10 @@ def parse_job_log_header(first_line: str) -> Optional[Tuple[str, str, str, str, 
     if len(path_parts) != 3:
         return None
     suite, subsuite, workload = path_parts
-    return (config, suite, subsuite, workload, cluster_id_str)
+    if sanitize_result:
+        return sanitize(config, suite, subsuite, workload, cluster_id_str)
+    else:
+        return (config, suite, subsuite, workload, cluster_id_str)
 
 def get_old_job_logs(log_dir: str) -> dict[Tuple[str, str, str, str, str], list[Path]]:
     """
@@ -2143,6 +2145,28 @@ def _scrub_ignorable_slurm_job_log_noise(log_text: str) -> str:
         out.append(line)
     return "".join(out)
 
+# Iterate over all log files, and return dictionary associating them with their parameters
+# Ditionary of form [(config, suite, subsuite, workload, cluster_id)] = "logfile path"
+def get_runner_logs(root_logfile_directory):
+    log_file_db = {}
+    for file in Path(root_logfile_directory).glob("job_*.out"):
+        # If we need to get slurm ids, we can use this code.
+        #try:
+        #    slurm_job_id = int(file.stem.split("_")[1])
+        #except (IndexError, ValueError):
+        #    # e.g. the literal "job_%j.out" placeholder touched before sbatch submission
+        #    # _unparseable.add(_lp.name)
+        #    continue
+        try:
+            with file.open(encoding="utf-8", errors="replace") as file_handle:
+                first_line = file_handle.readline().strip()
+        except OSError:
+            continue
+        parsed = parse_job_log_header(first_line, sanitize_result=True)
+        log_file_db[parsed] = file
+
+        return log_file_db
+
 
 def print_simulation_status_summary(
     descriptor_data,
@@ -2182,6 +2206,8 @@ def print_simulation_status_summary(
     if len(all_state_files) > len(all_job_ids):
         print("More log files than total runs. Maybe same experiment name was run multiple times?")
 
+    runner_logs = get_runner_logs(root_logfile_directory)
+
     error_runs = set()
 
     confs = list(map(lambda x:x.replace("_", "-"), descriptor_data["configurations"].keys()))
@@ -2201,6 +2227,7 @@ def print_simulation_status_summary(
             exit(1)
 
         config, suite, subsuite, workload, cluster_id = statefile.stem.split('_')
+        logfile_key = (config, suite, subsuite, workload, cluster_id) # Log dictionaries use tuple as key
 
         if not (config, suite, subsuite, workload, int(cluster_id)) in all_job_ids:
             info(f"Statefile {statefile.stem} not found in experiment", dbg_lvl)
@@ -2215,8 +2242,11 @@ def print_simulation_status_summary(
                 completed[config] += 1
             elif "Job FAILED - Runner" in contents:
                 prep_failed[config] += 1
+                error_runs.add(runner_logs[logfile_key])
             elif "Job FAILED - Scarab" in contents:
                 failed[config] += 1
+                # TODO: Check OOM. Use suite, subsuite, workload, cluster_id from above
+                # TODO: Get scarab log file
             elif "Job RUNNING" in contents:
                 total_running += 1
                 running[config] += 1
@@ -2227,7 +2257,6 @@ def print_simulation_status_summary(
                 # Should be safe to assume pending here, but I will throw warning
                 pending[config] += 1
                 warn(f"Statefile {statefile.stem} found but has no contents. Assuming pending", 2)
-
 
     print(f"Currently running {total_running} simulations")
 

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1227,6 +1227,8 @@ def prepare_simulation(user, scarab_path, scarab_build, docker_home, experiment_
 
         experiment_dir = f"{docker_home}/simulations/{experiment_name}"
         os.system(f"mkdir -p {experiment_dir}/logs/")
+        os.system(f"mkdir -p {experiment_dir}/logs/statefiles")
+        os.system(f"mkdir -p {experiment_dir}/logs/launch_scripts")
         dest_scarab_bin = f"{experiment_dir}/scarab/src/scarab"
         build_mode = scarab_build if scarab_build else "opt"
 
@@ -1588,9 +1590,13 @@ def write_docker_command_to_file(user, local_uid, local_gid, workload, workload_
         scarab_cmd = generate_single_scarab_run_command(user, workload_home, experiment_name, config_key, config,
                                                         scarab_mode, seg_size, architecture, scarab_binary, cluster_id,
                                                         warmup, trace_warmup, trace_type, trace_file, env_vars, bincmd, client_bincmd)
+
         with open(filename, "w") as f:
             f.write("#!/bin/bash\n")
             f.write(f"echo \"Running {config_key} {workload_home} {cluster_id} {scarab_mode}\"\n")
+            f.write(f"STATEFILE={docker_home}/simulations/{experiment_name}/logs/statefiles/{config_key}_{workload_home.replace('/', '_')}_{cluster_id}.log\n")
+            f.write("echo \"Writing state to $STATEFILE\"\n")
+            f.write("echo \"Job RUNNING\" >> $STATEFILE\n")
             f.write(f"echo \"Simulation mode: {scarab_mode}\"\n")
             f.write(f"echo \"Script name: {filename}\"\n")
             f.write("echo \"Running on $(uname -n)\"\n")
@@ -1598,7 +1604,13 @@ def write_docker_command_to_file(user, local_uid, local_gid, workload, workload_
             f.write("cleanup_container() {\n")
             f.write("    docker rm -f \"$CONTAINER_NAME\" >/dev/null 2>&1 || true\n")
             f.write("}\n")
-            f.write("trap cleanup_container EXIT INT TERM HUP\n")
+            f.write("graceful_exit() {\n")
+            f.write("    if [ -n $SCARAB_EXIT ]; then\n")
+            f.write("        echo \"Job FAILED - Runner\" >> $STATEFILE\n")
+            f.write("    fi\n")
+            f.write("    cleanup_container\n")
+            f.write("}\n")
+            f.write("trap graceful_exit EXIT INT TERM HUP\n")
             f.write(f"cd {infra_dir}\n")
             f.write(f"python -m scripts.prepare_docker_image --docker-prefix {docker_prefix} --githash {githash} \n")
             f.write(f"cd -\n")
@@ -1653,7 +1665,14 @@ def write_docker_command_to_file(user, local_uid, local_gid, workload, workload_
                 f.write(f"docker cp {infra_dir}/common/scripts/run_exec_single_simpoint.sh $CONTAINER_NAME:/usr/local/bin\n")
                 f.write("docker exec --privileged $CONTAINER_NAME /bin/bash -c \"echo 0 | sudo tee /proc/sys/kernel/randomize_va_space\"\n")
             f.write("docker exec --privileged $CONTAINER_NAME /bin/bash -c '/usr/local/bin/root_entrypoint.sh'\n")
-            f.write(f"docker exec --user={user} $CONTAINER_NAME /bin/bash -c \"source /usr/local/bin/user_entrypoint.sh && {scarab_cmd}\" || echo \"Scarab error detected\"\n")
+            f.write(f"docker exec --user={user} $CONTAINER_NAME /bin/bash -c \"source /usr/local/bin/user_entrypoint.sh && {scarab_cmd}\" \n")
+            f.write("SCARAB_EXIT=$?\n")
+            f.write("if [ $SCARAB_EXIT -ne 0 ]; then\n")
+            f.write("    echo \"Scarab error detected\"\n")
+            f.write("    echo \"Job FAILED - Scarab\" >> $STATEFILE\n")
+            f.write("else\n")
+            f.write("    echo \"Job COMPLETED SUCCESSFULLY\" >> $STATEFILE\n")
+            f.write("fi\n")
             f.write("cleanup_container\n")
             f.write("echo \"Completed Simulation\"\n")
             f.write(f"sync {docker_home}/simulations/{experiment_name}/logs")
@@ -2583,6 +2602,7 @@ def prepare_trace(user, scarab_path, scarab_build, docker_home, job_name, infra_
             raise FileNotFoundError(f"Required Scarab binary not found: {scarab_ver}")
 
         os.system(f"mkdir -p {trace_dir}/scarab/bin/scarab_globals")
+        os.system(f"mkdir -p {trace_dir}/logs/statefiles")
         os.system(f"cp {scarab_path}/bin/scarab_launch.py  {trace_dir}/scarab/bin/scarab_launch.py ")
         os.system(f"cp {scarab_path}/bin/scarab_globals/*  {trace_dir}/scarab/bin/scarab_globals/ ")
         os.system(f"mkdir -p {trace_dir}/scarab/utils/memtrace")
@@ -2846,6 +2866,8 @@ def clean_failed_run (descriptor_data, config_key, suite, subsuite, workload, ex
                 info(f"Removing log entry for failed run: {header.strip()}", dbg_lvl)
                 file.unlink()
 
+    # TODO: delete statefile and launch script
+
 # Check if run was already successful, and thus skippable
 # Please use as follows:
 # if check_can_skip(...):
@@ -2915,3 +2937,8 @@ def generate_table(data, title=""):
         table_string += row_string.replace(' 0 ', ' \033[30m0\033[0m ')
 
     return table_string
+
+def update_statefile(experiment_dir, config, suite, subsuite, workload, simpoint, message):
+    statefile = f"{experiment_dir}/logs/statefiles/{config}_{suite}_{subsuite}_{workload}_{simpoint}.log"
+    with open(statefile, "a") as f:
+        f.write(message+"\n")

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1733,7 +1733,6 @@ def write_trace_docker_command_to_file(user, local_uid, local_gid, docker_contai
                 f.write("echo $SLURM_CGROUP\n")
                 command += "--cgroup-parent $SLURM_CGROUP \
                             --cgroupns=host "
-
             if env_vars:
                 for env in env_vars:
                     command = command + f"-e {env} "
@@ -2229,8 +2228,6 @@ def print_simulation_status_summary(
     running = {conf: 0 for conf in confs}
     pending = {conf: 0 for conf in confs}
 
-    runner_log_to_sim_log = {}
-
     not_in_experiment = 0
     total_running = 0
     oom_killed_sps = []
@@ -2260,7 +2257,6 @@ def print_simulation_status_summary(
                     cluster_id,
                     "sim.log"
                 )
-            runner_log_to_sim_log[runner_logs[logfile_key]] = scarab_logfile
 
             if "Job COMPLETED SUCCESSFULLY" in contents:
                 completed[config] += 1
@@ -2528,6 +2524,7 @@ def prepare_trace(user, scarab_path, scarab_build, docker_home, job_name, infra_
 
         os.system(f"mkdir -p {trace_dir}/scarab/bin/scarab_globals")
         os.system(f"mkdir -p {trace_dir}/logs/statefiles")
+        os.system(f"mkdir -p {trace_dir}/logs/launch_scripts")
         os.system(f"cp {scarab_path}/bin/scarab_launch.py  {trace_dir}/scarab/bin/scarab_launch.py ")
         os.system(f"cp {scarab_path}/bin/scarab_globals/*  {trace_dir}/scarab/bin/scarab_globals/ ")
         os.system(f"mkdir -p {trace_dir}/scarab/utils/memtrace")

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1581,12 +1581,13 @@ def write_docker_command_to_file_run_by_root(user, local_uid, local_gid, workloa
     except Exception as e:
         raise e
 
-def write_docker_command_to_file(user, local_uid, local_gid, workload, workload_home, experiment_name,
+def write_docker_command_to_file(user, local_uid, local_gid, suite, subsuite, workload, experiment_name,
                                  docker_prefix, docker_container_name, traces_dir,
                                  docker_home, githash, config_key, config, scarab_mode, scarab_binary,
                                  seg_size, architecture, cluster_id, warmup, trace_warmup, trace_type,
                                  trace_file, env_vars, bincmd, client_bincmd, filename, infra_dir, application_dir, slurm=False):
     try:
+        workload_home = f"{suite}/{subsuite}/{workload}"
         scarab_cmd = generate_single_scarab_run_command(user, workload_home, experiment_name, config_key, config,
                                                         scarab_mode, seg_size, architecture, scarab_binary, cluster_id,
                                                         warmup, trace_warmup, trace_type, trace_file, env_vars, bincmd, client_bincmd)
@@ -1594,7 +1595,7 @@ def write_docker_command_to_file(user, local_uid, local_gid, workload, workload_
         with open(filename, "w") as f:
             f.write("#!/bin/bash\n")
             f.write(f"echo \"Running {config_key} {workload_home} {cluster_id} {scarab_mode}\"\n")
-            f.write(f"STATEFILE={docker_home}/simulations/{experiment_name}/logs/statefiles/{config_key}_{workload_home.replace('/', '_')}_{cluster_id}.log\n")
+            f.write(f"STATEFILE={docker_home}/simulations/{experiment_name}/logs/statefiles/{get_statefile_name(config_key, suite, subsuite, workload, cluster_id)}.log\n")
             f.write("echo \"Writing state to $STATEFILE\"\n")
             f.write("echo \"Job RUNNING\" >> $STATEFILE\n")
             f.write(f"echo \"Simulation mode: {scarab_mode}\"\n")
@@ -1817,6 +1818,7 @@ def normalize_simulations(simulations):
             expanded.append(sim)
     return expanded
 
+# Get docker container name for all jobs created from an experiment file
 def get_simulation_jobs(descriptor_data, workloads_data, docker_prefix, user, dbg_lvl = 1):
     experiment_name = descriptor_data["experiment"]
     configs = descriptor_data["configurations"]
@@ -1908,6 +1910,11 @@ def get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl = 1)
 
     all_jobs = []
 
+    # Perform input sanitization, so names with _ aren't messed up in statefile names
+    def sanitize(config, suite, subsuite, workload, cluster_id):
+        return (config.replace("_", '-'), suite.replace("_", '-'), subsuite.replace("_", '-'),
+                workload.replace("_", '-'), cluster_id)
+
     for simulation in simulations:
         suite = simulation["suite"]
         subsuite = simulation["subsuite"]
@@ -1925,7 +1932,7 @@ def get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl = 1)
                         sim_mode_ = workloads_data[suite][subsuite_][workload_]["simulation"]["prioritized_mode"]
                     simpoint_ids = get_simpoints_wrapper(suite, subsuite_, workload_, exp_cluster_id, sim_mode_) * len(configs)
                     all_jobs += [
-                        (config, suite, subsuite_, workload_, cluster_id)
+                        sanitize(config, suite, subsuite_, workload_, cluster_id)
                         for config in configs.keys()
                         for cluster_id in simpoint_ids
                     ]
@@ -1938,7 +1945,7 @@ def get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl = 1)
                     sim_mode_ = workloads_data[suite][subsuite][workload_]["simulation"]["prioritized_mode"]
                 simpoint_ids = get_simpoints_wrapper(suite, subsuite, workload_, exp_cluster_id, sim_mode_) * len(configs)
                 all_jobs += [
-                    (config, suite, subsuite, workload_, cluster_id)
+                    sanitize(config, suite, subsuite, workload_, cluster_id)
                     for config in configs.keys()
                     for cluster_id in simpoint_ids
                 ]
@@ -1948,7 +1955,7 @@ def get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl = 1)
                 sim_mode_ = workloads_data[suite][subsuite][workload]["simulation"]["prioritized_mode"]
             simpoint_ids = get_simpoints_wrapper(suite, subsuite, workload, exp_cluster_id, sim_mode_) * len(configs)
             all_jobs += [
-                (config, suite, subsuite, workload, cluster_id)
+                sanitize(config, suite, subsuite, workload, cluster_id)
                 for config in configs.keys()
                 for cluster_id in simpoint_ids
             ]
@@ -2143,68 +2150,38 @@ def print_simulation_status_summary(
     queued_sims,
     dbg_lvl = 1,
     all_nodes = None,
-    log_file_count_buffer = 0,
+    state_file_count_buffer = 0,
     strict_log_count = False,
     log_count_offset = 0,
     prep_failed_label = "Failed - Slurm",
 ):
-    all_jobs = get_simulation_jobs(descriptor_data, workloads_data, docker_prefix_list, user, dbg_lvl)
+
+    all_job_ids = get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl=dbg_lvl)
 
     root_directory = os.path.join(
         descriptor_data["root_dir"],
         "simulations",
         descriptor_data["experiment"],
     )
+
+    # Sync NFS
     root_logfile_directory = os.path.join(root_directory, "logs")
+    statefile_directory = os.path.join(root_logfile_directory, "statefiles")
     os.system(f"ls -R {root_directory} > /dev/null")
 
     try:
-        all_log_files = os.listdir(root_logfile_directory)
+        all_state_files = os.listdir(statefile_directory)
     except Exception:
-        print("Log file directory does not exist")
+        print("State file directory does not exist")
         print("The current experiment does not seem to have been run yet")
         return
 
-    if len(all_log_files) > len(all_jobs) + log_file_count_buffer:
+    if len(all_state_files) > len(all_job_ids):
         print("More log files than total runs. Maybe same experiment name was run multiple times?")
 
-    # Single pass: build latest parseable logs (for status processing) and count all
-    # unique log entries including unparseable ones (for log_count_offset assertions).
-    _parseable: dict = {}   # (config, suite, subsuite, workload, cid) → (job_id, Path)
-    _unparseable: set = set()   # unique filenames for unparseable logs
-    for _lp in Path(root_logfile_directory).glob("job_*.out"):
-        try:
-            _jid = int(_lp.stem.split("_")[1])
-        except (IndexError, ValueError):
-            # e.g. the literal "job_%j.out" placeholder touched before sbatch submission
-            _unparseable.add(_lp.name)
-            continue
-        try:
-            with _lp.open(encoding="utf-8", errors="replace") as _fh:
-                _first = _fh.readline().strip()
-        except OSError:
-            continue
-        _parsed = parse_job_log_header(_first)
-        if _parsed is not None:
-            _key = _parsed  # (config, suite, subsuite, workload, cid)
-            if _jid > _parseable.get(_key, (-1, None))[0]:
-                _parseable[_key] = (_jid, _lp)
-        else:
-            _unparseable.add(_lp.name)
-
-    latest_logs = [
-        (_jid, _lp, config, suite, subsuite, workload, cid)
-        for (config, suite, subsuite, workload, cid), (_jid, _lp) in _parseable.items()
-    ]
-    # total_log_count mirrors the old len(log_files) which included unparseable entries;
-    # log_count_offset and strict_log_count are calibrated against this value.
-    total_log_count = len(latest_logs) + len(_unparseable)
-
     error_runs = set()
-    sim_log_to_job_log = {}
-    skipped = 0
 
-    confs = list(descriptor_data["configurations"].keys())
+    confs = list(map(lambda x:x.replace("_", "-"), descriptor_data["configurations"].keys()))
 
     completed = {conf: 0 for conf in confs}
     failed = {conf: 0 for conf in confs}
@@ -2212,132 +2189,44 @@ def print_simulation_status_summary(
     running = {conf: 0 for conf in confs}
     pending = {conf: 0 for conf in confs}
 
-    experiment_name = descriptor_data["experiment"]
-    for sim in queued_sims:
-        matches = [conf for conf in confs if f"{experiment_name}_{conf}" in sim]
-        if not matches:
-            info(f"'{experiment_name}_{conf}' not found in any queued sim names", dbg_lvl)
-            continue
-        conf = max(matches, key=len)
-        pending[conf] += 1
+    not_in_experiment = 0
+    total_running = 0
+    for statefile in Path(statefile_directory).glob("*.log"):
+        print(statefile.stem)
+        if len(statefile.stem.split('_')) != 5:
+            err(f"Not 5 sections in statefile name {statefile.stem}", 1)
+            exit(1)
 
-    all_job_ids = get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl=dbg_lvl)
+        config, suite, subsuite, workload, cluster_id = statefile.stem.split('_')
 
-    not_in_experiment = []
-    oom_killed = []
-    oom_killed_sps = 0
-    descriptor_aligned_log_count = 0
-    for _job_id, log_path, config, suite, subsuite, workload, cluster_id in latest_logs:
         if not (config, suite, subsuite, workload, int(cluster_id)) in all_job_ids:
+            info(f"Statefile {statefile.stem} not found in experiment", dbg_lvl)
+            print(all_job_ids)
+            not_in_experiment += 1
             continue
 
-        descriptor_aligned_log_count += 1
-        workload_path = f"{suite}/{subsuite}/{workload}"
-        with open(log_path, 'r') as f:
+        with open(statefile, 'r') as f:
             contents = f.read()
-            contents_after_docker = contents
-            if len(contents.split("\n")) < 2:
-                continue
 
-            scarab_logfile_path = os.path.join(
-                root_directory,
-                config,
-                workload_path,
-                cluster_id,
-                "sim.log",
-            )
-            sim_log_to_job_log[scarab_logfile_path] = str(log_path)
-
-            if config not in confs:
-                if config not in not_in_experiment:
-                    print(f"WARN: Log files for config {config}, which is not in the experiment file")
-                not_in_experiment.append(config)
-                continue
-
-            pattern = r"Script name: (\S*)"
-            match = re.search(pattern, contents)
-            if match:
-                script_name = match.group(1)
-                is_running = any(sim in script_name for sim in running_sims)
-                if is_running:
-                    skipped += 1
-                    running[config] += 1
-                    continue
-
-            if "BEGIN prepare_docker_image" in contents:
-                if "FAILED prepare_docker_image" in contents:
-                    prep_failed[config] += 1
-                    error_runs.add(str(log_path))
-                    print("Docker image preparation failed, Simulation is not running (Error message in log file)")
-                    continue
-
-                if "END prepare_docker_image" in contents:
-                    contents_after_docker = contents.split("END prepare_docker_image\n")[1]
-                else:
-                    prep_failed[config] += 1
-                    error_runs.add(str(log_path))
-                    print("Docker image preparation failed, Simulation is not running (Image prep never completed; no failure message)")
-                    continue
-            else:
-                print("Docker image preparation failed (Image prep never started)")
-                prep_failed[config] += 1
-                error_runs.add(str(log_path))
-                continue
-
-            if 'docker: Error' in contents_after_docker:
-                prep_failed[config] += 1
-                error_runs.add(str(log_path))
-                continue
-
-            prep_err = 0
-            workload_parts = workload_path.split("/")
-            sim_dir = Path(descriptor_data["root_dir"]) / "simulations" / descriptor_data["experiment"] / config
-            sim_dir = sim_dir.joinpath(*workload_parts, cluster_id)
-            has_csv = False
-            try:
-                has_csv = any(x.endswith(".csv") for x in os.listdir(sim_dir))
-            except OSError:
-                has_csv = False
-
-            status_scan_text = _scrub_ignorable_slurm_job_log_noise(contents_after_docker)
-
-            # If slurm cancelled wrapper execution but results were already produced, treat as completed.
-            if "cancelled" in status_scan_text.lower() and has_csv:
+            if "Job COMPLETED SUCCESSFULLY" in contents:
                 completed[config] += 1
-                continue
+            elif "Job FAILED - Runner" in contents:
+                prep_failed[config] += 1
+            elif "Job FAILED - Scarab" in contents:
+                failed[config] += 1
+            elif "Job RUNNING" in contents:
+                total_running += 1
+                running[config] += 1
+            elif "Job PENDING" in contents:
+                pending[config] += 1
+            else:
+                # State file is created by echo-ing Job PENDING into statefile.
+                # Should be safe to assume pending here, but I will throw warning
+                pending[config] += 1
+                warn(f"Statefile {statefile.stem} found but has no contents. Assuming pending", 2)
 
-            if all_nodes:
-                for node in all_nodes:
-                    if f"{node}: error:" in status_scan_text:
-                        error_runs.add(str(log_path))
-                        prep_failed[config] += 1
-                        prep_err = 1
 
-                        if "oom_kill" in status_scan_text:
-                            oom_killed_sps += 1
-                            if config not in oom_killed:
-                                oom_killed.append(config)
-
-            if prep_err:
-                continue
-
-            error = 0
-            if 'Segmentation fault' in status_scan_text:
-                error = 1
-
-            if 'error' in status_scan_text.lower():
-                error = 1
-
-            if "Completed Simulation" in status_scan_text and not error:
-                if has_csv:
-                    completed[config] += 1
-                    continue
-                err("Stat files not generated, despite being completed with no errors.", 1)
-
-            error_runs.add(scarab_logfile_path)
-            failed[config] += 1
-
-    print(f"Currently running {len(running_sims)} simulations (from logs: {skipped})")
+    print(f"Currently running {total_running} simulations")
 
     calculated_logfile_count = 0
     data = {
@@ -2358,7 +2247,7 @@ def print_simulation_status_summary(
         data["Running"].append(running[conf])
         data["Pending"].append(pending[conf])
 
-        total_per_conf = int(len(all_jobs) / len(confs))
+        total_per_conf = int(len(all_job_ids) / len(confs))
         total_found = completed[conf] + failed[conf] + running[conf] + pending[conf] + prep_failed[conf]
         calculated_logfile_count += total_found - pending[conf]
 
@@ -2367,11 +2256,10 @@ def print_simulation_status_summary(
         data["Total"].append(total_per_conf)
         data["Non-existant"].append(total_per_conf - total_found)
 
-    if len(not_in_experiment) == 0:
-        if strict_log_count:
-            assert calculated_logfile_count == descriptor_aligned_log_count, "ERR: Assert Failed: Log file count doesn't match number of accounted jobs"
-        elif calculated_logfile_count != descriptor_aligned_log_count:
-            warn("Log file count doesn't match number of accounted jobs.", dbg_lvl)
+    if strict_log_count:
+        assert len(all_state_files) - not_in_experiment == len(all_job_ids), "ERR: Assert Failed: Log file count doesn't match number of accounted jobs"
+    elif len(all_state_files) - not_in_experiment != len(all_job_ids):
+        warn("Log file count doesn't match number of accounted jobs.", dbg_lvl)
 
     print("PRINTING SUMMARY TABLE:")
     print(generate_table(data))
@@ -2421,12 +2309,12 @@ def print_simulation_status_summary(
     else:
         print(f"\033[92mNo errors found in log files\033[0m")
 
-    if oom_killed_sps > 0:
-        print()
-        print(f"\033[31mOOM Killed Jobs: {oom_killed_sps}\033[0m")
-        print("To fix: Run './sci --collect-mem <descriptor>' after jobs complete to record per-simpoint memory measurements. The infra will use these to schedule future runs with appropriate --mem limits.")
-        print("If jobs haven't run yet, set 'memory_overhead_mb' in the config entry within the descriptor to add a fixed overhead on top of the auto-scheduled base memory.")
-        print("OOM Killed Configs:\n", "\n".join(oom_killed), "\033[0m", sep='')
+    # if oom_killed_sps > 0:
+    #     print()
+    #     print(f"\033[31mOOM Killed Jobs: {oom_killed_sps}\033[0m")
+    #     print("To fix: Run './sci --collect-mem <descriptor>' after jobs complete to record per-simpoint memory measurements. The infra will use these to schedule future runs with appropriate --mem limits.")
+    #     print("If jobs haven't run yet, set 'memory_overhead_mb' in the config entry within the descriptor to add a fixed overhead on top of the auto-scheduled base memory.")
+    #     print("OOM Killed Configs:\n", "\n".join(oom_killed), "\033[0m", sep='')
 
 def remove_docker_containers(docker_prefix_list, job_name, user, dbg_lvl):
     try:
@@ -2821,7 +2709,7 @@ def check_sp_exist (descriptor_data, config_key, suite, subsuite, workload, exp_
 
 # Returns true if experiment failed
 def check_sp_failed (experiment_dir, config_key, suite, subsuite, workload, exp_cluster_id, dbg_lvl=1):
-    statefile = f"{experiment_dir}/logs/statefiles/{config_key}_{suite}_{subsuite}_{workload}_{exp_cluster_id}.log"
+    statefile = f"{experiment_dir}/logs/statefiles/{get_statefile_name(config_key, suite, subsuite, workload, exp_cluster_id)}.log"
     try:
         with open(statefile, "r") as f:
             return "Job FAILED" in f.readlines()
@@ -2847,7 +2735,7 @@ def clean_failed_run (experiment_dir, config_key, suite, subsuite, workload, exp
         err(f"Error cleaning files in {experiment_dir}: {e}", 1)
 
     # Wipe statefile. Keep old run slurm log files
-    statefile = f"{experiment_dir}/logs/statefiles/{config_key}_{suite}_{subsuite}_{workload}_{exp_cluster_id}.log"
+    statefile = f"{experiment_dir}/logs/statefiles/{get_statefile_name(config_key, suite, subsuite, workload, exp_cluster_id)}.log"
     Path(statefile).unlink()
 
 # Check if run was already successful, and thus skippable
@@ -2920,11 +2808,16 @@ def generate_table(data, title=""):
 
     return table_string
 
+def get_statefile_name(config, suite, subsuite, workload, simpoint):
+    name = f"{config.replace('_', '-')}_{suite.replace('_', '-')}_{subsuite.replace('_', '-')}"
+    name += f"_{workload.replace('_', '-')}_{simpoint.replace('_', '-')}"
+    return name
+
 def update_statefile(experiment_dir, config, suite, subsuite, workload, simpoint, message):
-    statefile = f"{experiment_dir}/logs/statefiles/{config}_{suite}_{subsuite}_{workload}_{simpoint}.log"
+    statefile = f"{experiment_dir}/logs/statefiles/{get_statefile_name(config, suite, subsuite, workload, simpoint)}.log"
     with open(statefile, "a") as f:
         f.write(message+"\n")
 
 def check_statefile_exists(experiment_dir, config, suite, subsuite, workload, simpoint):
-    statefile = f"{experiment_dir}/logs/statefiles/{config}_{suite}_{subsuite}_{workload}_{simpoint}.log"
+    statefile = f"{experiment_dir}/logs/statefiles/{get_statefile_name(config, suite, subsuite, workload, simpoint)}.log"
     return os.path.exists(statefile)

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1585,7 +1585,7 @@ def write_docker_command_to_file(user, local_uid, local_gid, suite, subsuite, wo
                                  docker_prefix, docker_container_name, traces_dir,
                                  docker_home, githash, config_key, config, scarab_mode, scarab_binary,
                                  seg_size, architecture, cluster_id, warmup, trace_warmup, trace_type,
-                                 trace_file, env_vars, bincmd, client_bincmd, filename, infra_dir, application_dir, memory_mb, slurm=False):
+                                 trace_file, env_vars, bincmd, client_bincmd, filename, infra_dir, application_dir, memory_mb=None, slurm=False):
     try:
         workload_home = f"{suite}/{subsuite}/{workload}"
         scarab_cmd = generate_single_scarab_run_command(user, workload_home, experiment_name, config_key, config,

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1938,7 +1938,7 @@ def get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl = 1)
                         sim_mode_ = workloads_data[suite][subsuite_][workload_]["simulation"]["prioritized_mode"]
                     simpoint_ids = get_simpoints_wrapper(suite, subsuite_, workload_, exp_cluster_id, sim_mode_) * len(configs)
                     all_jobs += [
-                        sanitize(config, suite, subsuite_, workload_, cluster_id)
+                        (config, suite, subsuite_, workload_, cluster_id)
                         for config in configs.keys()
                         for cluster_id in simpoint_ids
                     ]
@@ -1951,7 +1951,7 @@ def get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl = 1)
                     sim_mode_ = workloads_data[suite][subsuite][workload_]["simulation"]["prioritized_mode"]
                 simpoint_ids = get_simpoints_wrapper(suite, subsuite, workload_, exp_cluster_id, sim_mode_) * len(configs)
                 all_jobs += [
-                    sanitize(config, suite, subsuite, workload_, cluster_id)
+                    (config, suite, subsuite, workload_, cluster_id)
                     for config in configs.keys()
                     for cluster_id in simpoint_ids
                 ]
@@ -1961,7 +1961,7 @@ def get_simulation_job_identifiers(descriptor_data, workloads_data, dbg_lvl = 1)
                 sim_mode_ = workloads_data[suite][subsuite][workload]["simulation"]["prioritized_mode"]
             simpoint_ids = get_simpoints_wrapper(suite, subsuite, workload, exp_cluster_id, sim_mode_) * len(configs)
             all_jobs += [
-                sanitize(config, suite, subsuite, workload, cluster_id)
+                (config, suite, subsuite, workload, cluster_id)
                 for config in configs.keys()
                 for cluster_id in simpoint_ids
             ]
@@ -2166,11 +2166,18 @@ def get_runner_logs(root_logfile_directory):
                 first_line = file_handle.readline().strip()
         except OSError:
             continue
-        parsed = parse_job_log_header(first_line, sanitize_result=True)
+        parsed = parse_job_log_header(first_line, sanitize_result=False)
         log_file_db[parsed] = file
 
     return log_file_db
 
+def is_log_readable(path):
+    try:
+        with open(path, "r") as f:
+            pass
+        return True
+    except:
+        return False
 
 def print_simulation_status_summary(
     descriptor_data,
@@ -2214,7 +2221,7 @@ def print_simulation_status_summary(
 
     error_runs = set()
 
-    confs = list(map(lambda x:x.replace("_", "-"), descriptor_data["configurations"].keys()))
+    confs = descriptor_data["configurations"]
 
     completed = {conf: 0 for conf in confs}
     failed = {conf: 0 for conf in confs}
@@ -2222,26 +2229,38 @@ def print_simulation_status_summary(
     running = {conf: 0 for conf in confs}
     pending = {conf: 0 for conf in confs}
 
+    runner_log_to_sim_log = {}
+
     not_in_experiment = 0
     total_running = 0
     oom_killed_sps = []
     statefiles = Path(statefile_directory).glob("*.log")
     for statefile in statefiles:
-        if len(statefile.stem.split('_')) != 5:
+        if len(statefile.stem.split('___')) != 5:
             err(f"Not 5 sections in statefile name {statefile.stem}", 1)
             exit(1)
 
-        config, suite, subsuite, workload, cluster_id = statefile.stem.split('_')
+        config, suite, subsuite, workload, cluster_id = statefile.stem.split('___')
         logfile_key = (config, suite, subsuite, workload, cluster_id) # Log dictionaries use tuple as key
 
         if not (config, suite, subsuite, workload, int(cluster_id)) in all_job_ids:
             info(f"Statefile {statefile.stem} not found in experiment", dbg_lvl)
-            print(all_job_ids)
+            print("Not found in:", all_job_ids)
             not_in_experiment += 1
             continue
 
         with open(statefile, 'r') as f:
             contents = f.read()
+            scarab_logfile = os.path.join(
+                    root_directory,
+                    config,
+                    suite,
+                    subsuite,
+                    workload,
+                    cluster_id,
+                    "sim.log"
+                )
+            runner_log_to_sim_log[runner_logs[logfile_key]] = scarab_logfile
 
             if "Job COMPLETED SUCCESSFULLY" in contents:
                 completed[config] += 1
@@ -2251,8 +2270,10 @@ def print_simulation_status_summary(
                 oom_killed_sps.append(statefile.stem)
             elif "Job FAILED - Scarab" in contents:
                 failed[config] += 1
-                # TODO: Check OOM. Use suite, subsuite, workload, cluster_id from above
-                # TODO: Get scarab log file
+                if is_log_readable(scarab_logfile):
+                    error_runs.add(scarab_logfile)
+                else:
+                    error_runs.add(runner_logs[logfile_key])
             elif "Job RUNNING" in contents:
                 total_running += 1
                 running[config] += 1
@@ -2317,34 +2338,10 @@ def print_simulation_status_summary(
                 tail_lines = list(deque(first_error_log_file, maxlen=20))
             if tail_lines:
                 print("".join(tail_lines).rstrip("\n"))
-            elif fallback_log:
-                print(f"<empty log file; showing runner log fallback: {fallback_log}>")
-                fallback_log = sim_log_to_job_log.get(first_error_log)
-                try:
-                    with open(fallback_log, "r", errors="replace") as fallback_log_file:
-                        fallback_tail_lines = list(deque(fallback_log_file, maxlen=20))
-                    if fallback_tail_lines:
-                        print("".join(fallback_tail_lines).rstrip("\n"))
-                    else:
-                        print("<runner log is also empty>")
-                except OSError as fallback_exc:
-                    print(f"<unable to read runner log fallback: {fallback_exc}>")
             else:
                 print("<empty log file>")
         except OSError as exc:
-            if fallback_log:
-                print(f"<unable to read log file: {exc}; showing runner log fallback: {fallback_log}>")
-                try:
-                    with open(fallback_log, "r", errors="replace") as fallback_log_file:
-                        fallback_tail_lines = list(deque(fallback_log_file, maxlen=20))
-                    if fallback_tail_lines:
-                        print("".join(fallback_tail_lines).rstrip("\n"))
-                    else:
-                        print("<runner log is also empty>")
-                except OSError as fallback_exc:
-                    print(f"<unable to read runner log fallback: {fallback_exc}>")
-            else:
-                print(f"<unable to read log file: {exc}>")
+            print(f"<unable to read log file: {exc}>")
         print("\033[0m", end="")
     else:
         print(f"\033[92mNo errors found in log files\033[0m")
@@ -2815,7 +2812,7 @@ def generate_table(data, title=""):
     Returns:
         str: A string representing the formatted table.
     """
-    
+
     if not data:
         return "No data provided."
 
@@ -2850,8 +2847,8 @@ def generate_table(data, title=""):
     return table_string
 
 def get_statefile_name(config, suite, subsuite, workload, simpoint):
-    name = f"{config.replace('_', '-')}_{suite.replace('_', '-')}_{subsuite.replace('_', '-')}"
-    name += f"_{workload.replace('_', '-')}_{simpoint.replace('_', '-')}"
+    name = f"{config}___{suite}___{subsuite}"
+    name += f"___{workload}___{simpoint}"
     return name
 
 def update_statefile(experiment_dir, config, suite, subsuite, workload, simpoint, message):

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1585,7 +1585,7 @@ def write_docker_command_to_file(user, local_uid, local_gid, suite, subsuite, wo
                                  docker_prefix, docker_container_name, traces_dir,
                                  docker_home, githash, config_key, config, scarab_mode, scarab_binary,
                                  seg_size, architecture, cluster_id, warmup, trace_warmup, trace_type,
-                                 trace_file, env_vars, bincmd, client_bincmd, filename, infra_dir, application_dir, slurm=False):
+                                 trace_file, env_vars, bincmd, client_bincmd, filename, infra_dir, application_dir, memory_mb, slurm=False):
     try:
         workload_home = f"{suite}/{subsuite}/{workload}"
         scarab_cmd = generate_single_scarab_run_command(user, workload_home, experiment_name, config_key, config,
@@ -1606,9 +1606,9 @@ def write_docker_command_to_file(user, local_uid, local_gid, suite, subsuite, wo
             f.write("    docker rm -f \"$CONTAINER_NAME\" >/dev/null 2>&1 || true\n")
             f.write("}\n")
             f.write("graceful_exit() {\n")
-            f.write("    if [ -z $SCARAB_EXIT ]; then\n")
-            f.write("        echo \"Job FAILED - Runner\" >> $STATEFILE\n")
-            f.write("    fi\n")
+            #f.write("    if [ -z $SCARAB_EXIT ]; then\n")
+            #f.write("        echo \"Job FAILED - Runner\" >> $STATEFILE\n")
+            #f.write("    fi\n")
             f.write("    cleanup_container\n")
             f.write("}\n")
             f.write("trap graceful_exit EXIT INT TERM HUP\n")
@@ -1619,8 +1619,9 @@ def write_docker_command_to_file(user, local_uid, local_gid, suite, subsuite, wo
                 f.write("SLURM_CGROUP=$(cat /proc/self/cgroup | cut -d: -f3 | head -n 1)\n")
                 f.write("echo $SLURM_CGROUP\n")
                 f.write(f"docker run --privileged\
-                --cgroup-parent $SLURM_CGROUP \
-                --cgroupns=host \
+                --memory={memory_mb}m \
+                --memory-swap={memory_mb}m \
+                --memory-swappiness=0 \
                 -e user_id={local_uid} \
                 -e group_id={local_gid} \
                 -e username={user} \
@@ -1668,17 +1669,21 @@ def write_docker_command_to_file(user, local_uid, local_gid, suite, subsuite, wo
             f.write("docker exec --privileged $CONTAINER_NAME /bin/bash -c '/usr/local/bin/root_entrypoint.sh'\n")
             f.write(f"docker exec --user={user} $CONTAINER_NAME /bin/bash -c \"source /usr/local/bin/user_entrypoint.sh && {scarab_cmd}\" \n")
             f.write("SCARAB_EXIT=$?\n")
+            f.write("OOMKILLED=$(docker inspect --format '{{.State.OOMKilled}}' $CONTAINER_NAME)\n")
             f.write(f"ls {docker_home}/simulations/{experiment_name}/{config_key}/{workload_home}/{cluster_id} | grep csv$ > /dev/null\n")
             f.write("STAT_FILE_CHECK=$?\n")
             f.write("echo $STAT_FILE_CHECK\n")
-            f.write("if [[ $SCARAB_EXIT -ne 0 || $STAT_FILE_CHECK -ne 0 ]]; then\n")
+            f.write("if [[ $OOMKILLED = \"true\" ]]; then\n")
+            f.write("    echo \"Runner error detected\"\n")
+            f.write("    echo \"Job FAILED - Runner : OOM Killed\" >> $STATEFILE\n")
+            f.write("elif [[ $SCARAB_EXIT -ne 0 || $STAT_FILE_CHECK -ne 0 ]]; then\n")
             f.write("    echo \"Scarab error detected\"\n")
             f.write("    echo \"Job FAILED - Scarab\" >> $STATEFILE\n")
             f.write("else\n")
+            f.write("    echo \"Completed Simulation\"\n")
             f.write("    echo \"Job COMPLETED SUCCESSFULLY\" >> $STATEFILE\n")
             f.write("fi\n")
             f.write("cleanup_container\n")
-            f.write("echo \"Completed Simulation\"\n")
             f.write(f"sync {docker_home}/simulations/{experiment_name}/logs")
     except Exception as e:
         raise e
@@ -2165,7 +2170,7 @@ def get_runner_logs(root_logfile_directory):
         parsed = parse_job_log_header(first_line, sanitize_result=True)
         log_file_db[parsed] = file
 
-        return log_file_db
+    return log_file_db
 
 
 def print_simulation_status_summary(
@@ -2220,7 +2225,8 @@ def print_simulation_status_summary(
 
     not_in_experiment = 0
     total_running = 0
-    for statefile in Path(statefile_directory).glob("*.log"):
+    statefiles = Path(statefile_directory).glob("*.log")
+    for statefile in statefiles:
         print(statefile.stem)
         if len(statefile.stem.split('_')) != 5:
             err(f"Not 5 sections in statefile name {statefile.stem}", 1)
@@ -2242,6 +2248,7 @@ def print_simulation_status_summary(
                 completed[config] += 1
             elif "Job FAILED - Runner" in contents:
                 prep_failed[config] += 1
+                print(runner_logs.keys())
                 error_runs.add(runner_logs[logfile_key])
             elif "Job FAILED - Scarab" in contents:
                 failed[config] += 1
@@ -2271,6 +2278,7 @@ def print_simulation_status_summary(
         "Non-existant": [],
         "Total": [],
     }
+    total_logfiles = 0
     for conf in confs:
         data["Configuration"].append(conf)
         data["Completed"].append(completed[conf])
@@ -2286,6 +2294,7 @@ def print_simulation_status_summary(
         assert total_per_conf >= total_found, "ERR: Assert Failed: More jobs found (via squeue and log files) than should exist"
 
         data["Total"].append(total_per_conf)
+        total_logfiles += total_per_conf
         data["Non-existant"].append(total_per_conf - total_found)
 
     if strict_log_count:
@@ -2299,7 +2308,7 @@ def print_simulation_status_summary(
     if error_runs:
         error_list = sorted(error_runs)
         print(f"\033[31mErroneous Jobs: {len(error_list)}\033[0m")
-        print(f"\033[31mErrors found in {len(error_list)}/{len(latest_logs)} latest log files.")
+        print(f"\033[31mErrors found in {len(error_list)}/{total_logfiles} latest log files.")
         print("First 5 error runs:\n", "\n".join(error_list[:5]), "\033[0m", sep='')
         first_error_log = error_list[0]
         print()

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1606,9 +1606,9 @@ def write_docker_command_to_file(user, local_uid, local_gid, suite, subsuite, wo
             f.write("    docker rm -f \"$CONTAINER_NAME\" >/dev/null 2>&1 || true\n")
             f.write("}\n")
             f.write("graceful_exit() {\n")
-            #f.write("    if [ -z $SCARAB_EXIT ]; then\n")
-            #f.write("        echo \"Job FAILED - Runner\" >> $STATEFILE\n")
-            #f.write("    fi\n")
+            f.write("    if [ -z $SCARAB_EXIT ]; then\n")
+            f.write("        echo \"Job FAILED - Runner\" >> $STATEFILE\n")
+            f.write("    fi\n")
             f.write("    cleanup_container\n")
             f.write("}\n")
             f.write("trap graceful_exit EXIT INT TERM HUP\n")
@@ -2224,9 +2224,9 @@ def print_simulation_status_summary(
 
     not_in_experiment = 0
     total_running = 0
+    oom_killed_sps = []
     statefiles = Path(statefile_directory).glob("*.log")
     for statefile in statefiles:
-        print(statefile.stem)
         if len(statefile.stem.split('_')) != 5:
             err(f"Not 5 sections in statefile name {statefile.stem}", 1)
             exit(1)
@@ -2247,8 +2247,8 @@ def print_simulation_status_summary(
                 completed[config] += 1
             elif "Job FAILED - Runner" in contents:
                 prep_failed[config] += 1
-                print(runner_logs.keys())
                 error_runs.add(runner_logs[logfile_key])
+                oom_killed_sps.append(statefile.stem)
             elif "Job FAILED - Scarab" in contents:
                 failed[config] += 1
                 # TODO: Check OOM. Use suite, subsuite, workload, cluster_id from above
@@ -2349,12 +2349,12 @@ def print_simulation_status_summary(
     else:
         print(f"\033[92mNo errors found in log files\033[0m")
 
-    # if oom_killed_sps > 0:
-    #     print()
-    #     print(f"\033[31mOOM Killed Jobs: {oom_killed_sps}\033[0m")
-    #     print("To fix: Run './sci --collect-mem <descriptor>' after jobs complete to record per-simpoint memory measurements. The infra will use these to schedule future runs with appropriate --mem limits.")
-    #     print("If jobs haven't run yet, set 'memory_overhead_mb' in the config entry within the descriptor to add a fixed overhead on top of the auto-scheduled base memory.")
-    #     print("OOM Killed Configs:\n", "\n".join(oom_killed), "\033[0m", sep='')
+    if len(oom_killed_sps) > 0:
+        print()
+        print(f"\033[31mOOM Killed Jobs: {len(oom_killed_sps)}\033[0m")
+        print("To fix: Run './sci --collect-mem <descriptor>' after jobs complete to record per-simpoint memory measurements. The infra will use these to schedule future runs with appropriate --mem limits.")
+        print("If jobs haven't run yet, set 'memory_overhead_mb' in the config entry within the descriptor to add a fixed overhead on top of the auto-scheduled base memory.")
+        print("OOM Killed Configs:\n", "\n".join(oom_killed_sps), "\033[0m", sep='')
 
 def remove_docker_containers(docker_prefix_list, job_name, user, dbg_lvl):
     try:

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1605,7 +1605,7 @@ def write_docker_command_to_file(user, local_uid, local_gid, workload, workload_
             f.write("    docker rm -f \"$CONTAINER_NAME\" >/dev/null 2>&1 || true\n")
             f.write("}\n")
             f.write("graceful_exit() {\n")
-            f.write("    if [ -n $SCARAB_EXIT ]; then\n")
+            f.write("    if [ -z $SCARAB_EXIT ]; then\n")
             f.write("        echo \"Job FAILED - Runner\" >> $STATEFILE\n")
             f.write("    fi\n")
             f.write("    cleanup_container\n")
@@ -2820,28 +2820,21 @@ def check_sp_exist (descriptor_data, config_key, suite, subsuite, workload, exp_
     return False
 
 # Returns true if experiment failed
-def check_sp_failed (descriptor_data, config_key, suite, subsuite, workload, exp_cluster_id):
-    # Check if simpoint exists
-    experiment_dir =  f"{descriptor_data['root_dir']}/simulations/{descriptor_data['experiment']}/"
-    experiment_dir += f"{config_key}/{suite}/{subsuite}/{workload}/{exp_cluster_id}"
-
-    if Path(experiment_dir).is_dir() == False:
+def check_sp_failed (experiment_dir, config_key, suite, subsuite, workload, exp_cluster_id, dbg_lvl=1):
+    statefile = f"{experiment_dir}/logs/statefiles/{config_key}_{suite}_{subsuite}_{workload}_{exp_cluster_id}.log"
+    try:
+        with open(statefile, "r") as f:
+            return "Job FAILED" in f.readlines()
+    except Exception as e:
+        warn(f"Statefile did not exist during check. Existance should have been checked previously: {e}", dbg_lvl)
         return True
-
-    # Failed case; CSV files not generated. Ignoring .csv.warmup files.
-    if len(list(filter(lambda x: x.endswith('.csv'), os.listdir(experiment_dir)))) == 0:
-        return True
-
-    # Success case
-    return False
 
 # Clean up failed run
-def clean_failed_run (descriptor_data, config_key, suite, subsuite, workload, exp_cluster_id, dbg_lvl=1):
+def clean_failed_run (experiment_dir, config_key, suite, subsuite, workload, exp_cluster_id, dbg_lvl=1):
     # Remove failed run artifacts while preserving directory structure
-    experiment_dir =  f"{descriptor_data['root_dir']}/simulations/{descriptor_data['experiment']}/"
-    experiment_dir += f"{config_key}/{suite}/{subsuite}/{workload}/{exp_cluster_id}"
+    cluster_output_path = f"{experiment_dir}/{config_key}/{suite}/{subsuite}/{workload}/{exp_cluster_id}"
 
-    experiment_path = Path(experiment_dir)
+    experiment_path = Path(cluster_output_path)
     patterns_to_clean = ["*.csv", "*.out", "*.in", "*.csv.warmup", "*.out.warmup", "sim.log"]
 
     try:
@@ -2853,39 +2846,28 @@ def clean_failed_run (descriptor_data, config_key, suite, subsuite, workload, ex
     except Exception as e:
         err(f"Error cleaning files in {experiment_dir}: {e}", 1)
 
-    # Wipe log file
-    log_dir =  Path(f"{descriptor_data['root_dir']}/simulations/{descriptor_data['experiment']}/logs/")
-    log_files = log_dir.glob("log_*.out")
-    for file in log_files:
-        with open(file, 'r') as f:
-            lines = f.readlines()
-
-            # Logfile will have {config} {suite}/{subsuite}/{workload} {simpoint} as header
-            header = f"Running {config_key} {suite}/{subsuite}/{workload} {exp_cluster_id}\n"
-            if header in lines:
-                info(f"Removing log entry for failed run: {header.strip()}", dbg_lvl)
-                file.unlink()
-
-    # TODO: delete statefile and launch script
+    # Wipe statefile. Keep old run slurm log files
+    statefile = f"{experiment_dir}/logs/statefiles/{config_key}_{suite}_{subsuite}_{workload}_{exp_cluster_id}.log"
+    Path(statefile).unlink()
 
 # Check if run was already successful, and thus skippable
 # Please use as follows:
 # if check_can_skip(...):
 #     continue
-def check_can_skip (descriptor_data, config_key, suite, subsuite, workload, cluster_id, filename, dbg_lvl=1):
+def check_can_skip (experiment_dir, config_key, suite, subsuite, workload, cluster_id, filename, dbg_lvl=1):
     # Check if it is about to be run
-    if os.path.exists(filename):
+    if not check_statefile_exists(experiment_dir, config_key, suite, subsuite, workload, cluster_id):
         # Run script has generated run file, it will be run shortly.
-        info(f"Run script for {config_key} for workload {workload} exists. Other script will run it.", dbg_lvl)
-        return True
+        info(f"Statefile for {config_key} for workload {workload} ({cluster_id}) not found.", dbg_lvl)
+        return False
 
     # If CSV files don't exist, clean up failed run and re-run (can skip = False)
-    if check_sp_failed(descriptor_data, config_key, suite, subsuite, workload, cluster_id):
+    if check_sp_failed(experiment_dir, config_key, suite, subsuite, workload, cluster_id, dbg_lvl=dbg_lvl):
         info(f"Previous run with config {config_key} for workload {workload} failed. Cleaning directory and Re-running.", dbg_lvl)
-        clean_failed_run(descriptor_data, config_key, suite, subsuite, workload, cluster_id, dbg_lvl=dbg_lvl)
+        clean_failed_run(experiment_dir, config_key, suite, subsuite, workload, cluster_id, dbg_lvl=dbg_lvl)
         return False
         
-    # Since sp_failed returned false, we know csv files exist. No need to re-run.
+    # Since check_sp_failed returned false, we know it completed successfully. No need to re-run.
     info(f"Run with config {config_key} for workload {workload} already completed. Skipping.", dbg_lvl)
     return True
     
@@ -2942,3 +2924,7 @@ def update_statefile(experiment_dir, config, suite, subsuite, workload, simpoint
     statefile = f"{experiment_dir}/logs/statefiles/{config}_{suite}_{subsuite}_{workload}_{simpoint}.log"
     with open(statefile, "a") as f:
         f.write(message+"\n")
+
+def check_statefile_exists(experiment_dir, config, suite, subsuite, workload, simpoint):
+    statefile = f"{experiment_dir}/logs/statefiles/{config}_{suite}_{subsuite}_{workload}_{simpoint}.log"
+    return os.path.exists(statefile)


### PR DESCRIPTION
Implemented 'state files' which store the state (and only the state) of a running process. This allows us to use one authoritative source of information for both the status command, and to check which simpoints to re-run. It also allows the simplification and standardization of these checks. Detailed error reporting is moved to explicit checks after state is determined and static (already failed or succeeded).

Statefiles are stored in {experiment_dir}/logs/statefiles, and contain *only* state information (In progress, Running, Completed, Failed - Scarab, Failed - Runner). Lack of state file means an experiment has not been run.

Runner scrips  are moved to {experiment_dir}/logs/launch_scripts instead of being deleted

### State updates:
- Scarab-infra sci creates the statefile and adds the In progress marker immediately after sbatching
- The launch script immediately writes that it is in the running state as the first thing it does after the slurm/manual scheduler runs it
-  If the docker container is sent exit, terminate, interrupt, or HUP signal, set state to FAILED - Runner
- After scarab completes, the launch script checks the status:
    - If an OOM kill was detected, set state to FAILED - Runner. This has to be handled separately (sigkill is non-maskable)
    - If Scarab returned non-zero exit code or failed to produce csv stats, set state to FAILED - Scarab
    - Otherwise, mark state as successfully completed

Statefiles for tracing is not currently implemented