### PR TITLE
Record host instructions per simulation with perf stat

### DIFF
--- a/common/scripts/run_exec_single_simpoint.sh
+++ b/common/scripts/run_exec_single_simpoint.sh
@@ -101,5 +101,8 @@ scarabCmd="python3 $SCARABHOME/bin/scarab_launch.py --program=\"$BINCMD\" \
 
 printf '%q ' "${scarabCmd[@]}" > $SIMHOME/launch_cmd.txt
 
-eval $scarabCmd &
+# Counts the whole launcher subtree: python, PIN and the benchmark as well as
+# Scarab itself.
+PERF_PREFIX=$(perf_stat_prefix "$OUTDIR/$segID/perf_stat.txt")
+eval $PERF_PREFIX $scarabCmd &
 wait $!

--- a/common/scripts/run_memtrace_single_simpoint.sh
+++ b/common/scripts/run_memtrace_single_simpoint.sh
@@ -146,5 +146,6 @@ fi
 
 #echo "simulating clusterID ${clusterID}, segment $segID..."
 #echo "command: ${scarabCmd}"
-eval $scarabCmd &
+PERF_PREFIX=$(perf_stat_prefix "$OUTDIR/$segID/perf_stat.txt")
+eval $PERF_PREFIX $scarabCmd &
 wait $!

--- a/common/scripts/run_pt_single_simpoint.sh
+++ b/common/scripts/run_pt_single_simpoint.sh
@@ -45,5 +45,6 @@ scarabCmd="$SCARABHOME/src/$SCARAB_BIN --full_warmup $WARMUP --frontend pt --cbp
 
 #echo "simulating clusterID ${clusterID}, segment $segID..."
 #echo "command: ${scarabCmd}"
-eval $scarabCmd &
+PERF_PREFIX=$(perf_stat_prefix "$OUTDIR/$segID/perf_stat.txt")
+eval $PERF_PREFIX $scarabCmd &
 wait $!

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -53,3 +53,24 @@ wait_for_non_child () {
     done
   done
 }
+
+perf_stat_prefix () {
+  # Prefix that makes `perf stat` count the host instructions a simulation
+  # retires, written to $1. Wall-clock speed (KIPS) tracks machine load as much
+  # as Scarab; the instruction count does not, so it is what CI regresses on.
+  # Prints nothing when perf cannot count here (no perf, restrictive
+  # perf_event_paranoid), so the simulation still runs -- just unmeasured.
+  local out="$1"
+  local perf_bin
+  perf_bin=$(command -v perf 2>/dev/null)
+  # The image's /usr/bin/perf is a wrapper that refuses to run when it finds no
+  # perf for the running kernel; the versioned linux-tools binary works anyway.
+  if [ -z "$perf_bin" ] || ! "$perf_bin" --version >/dev/null 2>&1; then
+    perf_bin=$(ls -d /usr/lib/linux-tools-*/perf 2>/dev/null | head -1)
+  fi
+  [ -n "$perf_bin" ] && [ -x "$perf_bin" ] || return 0
+  # User-mode only: kernel counting needs perf_event_paranoid <= 1, and syscall
+  # instructions are noise here.
+  "$perf_bin" stat -e instructions:u -x, -o /dev/null -- true >/dev/null 2>&1 || return 0
+  printf '%s stat -e instructions:u -x, -o %q --' "$perf_bin" "$out"
+}


### PR DESCRIPTION
## What

Makes every simulation record the host instructions it retires, via `perf stat`,
so the CI perf comment can report them.

Paired with **litz-lab/scarab#585**, which adds the row to the comment table:

*Layout only — the numbers below are made-up inputs I fed the comment script to
check the formatting and the flipped colours. They are not a measurement, and
nothing here changes what Scarab executes.*

| Metric | PR | Baseline | Δ |
| ------ | --: | -------: | :- |
| **KIPS** | `200` | `250` | 🔴 **0.80×** |
| **IPC** | `3.35351` | `3.35351` | 🟢 **1.00×** |
| **Instructions** | `1,000,000,000,000` | `1,000,000,000,000` | 🟢 **1.00×** |

That workflow checks out infra `main`, so this merges first.

KIPS divides simulated instructions by host wall seconds, so it tracks how
loaded the machine was as much as it tracks Scarab. Instructions retired don't
move with co-runners — but nothing in the run scripts produced that number.

## How

- `scripts/utilities.sh`: new `perf_stat_prefix <outfile>`. Picks a working
  perf (the image's `/usr/bin/perf` is a wrapper that refuses to run when it
  finds no perf for the running kernel, so it falls back to the versioned
  `linux-tools` binary), probes that counting actually works, and prints
  `perf stat -e instructions:u -x, -o <outfile> --`.
- `run_{memtrace,pt,exec}_single_simpoint.sh`: prefix the Scarab invocation,
  writing `perf_stat.txt` next to `sim.log`. Deliberately not a `.csv` —
  `--status` treats any `.csv` in a simpoint dir as "stats produced". For exec
  mode the count covers the whole launcher subtree (python, PIN and the
  benchmark as well as Scarab), which is what the run costs.

`instructions:u` rather than `instructions`: kernel counting needs
`perf_event_paranoid <= 1` (some of our nodes sit at 4), and syscall-side
instructions are noise for this.

The prefix comes out empty wherever perf can't count — no perf in the image, a
restrictive `perf_event_paranoid`, or a VM with no PMU, which is what
GitHub-hosted runners are (measured: `instructions` and `cycles` report
`<not supported>` there even at `perf_event_paranoid=-1` and inside a
privileged container). The simulation still runs; it is just unmeasured, and
the consumer sees no `perf_stat.txt`.

## Validation

Local memtrace run of `spec2017/rate_int_v2/deepsjeng_r`, 3 simpoints, 60M
instructions, in the real container:

- Simulations finish exactly as before — `2.32 IPC`, all stat CSVs written;
  perf adds no measurable interference.
- Per-simpoint counts: `1.353e12`, `1.349e12`, `1.395e12` user instructions.
- Degradation path checked: with no usable perf the prefix is empty and the
  command still runs.

