### PR TITLE
Fail the run script when the container or Scarab fails

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1600,7 +1600,12 @@ def write_docker_command_to_file(user, local_uid, local_gid, workload, workload_
             f.write("}\n")
             f.write("trap cleanup_container EXIT INT TERM HUP\n")
             f.write(f"cd {infra_dir}\n")
-            f.write(f"python -m scripts.prepare_docker_image --docker-prefix {docker_prefix}\n")
+            # Every step below is checked: an unstarted container used to leave the
+            # script exiting 0, so Slurm recorded COMPLETED for a sim that never ran.
+            f.write(f"if ! python -m scripts.prepare_docker_image --docker-prefix {docker_prefix}; then\n")
+            f.write(f"    echo \"ERROR: prepare_docker_image failed for {docker_prefix}\"\n")
+            f.write("    exit 1\n")
+            f.write("fi\n")
             f.write(f"cd -\n")
             if slurm:
                 f.write("SLURM_CGROUP=$(cat /proc/self/cgroup | cut -d: -f3 | head -n 1)\n")
@@ -1640,16 +1645,30 @@ def write_docker_command_to_file(user, local_uid, local_gid, workload, workload_
                 --mount {infra_mount_arg(infra_dir)} \
                 {image_tag_for(docker_prefix, infra_dir)} \
                 /bin/bash\n")
+            f.write("if [ $? -ne 0 ]; then\n")
+            f.write("    echo \"ERROR: docker run failed for $CONTAINER_NAME\"\n")
+            f.write("    exit 1\n")
+            f.write("fi\n")
+            # -dit can exit 0 and still leave no running container.
+            f.write("if ! docker inspect -f '{{.State.Running}}' \"$CONTAINER_NAME\" 2>/dev/null | grep -q true; then\n")
+            f.write("    echo \"ERROR: container $CONTAINER_NAME is not running after docker run\"\n")
+            f.write("    exit 1\n")
+            f.write("fi\n")
             if scarab_mode == "exec":
-                f.write("docker exec --privileged $CONTAINER_NAME /bin/bash -c \"echo 0 | sudo tee /proc/sys/kernel/randomize_va_space\"\n")
+                f.write("docker exec --privileged $CONTAINER_NAME /bin/bash -c \"echo 0 | sudo tee /proc/sys/kernel/randomize_va_space\" || echo \"WARN: could not disable VA randomization\"\n")
             # No `docker cp` of the infra scripts: they come from the read-only
             # bind mount above, and root_entrypoint.sh publishes them into
             # /usr/local/bin.
-            f.write(f"docker exec --privileged $CONTAINER_NAME /bin/bash -c '{ROOT_ENTRYPOINT}'\n")
-            f.write(f"docker exec --user={user} $CONTAINER_NAME /bin/bash -c \"source /usr/local/bin/user_entrypoint.sh && {scarab_cmd}\" || echo \"Scarab error detected\"\n")
+            f.write(f"if ! docker exec --privileged $CONTAINER_NAME /bin/bash -c '{ROOT_ENTRYPOINT}'; then\n")
+            f.write("    echo \"ERROR: root_entrypoint.sh failed in $CONTAINER_NAME\"\n")
+            f.write("    exit 1\n")
+            f.write("fi\n")
+            f.write("RC=0\n")
+            f.write(f"docker exec --user={user} $CONTAINER_NAME /bin/bash -c \"source /usr/local/bin/user_entrypoint.sh && {scarab_cmd}\" || {{ echo \"Scarab error detected\"; RC=1; }}\n")
             f.write("cleanup_container\n")
             f.write("echo \"Completed Simulation\"\n")
-            f.write(f"sync {docker_home}/simulations/{experiment_name}/logs")
+            f.write(f"sync {docker_home}/simulations/{experiment_name}/logs || true\n")
+            f.write("exit $RC\n")
     except Exception as e:
         raise e
 


### PR DESCRIPTION
## The problem

A simulation whose container never started still exited 0. Slurm recorded `COMPLETED`, `sci --sim` reported success, and stat collection said only:

```
WARN: Couldn't find csv file .../bp.stat.0.csv
WARN: The following simpoints were not found, and will be ignored for ALL configs
```

The generated run script ended with:

```bash
docker exec --user=$user $CONTAINER_NAME ... || echo "Scarab error detected"
cleanup_container
echo "Completed Simulation"
sync .../logs                      # <- this decided the exit status
```

`docker run` was never checked at all, and `sync` supplied the exit code.

## What it hid

Three weeks of failures on `dennard`. Its `/etc/docker/daemon.json` had `"data-root": "/dev/docker"` (set 2026-07-29, because `/` is 97% full). Since every sim runs `docker run --privileged`, the daemon builds the container's device list by walking `/dev` recursively — and on that node the walk descended into `/dev/docker/rootfs/overlayfs/<id>/…`, i.e. the live rootfs of every other running container. Containers use `--rm`, so entries enumerated by the walk disappeared before it could `stat` them:

```
docker: Error response from daemon: error stating device path:
  stat /dev/docker/rootfs/overlayfs/036465b1…/etc/ssl/private: no such file or directory
```

Measured on the same image and command: privileged start took **15.68 s** on that node vs **0.44 s** unprivileged, and **0.92 s** on a node with a normal data-root. Under load it failed **12/12**. A node with the identical Docker version and snapshotter but a normal data-root failed 0/382.

**1819 runs across 14 experiments were lost this way, every one of them reported COMPLETED** — including 933 from one full SPEC17 sweep. The node has since been fixed (data-root moved to `/scratch/docker`; privileged start is now 0.36 s), but the silence is the part worth fixing here: the same class of failure will recur on any node with an odd data-root, a full disk, or a stale image.

## The change

Each step in the generated script is now checked:

- `prepare_docker_image` — fatal
- `docker run` — exit status **and** a `docker inspect .State.Running` check, since `-dit` can exit 0 leaving no container — fatal
- `root_entrypoint.sh` — fatal
- Scarab itself — sets `RC=1` so `cleanup_container` still runs, then `exit $RC`
- `sync` gets `|| true` so it no longer decides the exit status
- `docker exec … randomize_va_space` warns instead of passing silently

`"Scarab error detected"` is deliberately kept so the log scanning in `sci --status` (`utilities.py:2371`) keeps classifying these runs.

## Verification

Generated a script via `write_docker_command_to_file()` and ran it against a stub `docker` on `PATH`:

| scenario | exit |
|---|---|
| `docker run` fails (the dennard bug) | 1 |
| `docker run` ok, container not running | 1 |
| Scarab exits nonzero | 1 (+ legacy marker printed) |
| everything succeeds | 0 |

`bash -n` clean.

## Follow-up worth considering

`--privileged` is what turns any unusual data-root into this failure. Replacing it with explicit `--device`/capabilities would remove the whole class, but that needs a look at what the perf and exec-driven paths actually require.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
