### PR TITLE
Let docker reap containers that outlive their job or build

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -402,12 +402,18 @@ def build_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_pre
     scarab_bin = f"{scarab_path}/src/build/{scarab_build}/scarab"
     info(f"Scarab binary at '{scarab_bin}', building it first, please wait...", dbg_lvl)
     docker_container_name = f"{docker_prefix}_{user}_scarab_build"
+    # The container name is deterministic, so one left over from an earlier run makes
+    # this `docker run` fail with a bare exit 125 and no explanation. Clear it first:
+    # the finally below does not cover a SIGTERM'd sci (slurm timeout, CI kill, or a
+    # wrapper timeout), because Python does not unwind the stack on SIGTERM.
+    subprocess.run(["docker", "rm", "-f", f"{docker_container_name}"],
+                   check=False, capture_output=True, text=True)
     try:
         subprocess.run(
                 ["docker", "run", "-e", f"user_id={local_uid}",
                  "-e", f"group_id={local_gid}",
                  "-e", f"username={user}",
-                 "-dit", "--name", f"{docker_container_name}",
+                 "-dit", "--rm", "--name", f"{docker_container_name}",
                  "--mount", f"type=bind,source={docker_home},target=/home/{user},readonly=false",
                  "--mount", f"type=bind,source={scarab_path},target=/scarab,readonly=false",
                  "--mount", infra_mount_arg(infra_dir),
@@ -446,8 +452,10 @@ def build_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_pre
     except Exception as e:
         exception = e
     finally:
-        # Always clean up build container
-        subprocess.run(["docker", "rm", "-f", f"{docker_container_name}"], check=True, capture_output=True, text=True)
+        # Always clean up build container. check=False because with --rm the daemon may
+        # have reaped it already; raising here would replace the real build exception
+        # with a misleading "No such container" failure.
+        subprocess.run(["docker", "rm", "-f", f"{docker_container_name}"], check=False, capture_output=True, text=True)
 
     if exception != None:
         raise exception
@@ -599,13 +607,17 @@ def lint_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_pref
 
     info(f"Linting scarab with image {image_ref}...", dbg_lvl)
     exception = None
+    # Same deterministic-name hazard as build_scarab_binary: clear any leftover
+    # container so a previously killed lint run does not block this one.
+    subprocess.run(["docker", "rm", "-f", f"{docker_container_name}"],
+                   check=False, capture_output=True, text=True)
     try:
         subprocess.run(
             ["docker", "run",
              "-e", f"user_id={local_uid}",
              "-e", f"group_id={local_gid}",
              "-e", f"username={user}",
-             "-dit", "--name", f"{docker_container_name}",
+             "-dit", "--rm", "--name", f"{docker_container_name}",
              "--mount", f"type=bind,source={docker_home},target=/home/{user},readonly=false",
              "--mount", f"type=bind,source={scarab_path},target=/scarab,readonly=false",
              "--mount", infra_mount_arg(infra_dir),
@@ -1703,7 +1715,13 @@ def write_trace_docker_command_to_file(user, local_uid, local_gid, docker_contai
             if env_vars:
                 for env in env_vars:
                     command = command + f"-e {env} "
+            # --rm matches the simulation path: it lets the docker daemon reap the
+            # container even when this script is SIGKILLed and never reaches
+            # cleanup_container. Without it, a cancelled trace job leaves the
+            # container running forever, which keeps the job's cgroup non-empty;
+            # slurmd then reports "Kill task failed" and drains the node.
             command = command + f"-dit \
+                    --rm \
                     --name $CONTAINER_NAME \
                     --mount type=bind,source={docker_home},target=/home/{user},readonly=false \
                     --mount type=bind,source={application_dir},target=/tmp_home/application,readonly=false \


### PR DESCRIPTION
Three container-lifecycle leaks in `scripts/utilities.py`, all the same shape: cleanup runs only on a graceful exit, so anything killed abruptly strands a container under a deterministic name, which then blocks the next run.

## 1. Build container had no `--rm`

`build_scarab_binary` started the container with `-dit --name <prefix>_<user>_scarab_build` and removed it only in a Python `finally`. Python does **not** unwind the stack on `SIGTERM`, so a killed `sci` — slurm timeout, CI kill, wrapper timeout — never reached it. The name is fixed per user and workload group, so the next build failed with a bare:

```
subprocess.CalledProcessError: Command '['docker', 'run', ..., '--name', 'allbench_traces_hlitz_scarab_build', ...]' returned non-zero exit status 125
```

Exit 125 is the daemon rejecting the run, and the actual reason appeared nowhere in the output:

```
docker: Error response from daemon: Conflict. The container name
"/allbench_traces_hlitz_scarab_build" is already in use by container "7bc743b3e415..."
```

Now adds `--rm` (so the daemon reaps it however the script dies) plus a pre-emptive `docker rm -f`, which also clears containers left by older versions that lacked `--rm`.

## 2. That cleanup could mask the real error

The same `finally` used `check=True`. With `--rm` in play the daemon may have already reaped the container, so `docker rm -f` would fail and raise *from inside the finally*, replacing the genuine build exception with a misleading `No such container`. Now `check=False`, matching `lint_scarab_binary`, which already did this.

## 3. Trace containers were never reaped — this drains nodes

The trace job script ran its container **without** `--rm`, unlike both simulation paths. A cancelled trace job left the container running, and since containers start with `--cgroup-parent $SLURM_CGROUP`, the job's cgroup never empties. slurmd waits `UnkillableStepTimeout` (60s here), gives up, and drains the node:

```
moore  drained  Reason=Kill task failed
ohm    drained  Reason=Kill task failed
```

On the cluster this was found on, two nodes were drained this way, and one still had **11 orphaned `*_cluster_then_trace_*` containers** running hours later with `CPUAlloc=0` — Slurm believed nothing was running there.

## Verification

For (1): planted a container under the blocking name, reproduced the daemon's `Conflict` error with the old invocation, and confirmed the patched sequence (`docker rm -f` then `docker run --rm`) succeeds.

## What this deliberately does *not* change

The job scripts install `trap cleanup_container EXIT INT TERM HUP`, and it was tempting to blame trap deferral. Measured directly instead:

| signal | foreground `docker exec` | backgrounded behind `wait` |
|---|---|---|
| SIGTERM | trap fires | trap fires |
| SIGKILL | trap does not fire | trap does not fire |

So bash runs the handler on `SIGTERM` either way, and neither form survives `SIGKILL` — which is what slurmd sends `KillWait` (30s) after `SIGTERM`. Restructuring the traps would be pure churn; `--rm` is what actually closes the window, because it moves responsibility to the daemon, which is not the process being killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)