### PR TITLE
Add IPC S-curve generation to visualize flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You only need additional steps if you want to inspect workloads, collect traces,
 ```
 ./sci --visualize <descriptor>
 ```
-Generates bar charts (value and speedup) for each counter listed in `visualize.counters` and saves them next to `collected_stats.csv` under `<root_dir>/simulations/<descriptor>/`.
+Generates bar charts (value and speedup) for each counter listed in `visualize.counters` and saves them next to `collected_stats.csv` under `<root_dir>/simulations/<descriptor>/`. Also, generates IPC S-curves and saves the corresponding per-simpoint data in CSV format.
 
 Use the descriptor structure:
 ```json

--- a/README.md
+++ b/README.md
@@ -51,12 +51,14 @@ You only need additional steps if you want to inspect workloads, collect traces,
 ```
 ./sci --visualize <descriptor>
 ```
-Generates bar charts (value and speedup) for each counter listed in `visualize.counters` and saves them next to `collected_stats.csv` under `<root_dir>/simulations/<descriptor>/`. Also, generates IPC S-curves and saves the corresponding per-simpoint data in CSV format.
+Generates bar charts (value and speedup) for each counter listed in `visualize.counters` and saves them next to `collected_stats.csv` under `<root_dir>/simulations/<descriptor>/`. When `visualize.scurve` is enabled, it also generates per-simpoint IPC S-curves and prints an ASCII S-curve plus the best/worst simpoints to the console.
 
 Use the descriptor structure:
 ```json
 "visualize": {
   "baseline": "baseline",
+  "configs": ["candidate"],
+  "scurve": true,
   "counters": ["IPC"]
 }
 ```
@@ -78,6 +80,16 @@ For additional control you may instead supply objects such as:
 The `name` (optional) governs the output filename stem, while `title` and `y_label` adjust plot annotations.
 
 Set `visualize.baseline` to force the speedup plots to use a specific configuration as their reference (defaults to the first configuration present in the stats file).
+
+Set `visualize.scurve` to `true` to emit IPC S-curves for the same baseline/config selection. Outputs are written under `ipc_scurves/<baseline>_vs_<candidate>/` beside `collected_stats.csv`; each pair contains `ipc_scurve_graph.pdf` and `ipc_scurve_data.csv`. For console tuning, use object form:
+```json
+"scurve": {
+  "enabled": true,
+  "top_n": 10,
+  "width": 60,
+  "height": 12
+}
+```
 
 ### Analyze performance drift
 ```

--- a/json/exp.json
+++ b/json/exp.json
@@ -73,12 +73,13 @@
   "collect_stats":{
     "configs":null
   },
-  "_visualize":"Visualization settings for ./sci --visualize. Configure baseline and counters.",
+  "_visualize":"Visualization settings for ./sci --visualize. Configure baseline, configs, counters, and optional IPC S-curves.",
   "visualize":{
     "baseline":"icache_32k",
     "configs":[
       "icache_64k"
     ],
+    "scurve":true,
     "counters":[
       "IPC",
       [

--- a/scarab_stats/ipc_scurve.py
+++ b/scarab_stats/ipc_scurve.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Generate IPC S-curves from a scarab-infra collected_stats.csv file."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+DATA_START_COL = 3
+DEFAULT_OUTDIR = "ipc_scurves"
+GRAPH_NAME = "ipc_scurve_graph.pdf"
+DATA_NAME = "ipc_scurve_data.csv"
+
+
+def _safe_filename(stem: str) -> str:
+    return "".join(c if c.isalnum() or c in {"-", "_"} else "_" for c in stem)
+
+
+def _ordered_unique(values: Iterable[str]) -> List[str]:
+    seen = set()
+    out = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return out
+
+
+def _find_row(df: pd.DataFrame, names: Sequence[str]) -> Optional[pd.Series]:
+    stats = df["stats"].astype(str)
+    lowered = {name.lower() for name in names}
+    matches = df.loc[stats.str.lower().isin(lowered)]
+    if matches.empty:
+        return None
+    return matches.iloc[0]
+
+
+def _row_values(df: pd.DataFrame, names: Sequence[str], data_cols: Sequence[str]) -> Optional[List[object]]:
+    row = _find_row(df, names)
+    if row is None:
+        return None
+    return list(row.loc[list(data_cols)])
+
+
+def _as_float(value: object) -> Optional[float]:
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(out):
+        return None
+    return out
+
+
+def _as_bool(value: object) -> bool:
+    return str(value).strip().lower() in {"1", "true", "t", "yes", "y"}
+
+
+def _parse_colname(colname: str) -> Optional[Tuple[str, str, str]]:
+    parts = str(colname).strip().split()
+    if len(parts) < 3:
+        return None
+    config = parts[0]
+    simpoint = parts[-1]
+    workload = " ".join(parts[1:-1])
+    return config, workload, simpoint
+
+
+def _load_column_metadata(df: pd.DataFrame, data_cols: Sequence[str]) -> List[Tuple[str, str, str]]:
+    configs = _row_values(df, ["Configuration"], data_cols)
+    workloads = _row_values(df, ["Workload"], data_cols)
+    simpoints = _row_values(df, ["Cluster Id", "Cluster ID", "cluster_id"], data_cols)
+
+    if configs is not None and workloads is not None and simpoints is not None:
+        return [
+            (str(configs[i]), str(workloads[i]), str(simpoints[i]))
+            for i in range(len(data_cols))
+        ]
+
+    parsed: List[Tuple[str, str, str]] = []
+    for col in data_cols:
+        item = _parse_colname(col)
+        if item is None:
+            raise ValueError(
+                "Could not find collected-stats metadata rows and could not parse "
+                f"column name: {col!r}"
+            )
+        parsed.append(item)
+    return parsed
+
+
+def _load_ipc_by_config(
+    csv_path: Path,
+) -> Tuple[Dict[str, Dict[Tuple[str, str], float]], List[str]]:
+    df = pd.read_csv(csv_path, low_memory=False)
+    if "stats" not in df.columns:
+        raise ValueError(f"Input CSV must contain a 'stats' column: {csv_path}")
+
+    data_cols = list(df.columns[DATA_START_COL:])
+    if not data_cols:
+        raise ValueError(f"Input CSV has no simpoint data columns: {csv_path}")
+
+    instr = _row_values(
+        df,
+        ["Periodic_Instructions", "Periodic Instructions", "PeriodicInstructions"],
+        data_cols,
+    )
+    cycles = _row_values(
+        df,
+        ["Periodic_Cycles", "Periodic Cycles", "PeriodicCycles"],
+        data_cols,
+    )
+    if instr is None or cycles is None:
+        raise ValueError("Missing required Periodic_Instructions and/or Periodic_Cycles rows.")
+
+    failed = _row_values(df, ["Collect Failed"], data_cols)
+    metadata = _load_column_metadata(df, data_cols)
+
+    ipc_by_config: Dict[str, Dict[Tuple[str, str], float]] = {}
+    configs_in_order: List[str] = []
+    for i, (config, workload, simpoint) in enumerate(metadata):
+        if failed is not None and _as_bool(failed[i]):
+            continue
+        inst = _as_float(instr[i])
+        cyc = _as_float(cycles[i])
+        if inst is None or cyc is None or cyc == 0:
+            continue
+        if config not in ipc_by_config:
+            ipc_by_config[config] = {}
+            configs_in_order.append(config)
+        ipc_by_config[config][(workload, simpoint)] = inst / cyc
+
+    return ipc_by_config, configs_in_order
+
+
+def _build_pair_rows(
+    ipc_by_config: Dict[str, Dict[Tuple[str, str], float]],
+    baseline: str,
+    candidate: str,
+) -> List[Dict[str, object]]:
+    baseline_ipc = ipc_by_config.get(baseline, {})
+    candidate_ipc = ipc_by_config.get(candidate, {})
+    common = sorted(set(baseline_ipc) & set(candidate_ipc))
+
+    rows: List[Dict[str, object]] = []
+    for workload, simpoint in common:
+        base = baseline_ipc[(workload, simpoint)]
+        cand = candidate_ipc[(workload, simpoint)]
+        if base == 0:
+            continue
+        pct = (cand - base) / base * 100.0
+        rows.append(
+            {
+                "workload": workload,
+                "simpoint": simpoint,
+                f"ipc_{baseline}": base,
+                f"ipc_{candidate}": cand,
+                f"percent_change({candidate}_vs_{baseline})": pct,
+            }
+        )
+
+    pct_col = f"percent_change({candidate}_vs_{baseline})"
+    rows.sort(key=lambda row: float(row[pct_col]))
+    for rank, row in enumerate(rows, start=1):
+        row["rank"] = rank
+    return rows
+
+
+def _write_pair_csv(rows: List[Dict[str, object]], csv_path: Path) -> None:
+    if not rows:
+        return
+    fieldnames = ["rank"] + [name for name in rows[0].keys() if name != "rank"]
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_pair_plot(
+    rows: List[Dict[str, object]],
+    baseline: str,
+    candidate: str,
+    graph_path: Path,
+) -> None:
+    pct_col = f"percent_change({candidate}_vs_{baseline})"
+    ranks = [int(row["rank"]) for row in rows]
+    deltas = [float(row[pct_col]) for row in rows]
+
+    fig, ax = plt.subplots(figsize=(5.2, 3.0), dpi=300, constrained_layout=True)
+    ax.plot(
+        ranks,
+        deltas,
+        linewidth=1.6,
+        color="tab:blue",
+    )
+    ax.axhline(0.0, linestyle="--", linewidth=0.8, color="tab:gray")
+    ax.set_title(f"IPC S-curve: {candidate} vs {baseline}", fontsize=10, pad=6)
+    ax.set_xlabel(f"Simpoints sorted by IPC change (n={len(rows)})", fontsize=9, labelpad=6)
+    ax.set_ylabel("Relative IPC change (%)", fontsize=9, labelpad=6)
+    ax.tick_params(axis="both", labelsize=8)
+    ax.margins(x=0.01)
+    ax.grid(True, axis="y", linestyle=":", linewidth=0.6, alpha=0.6)
+    fig.savefig(graph_path, format="pdf")
+    plt.close(fig)
+
+
+def generate_ipc_scurves(
+    csv_path: Path,
+    baseline_config: Optional[str] = None,
+    configs: Optional[Sequence[str]] = None,
+    outdir: Optional[Path] = None,
+) -> List[Dict[str, object]]:
+    """Generate one IPC S-curve for baseline_config vs each other config."""
+    csv_path = Path(csv_path)
+    outdir = Path(outdir) if outdir is not None else csv_path.parent / DEFAULT_OUTDIR
+
+    ipc_by_config, configs_in_order = _load_ipc_by_config(csv_path)
+    if configs:
+        requested = [str(config) for config in configs if str(config) in ipc_by_config]
+    else:
+        requested = list(configs_in_order)
+
+    requested = _ordered_unique(requested)
+    if len(requested) < 2:
+        return []
+
+    baseline = baseline_config if baseline_config in requested else requested[0]
+    candidates = [config for config in requested if config != baseline]
+    outputs: List[Dict[str, object]] = []
+
+    for candidate in candidates:
+        rows = _build_pair_rows(ipc_by_config, baseline, candidate)
+        if not rows:
+            continue
+
+        pair_dir = outdir / f"{_safe_filename(baseline)}_vs_{_safe_filename(candidate)}"
+        pair_dir.mkdir(parents=True, exist_ok=True)
+        graph_path = pair_dir / GRAPH_NAME
+        data_path = pair_dir / DATA_NAME
+
+        _write_pair_csv(rows, data_path)
+        _write_pair_plot(rows, baseline, candidate, graph_path)
+
+        outputs.append(
+            {
+                "baseline": baseline,
+                "candidate": candidate,
+                "points": len(rows),
+                "graph": graph_path,
+                "data": data_path,
+            }
+        )
+
+    return outputs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate per-simpoint IPC S-curves from collected_stats.csv."
+    )
+    parser.add_argument("--input", required=True, help="Path to collected_stats.csv.")
+    parser.add_argument("--outdir", default=None, help="Output directory.")
+    parser.add_argument("--baseline", default=None, help="Baseline configuration name.")
+    parser.add_argument(
+        "--configs",
+        nargs="*",
+        default=None,
+        help="Optional configuration subset/order.",
+    )
+    args = parser.parse_args()
+
+    outputs = generate_ipc_scurves(
+        Path(args.input),
+        baseline_config=args.baseline,
+        configs=args.configs,
+        outdir=Path(args.outdir) if args.outdir else None,
+    )
+    if not outputs:
+        print("No IPC S-curves generated.")
+        return
+    for item in outputs:
+        print(
+            f"{item['baseline']} vs {item['candidate']}: "
+            f"{item['graph']} {item['data']} ({item['points']} simpoints)"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scarab_stats/ipc_scurve.py
+++ b/scarab_stats/ipc_scurve.py
@@ -7,7 +7,7 @@ import argparse
 import csv
 import math
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import matplotlib
 
@@ -20,10 +20,21 @@ DATA_START_COL = 3
 DEFAULT_OUTDIR = "ipc_scurves"
 GRAPH_NAME = "ipc_scurve_graph.pdf"
 DATA_NAME = "ipc_scurve_data.csv"
+DEFAULT_ASCII_WIDTH = 60
+DEFAULT_ASCII_HEIGHT = 12
+DEFAULT_EXTREME_COUNT = 10
 
 
 def _safe_filename(stem: str) -> str:
     return "".join(c if c.isalnum() or c in {"-", "_"} else "_" for c in stem)
+
+
+def _ipc_col(config: str) -> str:
+    return f"ipc_{config}"
+
+
+def _pct_col(baseline: str, candidate: str) -> str:
+    return f"percent_change({candidate}_vs_{baseline})"
 
 
 def _ordered_unique(values: Iterable[str]) -> List[str]:
@@ -164,13 +175,13 @@ def _build_pair_rows(
             {
                 "workload": workload,
                 "simpoint": simpoint,
-                f"ipc_{baseline}": base,
-                f"ipc_{candidate}": cand,
-                f"percent_change({candidate}_vs_{baseline})": pct,
+                _ipc_col(baseline): base,
+                _ipc_col(candidate): cand,
+                _pct_col(baseline, candidate): pct,
             }
         )
 
-    pct_col = f"percent_change({candidate}_vs_{baseline})"
+    pct_col = _pct_col(baseline, candidate)
     rows.sort(key=lambda row: float(row[pct_col]))
     for rank, row in enumerate(rows, start=1):
         row["rank"] = rank
@@ -187,13 +198,21 @@ def _write_pair_csv(rows: List[Dict[str, object]], csv_path: Path) -> None:
         writer.writerows(rows)
 
 
+def _format_float(value: object, digits: int = 4) -> str:
+    numeric = _as_float(value)
+    if numeric is None:
+        return "N/A"
+    formatted = f"{numeric:.{digits}f}".rstrip("0").rstrip(".")
+    return formatted or "0"
+
+
 def _write_pair_plot(
     rows: List[Dict[str, object]],
     baseline: str,
     candidate: str,
     graph_path: Path,
 ) -> None:
-    pct_col = f"percent_change({candidate}_vs_{baseline})"
+    pct_col = _pct_col(baseline, candidate)
     ranks = [int(row["rank"]) for row in rows]
     deltas = [float(row[pct_col]) for row in rows]
 
@@ -205,7 +224,7 @@ def _write_pair_plot(
         color="tab:blue",
     )
     ax.axhline(0.0, linestyle="--", linewidth=0.8, color="tab:gray")
-    ax.set_title(f"IPC S-curve: {candidate} vs {baseline}", fontsize=10, pad=6)
+    ax.set_title(f"IPC S-curve: {baseline} vs {candidate}", fontsize=10, pad=6)
     ax.set_xlabel(f"Simpoints sorted by IPC change (n={len(rows)})", fontsize=9, labelpad=6)
     ax.set_ylabel("Relative IPC change (%)", fontsize=9, labelpad=6)
     ax.tick_params(axis="both", labelsize=8)
@@ -213,6 +232,136 @@ def _write_pair_plot(
     ax.grid(True, axis="y", linestyle=":", linewidth=0.6, alpha=0.6)
     fig.savefig(graph_path, format="pdf")
     plt.close(fig)
+
+
+def format_ipc_scurve_ascii(
+    rows: Sequence[Dict[str, object]],
+    baseline: str,
+    candidate: str,
+    *,
+    width: int = DEFAULT_ASCII_WIDTH,
+    height: int = DEFAULT_ASCII_HEIGHT,
+) -> str:
+    """Return an ASCII S-curve for rows sorted by percent IPC change."""
+    if not rows:
+        return "No common simpoints to draw."
+
+    pct_col = _pct_col(baseline, candidate)
+    deltas = [float(row[pct_col]) for row in rows]
+    width = max(2, int(width))
+    height = max(3, int(height))
+
+    if len(deltas) <= width:
+        sampled = deltas
+    else:
+        sampled = [
+            deltas[round(i * (len(deltas) - 1) / (width - 1))]
+            for i in range(width)
+        ]
+
+    grid_width = max(1, len(sampled))
+    lo = min(min(sampled), 0.0)
+    hi = max(max(sampled), 0.0)
+    if lo == hi:
+        lo -= 1.0
+        hi += 1.0
+
+    def row_for(value: float) -> int:
+        scaled = (value - lo) / (hi - lo)
+        return height - 1 - int(round(scaled * (height - 1)))
+
+    grid = [[" " for _ in range(grid_width)] for _ in range(height)]
+    zero_row = row_for(0.0)
+    for x in range(grid_width):
+        grid[zero_row][x] = "-"
+    for x, value in enumerate(sampled):
+        grid[row_for(value)][x] = "*"
+
+    lines = [f"ASCII IPC S-curve: {baseline} vs {candidate} ({candidate} relative to {baseline})"]
+    for row_idx, cells in enumerate(grid):
+        value = hi - row_idx * (hi - lo) / (height - 1)
+        label = f"{value:8.2f}%"
+        if row_idx == zero_row:
+            label = f"{0.0:8.2f}%"
+        lines.append(f"{label} |{''.join(cells)}")
+    lines.append(f"{'':>9}+{'-' * grid_width}")
+    lines.append(f"{'':>10}worst -> best simpoints sorted by IPC change")
+    return "\n".join(lines)
+
+
+def format_extreme_simpoints(
+    rows: Sequence[Dict[str, object]],
+    baseline: str,
+    candidate: str,
+    *,
+    count: int = DEFAULT_EXTREME_COUNT,
+) -> str:
+    """Return negative and positive simpoint IPC deltas as plain text tables."""
+    if not rows:
+        return "No common simpoints to summarize."
+
+    count = max(1, int(count))
+    pct_col = _pct_col(baseline, candidate)
+    base_col = _ipc_col(baseline)
+    cand_col = _ipc_col(candidate)
+
+    def render_table(title: str, selected_rows: Sequence[Dict[str, object]]) -> List[str]:
+        lines = [
+            title,
+            "rank  delta%     baseline_ipc  candidate_ipc  workload  simpoint",
+        ]
+        for row in selected_rows:
+            lines.append(
+                f"{int(row['rank']):>4}  "
+                f"{_format_float(row[pct_col], 2):>7}  "
+                f"{_format_float(row[base_col], 4):>12}  "
+                f"{_format_float(row[cand_col], 4):>13}  "
+                f"{row['workload']}  {row['simpoint']}"
+            )
+        return lines
+
+    negative_rows = [row for row in rows if float(row[pct_col]) < 0.0]
+    positive_rows = [row for row in rows if float(row[pct_col]) > 0.0]
+    worst = negative_rows[:count]
+    top = list(reversed(positive_rows[-count:]))
+    lines: List[str] = []
+    if worst:
+        lines.extend(render_table(f"Worst {len(worst)} negative simpoints", worst))
+    else:
+        lines.append("Worst 0 negative simpoints")
+        lines.append("No negative IPC changes.")
+    lines.append("")
+    if top:
+        lines.extend(render_table(f"Top {len(top)} positive simpoints", top))
+    else:
+        lines.append("Top 0 positive simpoints")
+        lines.append("No positive IPC changes.")
+    return "\n".join(lines)
+
+
+def format_ipc_scurve_report(
+    output: Dict[str, Any],
+    *,
+    width: int = DEFAULT_ASCII_WIDTH,
+    height: int = DEFAULT_ASCII_HEIGHT,
+    top_n: int = DEFAULT_EXTREME_COUNT,
+) -> str:
+    """Return the console report for one generated baseline/candidate S-curve."""
+    baseline = str(output["baseline"])
+    candidate = str(output["candidate"])
+    rows = output.get("rows") or []
+    lines = [
+        f"IPC S-curve: {baseline} vs {candidate} ({len(rows)} simpoints; {candidate} relative to {baseline})",
+        format_ipc_scurve_ascii(
+            rows,
+            baseline,
+            candidate,
+            width=width,
+            height=height,
+        ),
+        format_extreme_simpoints(rows, baseline, candidate, count=top_n),
+    ]
+    return "\n\n".join(lines)
 
 
 def generate_ipc_scurves(
@@ -259,6 +408,7 @@ def generate_ipc_scurves(
                 "points": len(rows),
                 "graph": graph_path,
                 "data": data_path,
+                "rows": rows,
             }
         )
 
@@ -272,6 +422,9 @@ def main() -> None:
     parser.add_argument("--input", required=True, help="Path to collected_stats.csv.")
     parser.add_argument("--outdir", default=None, help="Output directory.")
     parser.add_argument("--baseline", default=None, help="Baseline configuration name.")
+    parser.add_argument("--ascii-width", type=int, default=DEFAULT_ASCII_WIDTH)
+    parser.add_argument("--ascii-height", type=int, default=DEFAULT_ASCII_HEIGHT)
+    parser.add_argument("--top", type=int, default=DEFAULT_EXTREME_COUNT)
     parser.add_argument(
         "--configs",
         nargs="*",
@@ -293,6 +446,14 @@ def main() -> None:
         print(
             f"{item['baseline']} vs {item['candidate']}: "
             f"{item['graph']} {item['data']} ({item['points']} simpoints)"
+        )
+        print(
+            format_ipc_scurve_report(
+                item,
+                width=args.ascii_width,
+                height=args.ascii_height,
+                top_n=args.top,
+            )
         )
 
 

--- a/sci
+++ b/sci
@@ -2416,6 +2416,53 @@ def resolve_visualize_settings(
     return stats_to_plot, baseline, plot_configs
 
 
+def resolve_visualize_scurve_settings(descriptor: Dict[str, Any]) -> Dict[str, Any]:
+    visualize = descriptor.get("visualize") or {}
+    if not isinstance(visualize, dict):
+        return {"enabled": False, "top_n": 10, "width": 60, "height": 12}
+
+    raw_scurve = visualize.get("scurve", False)
+    settings: Dict[str, Any] = {
+        "enabled": False,
+        "top_n": 10,
+        "width": 60,
+        "height": 12,
+    }
+
+    if isinstance(raw_scurve, bool):
+        settings["enabled"] = raw_scurve
+        return settings
+    if raw_scurve is None:
+        return settings
+    if not isinstance(raw_scurve, dict):
+        print("Descriptor field 'visualize.scurve' must be a boolean or object; disabling IPC S-curves.")
+        return settings
+
+    raw_enabled = raw_scurve.get("enabled", True)
+    if isinstance(raw_enabled, bool):
+        settings["enabled"] = raw_enabled
+    else:
+        print("Descriptor field 'visualize.scurve.enabled' must be a boolean; disabling IPC S-curves.")
+        return settings
+
+    def apply_int(name: str, *, minimum: int) -> None:
+        raw_value = raw_scurve.get(name)
+        if raw_value is None:
+            return
+        if isinstance(raw_value, bool) or not isinstance(raw_value, int) or raw_value < minimum:
+            print(
+                f"Descriptor field 'visualize.scurve.{name}' must be an integer >= {minimum}; "
+                f"using {settings[name]}."
+            )
+            return
+        settings[name] = raw_value
+
+    apply_int("top_n", minimum=1)
+    apply_int("width", minimum=20)
+    apply_int("height", minimum=5)
+    return settings
+
+
 def resolve_perf_analyze_settings(
     descriptor: Dict[str, Any],
     configs: List[str],
@@ -2888,6 +2935,7 @@ def run_visualize(descriptor_name: str) -> int:
     except StepError as exc:
         print(exc)
         return 1
+    scurve_settings = resolve_visualize_scurve_settings(descriptor)
 
     def normalize_counter_entry(entry: object) -> Optional[Dict[str, object]]:
         """
@@ -3158,6 +3206,44 @@ def run_visualize(descriptor_name: str) -> int:
             )
         except Exception as exc:  # pragma: no cover - matplotlib backend dependent
             print(f"Failed to generate plots for '{stat_name}': {exc}")
+
+    if scurve_settings["enabled"]:
+        print("\nGenerating IPC S-curves...")
+        try:
+            from scarab_stats.ipc_scurve import generate_ipc_scurves, format_ipc_scurve_report
+        except Exception as exc:  # pragma: no cover - depends on optional plotting deps
+            print(f"Failed to load IPC S-curve generator: {exc}")
+        else:
+            try:
+                scurve_outputs = generate_ipc_scurves(
+                    stats_path,
+                    baseline_config=baseline,
+                    configs=configs,
+                )
+            except Exception as exc:  # pragma: no cover - depends on user data
+                print(f"Failed to generate IPC S-curves: {exc}")
+            else:
+                if not scurve_outputs:
+                    print("No IPC S-curves generated. Need at least two configs with common simpoints.")
+                for item in scurve_outputs:
+                    print(
+                        f"Wrote IPC S-curve {item['baseline']} vs {item['candidate']} -> "
+                        f"{item['graph']} and {item['data']}"
+                    )
+                    try:
+                        print(
+                            format_ipc_scurve_report(
+                                item,
+                                width=int(scurve_settings["width"]),
+                                height=int(scurve_settings["height"]),
+                                top_n=int(scurve_settings["top_n"]),
+                            )
+                        )
+                    except Exception as exc:  # pragma: no cover - console-only formatting
+                        print(
+                            f"Failed to print IPC S-curve console report for "
+                            f"{item.get('baseline')} vs {item.get('candidate')}: {exc}"
+                        )
 
     # Memory delta table — printed if --collect-mem has been run for this experiment
     memory_stats_path = stats_path.parent / "memory_stats.json"


### PR DESCRIPTION


  ## Summary

  This PR adds automatic IPC S-curve generation to `./sci --visualize`.

  After `./sci --visualize <descriptor>` creates or refreshes `collected_stats.csv`, scarab-infra now generates per-simpoint IPC S-curves directly from that raw CSV format.

  ## Behavior

  The S-curves use the same config selection as the existing visualize flow:

  - visualize.baseline is used when set.
  - Otherwise, the first resolved config is used as the baseline.
  - If visualize.configs is set, only those configs are considered.
  - One S-curve is generated for each baseline-vs-other-config pair.

  Example with config1, config2, config3, config4 and baseline config1:

  config1 vs config2
  config1 vs config3
  config1 vs config4

  ## Outputs

  Files are saved next to collected_stats.csv:

  <root_dir>/simulations/<experiment>/ipc_scurves/
    <baseline>_vs_<candidate>/
      ipc_scurve_graph.pdf
      ipc_scurve_data.csv

  ipc_scurve_graph.pdf is the S-curve plot.

  ipc_scurve_data.csv contains the per-simpoint ranking data, sorted by percent IPC change ascending, so the largest regressions appear first.

  Example columns:

  rank,workload,simpoint,ipc_config1,ipc_config2,percent_change(config2_vs_config1)

  ## Code Changes

  - Adds a helper in scarab_stats to parse raw collected_stats.csv.
  - Wires S-curve generation into ./sci --visualize.
  - Existing visualize plots continue to run as before.

  ## Test Evidence

Descriptor: scurve_test.json
4 configs (config1 has largest icache size while other 3 configs have lower icache sizes). 2 / 6 generated files are attached.
[ipc_scurve_graph.pdf](https://github.com/user-attachments/files/30177885/ipc_scurve_graph.pdf)
[ipc_scurve_data.csv](https://github.com/user-attachments/files/30177886/ipc_scurve_data.csv)
[scurve_test.json](https://github.com/user-attachments/files/30177887/scurve_test.json)
