### PR TITLE
Resolve an error from tracing command

### DIFF
--- a/common/scripts/run_simpoint_trace.py
+++ b/common/scripts/run_simpoint_trace.py
@@ -835,7 +835,7 @@ def cluster_then_trace(workload, suite, simpoint_home, bincmd, client_bincmd, si
             print(f"  tracing segments {batch_start+1}-{batch_start+len(batch)} of {len(trace_cmds)}")
             procs = []
             for cmd in batch:
-                p = subprocess.Popen("exec " + cmd, stdout=subprocess.DEVNULL, shell=True, env=trace_env)
+                p = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, shell=True, env=trace_env)
                 procs.append(p)
             for p in procs:
                 p.wait()


### PR DESCRIPTION
Hi, @5surim 

We had a minor bug at tracing.
```
Error msg:
/bin/sh: 1: exec: PYTHONHASHSEED=0: not found
/bin/sh: 1: exec: PYTHONHASHSEED=0: not found
/bin/sh: 1: exec: PYTHONHASHSEED=0: not found
/bin/sh: 1: exec: PYTHONHASHSEED=0: not found
/bin/sh: 1: exec: PYTHONHASHSEED=0: not found
/bin/sh: 1: exec: PYTHONHASHSEED=0: not found
/bin/sh: 1: exec: PYTHONHASHSEED=0: not found
/bin/sh: 1: exec: PYTHONHASHSEED=0: not found
mv: cannot stat '/home/mkim293/simpoint_flow/bfs_road/bfs_road/traces_simp/9575/dr*/raw/': No such file or directory Traceback (most recent call last):
  File "/usr/local/bin/run_simpoint_trace.py", line 1200, in <module>
    cluster_then_trace(workload, suite, simpoint_home, bincmd, client_bincmd, simpoint_mode, drio_args, clustering_userk, manual_trace)
  File "/usr/local/bin/run_simpoint_trace.py", line 956, in cluster_then_trace
    raise e
  File "/usr/local/bin/run_simpoint_trace.py", line 892, in cluster_then_trace
    subprocess.run(f"mv {trace_path}/dr*/raw/ {trace_path}/raw/", check=True, shell=True)
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'mv /home/mkim293/simpoint_flow/bfs_road/bfs_road/traces_simp/9575/dr*/raw/ /home/mkim293/simpoint_flow/bfs_road/bfs_road/traces_simp/9575/raw/' returned non-zero exit status 1.
```

Please, approve it.

Thanks.
Best regards,