### PR TITLE
docker: switch PIN kit to Intel SDE 9.44.0 (PIN 3.31 + pinplay)

### DIFF
--- a/common/Dockerfile.common
+++ b/common/Dockerfile.common
@@ -94,13 +94,16 @@ RUN mkdir $tmpdir/fingerprint_src/build && \
     cp ./libfpg.so $tmpdir/libfpg.so
 
 # Install Scarab dependencies
-RUN cd $tmpdir && wget -nc https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.15-98253-gb56e429b1-gcc-linux.tar.gz && tar -xzvf pin-3.15-98253-gb56e429b1-gcc-linux.tar.gz
+RUN cd $tmpdir && wget -q https://github.com/litz-lab/scarab-infra/releases/download/sde-9.44.0/sde-external-9.44.0-2024-08-22-lin.tar.xz -O sde.tar.xz && \
+    echo "c6bc16fc6d1855049ea22daf214a8c00331713bc6a7b0c4d6955d6ed84148b9b  sde.tar.xz" | sha256sum -c - && \
+    tar -xJf sde.tar.xz && rm sde.tar.xz
 
 # Env to build Scarab
-ENV PIN_ROOT $tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux
+ENV PIN_ROOT $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit
 ENV SCARAB_ENABLE_PT_MEMTRACE 1
-ENV LD_LIBRARY_PATH $tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux/extras/xed-intel64/lib
-ENV LD_LIBRARY_PATH $tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux/intel64/runtime/pincrt:$LD_LIBRARY_PATH
+ENV SCARAB_ENABLE_PINPLAY 1
+ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/extras/xed-intel64/lib
+ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/intel64/runtime/pincrt:$LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH $DYNAMORIO_HOME/lib64/release:$LD_LIBRARY_PATH
 
 # Build SimPoint 3.2

--- a/common/Dockerfile.oss
+++ b/common/Dockerfile.oss
@@ -54,13 +54,16 @@ RUN mkdir $tmpdir/fingerprint_src/build && \
     cp ./libfpg.so $tmpdir/libfpg.so
 
 # Install Scarab dependencies
-RUN cd $tmpdir && wget -nc https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.15-98253-gb56e429b1-gcc-linux.tar.gz && tar -xzvf pin-3.15-98253-gb56e429b1-gcc-linux.tar.gz
+RUN cd $tmpdir && wget -q https://github.com/litz-lab/scarab-infra/releases/download/sde-9.44.0/sde-external-9.44.0-2024-08-22-lin.tar.xz -O sde.tar.xz && \
+    echo "c6bc16fc6d1855049ea22daf214a8c00331713bc6a7b0c4d6955d6ed84148b9b  sde.tar.xz" | sha256sum -c - && \
+    tar -xJf sde.tar.xz && rm sde.tar.xz
 
 # Env to build Scarab
-ENV PIN_ROOT $tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux
+ENV PIN_ROOT $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit
 ENV SCARAB_ENABLE_PT_MEMTRACE 1
-ENV LD_LIBRARY_PATH $tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux/extras/xed-intel64/lib
-ENV LD_LIBRARY_PATH $tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux/intel64/runtime/pincrt:$LD_LIBRARY_PATH
+ENV SCARAB_ENABLE_PINPLAY 1
+ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/extras/xed-intel64/lib
+ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/intel64/runtime/pincrt:$LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH $DYNAMORIO_HOME/lib64/release:$LD_LIBRARY_PATH
 
 # Build SimPoint 3.2

--- a/common/Dockerfile.tailbench
+++ b/common/Dockerfile.tailbench
@@ -54,13 +54,16 @@ RUN mkdir $tmpdir/fingerprint_src/build && \
     cp ./libfpg.so $tmpdir/libfpg.so
 
 # Install Scarab dependencies
-RUN cd $tmpdir && wget -nc https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.15-98253-gb56e429b1-gcc-linux.tar.gz && tar -xzvf pin-3.15-98253-gb56e429b1-gcc-linux.tar.gz
+RUN cd $tmpdir && wget -q https://github.com/litz-lab/scarab-infra/releases/download/sde-9.44.0/sde-external-9.44.0-2024-08-22-lin.tar.xz -O sde.tar.xz && \
+    echo "c6bc16fc6d1855049ea22daf214a8c00331713bc6a7b0c4d6955d6ed84148b9b  sde.tar.xz" | sha256sum -c - && \
+    tar -xJf sde.tar.xz && rm sde.tar.xz
 
 # Env to build Scarab
-ENV PIN_ROOT $tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux
+ENV PIN_ROOT $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit
 ENV SCARAB_ENABLE_PT_MEMTRACE 1
-ENV LD_LIBRARY_PATH $tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux/extras/xed-intel64/lib
-ENV LD_LIBRARY_PATH $tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux/intel64/runtime/pincrt:$LD_LIBRARY_PATH
+ENV SCARAB_ENABLE_PINPLAY 1
+ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/extras/xed-intel64/lib
+ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/intel64/runtime/pincrt:$LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH $DYNAMORIO_HOME/lib64/release:$LD_LIBRARY_PATH
 
 # Build SimPoint 3.2

--- a/common/scripts/user_entrypoint.sh
+++ b/common/scripts/user_entrypoint.sh
@@ -3,10 +3,11 @@
 
 export tmpdir="/tmp_home"
 export DYNAMORIO_HOME=$tmpdir/DynamoRIO-Linux-10.0.0/
-export PIN_ROOT=$tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux
+export PIN_ROOT=$tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit
 export SCARAB_ENABLE_PT_MEMTRACE=1
-export LD_LIBRARY_PATH=$tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux/extras/xed-intel64/lib
-export LD_LIBRARY_PATH=$tmpdir/pin-3.15-98253-gb56e429b1-gcc-linux/intel64/runtime/pincrt:$LD_LIBRARY_PATH
+export SCARAB_ENABLE_PINPLAY=1
+export LD_LIBRARY_PATH=$tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/extras/xed-intel64/lib
+export LD_LIBRARY_PATH=$tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/intel64/runtime/pincrt:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$DYNAMORIO_HOME/lib64/release:$LD_LIBRARY_PATH
 
 export DOCKER_BUILDKIT=1


### PR DESCRIPTION
## What

Replace the stock **PIN 3.15** kit (no pinplay) with the **Intel SDE 9.44.0** pinkit (**PIN 3.31-98861 + pinplay engine**) in the Docker images, so the exec-driven frontend can be built with pinplay for **deterministic, host-independent pinball replay**.

## Why

Exec-driven runs are host-dependent: the same simulation on different cluster nodes (different CPU SKU + kernel, which Docker can't isolate) fast-forwards to different program points (BBV cosine ~0.01 cross-node vs ~1.0 same-node). PinPlay replay removes that. PinPlay isn't in stock PIN 3.15/3.20 — only in Intel SDE — so the kit has to change.

## Changes

- `common/Dockerfile.{common,oss,tailbench}` + `common/scripts/user_entrypoint.sh`:
  - fetch the SDE tarball from **our own release** (`litz-lab/scarab-infra` → `releases/sde-9.44.0`), **verify its SHA-256**, extract;
  - `PIN_ROOT` → the SDE `pinkit`; add `SCARAB_ENABLE_PINPLAY=1`; `LD_LIBRARY_PATH` → pinkit xed/pincrt.
- Base stays **`ubuntu:focal` (gcc 9.4)** — the SDE 3.31 build was validated to **build and run** there (a tool ran scarab exec-driven end-to-end: 299,705 insts, 0.80 IPC, clean exit). No toolchain bump.

## Validation

- `./sci --build-image allbench_traces` succeeds (SDE download + SHA-256 gate + extract).
- `./sci --build-scarab` succeeds in the new image: scarab + `pin_exec.so` (17 MB, pinplay linked) both build.

## Licensing

The SDE tarball is hosted **unmodified** as a release asset. The bundled Intel Simplified Software License (Feb 2020) explicitly permits **unmodified redistribution** (retain notice/license), which the intact tarball satisfies.

## Dependency

Companion scarab change: **litz-lab/scarab#581** (PIN 3.31 port + SDE pinplay integration). That PR needs this image to build in CI, so **merge this first**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)