### PR TITLE
add .dockerignore to shrink the docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# The whole repo directory is the Docker build context for the workload images
+# (allbench_traces, spec2017, ...), but the Dockerfiles only need common/ and
+# workloads/. Exclude local-only artifacts and caches so `docker build` does not
+# stream them into the daemon. The big one is scarab_builds/ (sci's compiled-
+# scarab output cache, tens of GB), which no Dockerfile ever uses; without this
+# ignore, local builds transfer that entire cache as build context and OOM under
+# the Slurm per-job memory limit. (CI builds from a clean checkout and are
+# unaffected either way; this only helps local builds.)
+.git/
+__pycache__/
+**/__pycache__/
+*.pyc
+scarab_builds/
+scarab_stats/
+simulations/
+.vscode/
+*~
+**/#*#


### PR DESCRIPTION
## What

Adds a root `.dockerignore` excluding local-only artifacts and caches from the Docker build context (`.git/`, `__pycache__/`, `*.pyc`, `scarab_builds/`, `scarab_stats/`, `simulations/`, editor cruft).

## Why

The repo directory is the build context for the workload images, but the Dockerfiles only consume `common/` and `workloads/`. Locally, `scarab_builds/` — `sci`'s compiled-scarab output cache — grows to tens of GB (~35 GB here), and `docker build` streams that entire cache into the daemon as build context even though no Dockerfile uses it. On Slurm compute nodes that rebuild the image, that bloated context blows past the per-job memory limit and the build is OOM-killed.

## Validation

Measured on this branch:
- `du` of the repo dir: **35 G**; with the ignored paths excluded: **2.9 M**.
- Real `docker build` (BuildKit) with the `.dockerignore` active: build-context transfer = **343 kB** (previously streamed toward 35 G and OOM-killed at ~4.5 G under the 4 G job limit).

## Scope / notes

- One root `.dockerignore` covers **all** workload images (allbench_traces, spec2017, …) since they share the build-context root.
- **CI is unaffected** — CI builds from a clean checkout that has none of these artifacts. This only helps/unblocks **local** builds.
- Independent of #411 / #412; also the piece that lets local exec-driven runs work before the ghcr publish path (#412) is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)