### PR TITLE
spec2017 exec: private local run dir + drop shrc (read-only app tree)

### DIFF
--- a/common/scripts/run_exec_single_simpoint.sh
+++ b/common/scripts/run_exec_single_simpoint.sh
@@ -44,8 +44,23 @@ PIN_EXEC="$SCARABHOME/src/pin/pin_exec/obj-intel64/pin_exec_${SCARAB_BIN}.so"
 cp "$PIN_EXEC" "$OUTDIR/$segID/pin_exec.so"
 
 cd $OUTDIR/$segID
-BINARY_DIR=$(dirname ${BINCMD%% *})
-cd $BINARY_DIR
+
+# Run the benchmark with cwd = a PRIVATE, node-local run dir. This keeps the
+# benchmark's output-file writes off the shared app tree, which is bind-mounted
+# read-only from NFS: writing there fails (and, when it didn't, concurrent
+# simpoints/users clobbered each other's outputs). Inputs are symlinked in
+# (shared read-only, no copy); the binary is launched by absolute path from
+# BINCMD, so cwd only governs where the benchmark's own output files land.
+REFDIR=$(dirname ${BINCMD%% *})
+RUNDIR="${SCARAB_RUN_LOCAL_TMP:-/tmp}/scarab_run_${SCARAB_BIN}_$$_${segID}"
+rm -rf "$RUNDIR"
+mkdir -p "$RUNDIR"
+# GNU `cp -rs`: recreate the tree with real directories and symlinked files, so
+# outputs (and writes into subdirs) stay local while inputs are shared via
+# symlink. Fall back to a real copy if cp lacks -s.
+cp -rs "$REFDIR"/. "$RUNDIR"/ 2>/dev/null || cp -a "$REFDIR"/. "$RUNDIR"/
+trap 'rm -rf "$RUNDIR"' EXIT
+cd "$RUNDIR"
 
 roiStart=$(( $segID * $SEGSIZE + 1 ))
 roiEnd=$(( $segID * $SEGSIZE + $SEGSIZE ))

--- a/common/scripts/run_exec_single_simpoint.sh
+++ b/common/scripts/run_exec_single_simpoint.sh
@@ -45,20 +45,33 @@ cp "$PIN_EXEC" "$OUTDIR/$segID/pin_exec.so"
 
 cd $OUTDIR/$segID
 
-# Run the benchmark with cwd = a PRIVATE, node-local run dir. This keeps the
-# benchmark's output-file writes off the shared app tree, which is bind-mounted
-# read-only from NFS: writing there fails (and, when it didn't, concurrent
-# simpoints/users clobbered each other's outputs). Inputs are symlinked in
-# (shared read-only, no copy); the binary is launched by absolute path from
-# BINCMD, so cwd only governs where the benchmark's own output files land.
+# Run each simpoint in a PRIVATE, node-local run dir so the benchmark never
+# writes into the shared app tree, which is bind-mounted read-only from NFS
+# (writes there fail, and concurrent simpoints/users would otherwise clobber
+# each other's output files). SPEC binary_cmd embeds ABSOLUTE paths for the
+# binary, its inputs AND its outputs (e.g. gcc_r's `-o .../foo.s`), so
+# redirecting cwd alone is not enough: we make a private copy of the reference
+# run dir and rewrite the command's reference-dir prefix to it, so every output
+# lands locally. A real copy (not symlinks) is required because the shared tree
+# is often polluted with prior-run output files: a symlink to such a file is a
+# link to a read-only NFS target, and overwriting it fails. Run dirs are small
+# (tens to ~200 MB) and the copy is removed on exit. Overlayfs/bind copy-on-
+# write would avoid the copy but needs root; the benchmark runs unprivileged.
+
+# workloads_db stores paths with a literal $tmpdir; expand it (as the eval
+# below and the container env would) before we can match/rewrite the prefix.
+[ -n "$tmpdir" ] && BINCMD="${BINCMD//\$tmpdir/$tmpdir}"
 REFDIR=$(dirname ${BINCMD%% *})
 RUNDIR="${SCARAB_RUN_LOCAL_TMP:-/tmp}/scarab_run_${SCARAB_BIN}_$$_${segID}"
 rm -rf "$RUNDIR"
 mkdir -p "$RUNDIR"
-# GNU `cp -rs`: recreate the tree with real directories and symlinked files, so
-# outputs (and writes into subdirs) stay local while inputs are shared via
-# symlink. Fall back to a real copy if cp lacks -s.
-cp -rs "$REFDIR"/. "$RUNDIR"/ 2>/dev/null || cp -a "$REFDIR"/. "$RUNDIR"/
+# Real local copy (dereferencing any source symlinks): every file becomes a
+# writable local file owned by us, so the benchmark can create/overwrite its
+# outputs. Preserve timestamps but not ownership (we may not be the owner).
+cp -rL --preserve=timestamps "$REFDIR"/. "$RUNDIR"/
+chmod -R u+rwX "$RUNDIR"
+# Point the command's binary/inputs/outputs at the private RUNDIR.
+BINCMD="${BINCMD//$REFDIR/$RUNDIR}"
 trap 'rm -rf "$RUNDIR"' EXIT
 cd "$RUNDIR"
 

--- a/workloads/spec2017/workload_user_entrypoint.sh
+++ b/workloads/spec2017/workload_user_entrypoint.sh
@@ -1,1 +1,6 @@
-cd /tmp_home/application/cpu2017 && source shrc
+# No-op: the SPEC binaries are run directly under PIN by absolute path (see
+# workloads_db binary_cmd), so we do NOT source shrc. shrc is SPEC's runcpu
+# harness bootstrap and insists the (bind-mounted, read-only) cpu2017 tree be
+# writable, which fails with "not allowed to write into .../config". We don't
+# call runcpu and the launch command sets no env from shrc, so nothing needs it.
+:


### PR DESCRIPTION
## Problem
Exec-driven SPEC2017 sims fail on every node with:

```
You are not allowed to write into /tmp_home/application/cpu2017/config.
```

The SPEC binaries are now bind-mounted **read-only** from NFS (see #411), and `/soe/hlitz` NFS is full. Two independent writes into that shared tree were the cause:

1. **`source shrc`** in `workloads/spec2017/workload_user_entrypoint.sh` — SPEC's `runcpu` bootstrap, which insists `$SPEC` be writable. We never run `runcpu`; the launch command (`workloads_db` `binary_cmd`) invokes the benchmark by **absolute path** with **no env from shrc** (`env_vars: null`), so it's pure ceremony.
2. **The benchmark's own file writes** land in the shared run dir. `run_exec_single_simpoint.sh` `cd`'d into the benchmark's run dir, and — critically — SPEC `binary_cmd`s embed **absolute paths for the binary, inputs AND outputs** (e.g. `gcc_r ... -o $tmpdir/.../foo.s`), so the output is written by absolute path into the shared tree regardless of cwd. Even when the tree was writable, concurrent simpoints/users clobbered each other.

## Fix
1. Drop `source shrc` (entrypoint becomes a documented no-op).
2. Run each simpoint in a **private, node-local** run dir:
   - make a real local **copy** of the reference run dir (`cp -rL --preserve=timestamps` + `chmod -R u+rwX`),
   - rewrite the command's reference-dir prefix (with `$tmpdir` expanded) to the private dir, so the binary/inputs/outputs all resolve locally,
   - `cd` there and clean up on exit.

Local base is overridable via `SCARAB_RUN_LOCAL_TMP` (default `/tmp`, i.e. the container overlay — which is node-local disk).

### Why a real copy, not symlinks
A symlink-the-inputs approach was tried first and fails in practice: the shared run dirs are **polluted with prior-run output files** (arbitrary benchmark-specific names). A symlink to such a file points at a read-only NFS target, and the benchmark overwriting it fails with EACCES. The clean copy-on-write primitive (overlayfs / bind CoW) needs root, but the benchmark runs **unprivileged**, so we use a real copy. Run dirs are small (tens to ~200 MB) and removed on exit.

## Verification
- Old `not allowed to write` / EACCES failures: **gone**.
- Baseline SPEC2017 exec simpoints complete with full `core.stat.0.out`.
- (Separately observed: the load-prediction scarab configs hit an unrelated assertion in `map_rename.c` — a scarab-code issue, not part of this infra PR.)

## Scope / risk
`run_exec_single_simpoint.sh` is shared by all exec-driven sims; the private-copy change is strictly safer for all of them (isolation + no shared-tree writes). Completes the read-only-mounted-app work started in #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)