### PR TITLE
Make the weekly sweep actually record a run

### DIFF
--- a/json/weekly_spec17_exec_opt.json
+++ b/json/weekly_spec17_exec_opt.json
@@ -4,7 +4,7 @@
   "experiment":"WEEKLY_PLACEHOLDER",
   "workload_manager":"slurm",
   "root_dir":"/soe/hlitz",
-  "application_dir":"/soe/hlitz/applications",
+  "application_dir":"/soe/hlitz/lab/applications",
   "scarab_path":"/soe/hlitz/git/scarab-weekly",
   "traces_dir":"/soe/hlitz/lab/traces",
   "top_simpoint":true,
@@ -15,7 +15,7 @@
       "workload":null,
       "cluster_id":null,
       "simulation_type":"exec",
-      "warmup":null
+      "warmup":0
     }
   ],
   "configurations":{

--- a/json/weekly_spec17_memtrace_dbg.json
+++ b/json/weekly_spec17_memtrace_dbg.json
@@ -4,7 +4,7 @@
   "experiment":"WEEKLY_PLACEHOLDER",
   "workload_manager":"slurm",
   "root_dir":"/soe/hlitz",
-  "application_dir":"/soe/hlitz/applications",
+  "application_dir":"/soe/hlitz/lab/applications",
   "scarab_path":"/soe/hlitz/git/scarab-weekly",
   "traces_dir":"/soe/hlitz/lab/traces",
   "top_simpoint":true,

--- a/json/weekly_spec17_memtrace_opt.json
+++ b/json/weekly_spec17_memtrace_opt.json
@@ -4,7 +4,7 @@
   "experiment":"WEEKLY_PLACEHOLDER",
   "workload_manager":"slurm",
   "root_dir":"/soe/hlitz",
-  "application_dir":"/soe/hlitz/applications",
+  "application_dir":"/soe/hlitz/lab/applications",
   "scarab_path":"/soe/hlitz/git/scarab-weekly",
   "traces_dir":"/soe/hlitz/lab/traces",
   "top_simpoint":true,

--- a/scripts/weekly_perf_sweep.py
+++ b/scripts/weekly_perf_sweep.py
@@ -19,6 +19,7 @@ import argparse
 import csv
 import datetime as _dt
 import fcntl
+import getpass
 import json
 import math
 import os
@@ -27,6 +28,7 @@ import smtplib
 import subprocess
 import sys
 import tempfile
+import time
 from email.message import EmailMessage
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -49,6 +51,12 @@ HISTORY_CSV = "history.csv"
 PLOT_SUBDIR = "plots"
 
 LOCK_PATH = Path("/tmp/scarab_weekly_sweep.lock")
+# Where the cron entry sends this script's output; quoted in the failure mail.
+LOG_PATH = Path("/soe/hlitz/logs/weekly_perf_sweep.log")
+
+POLL_SECONDS = 300
+# A full SPEC17 sweep behind a busy queue; past this we take what finished.
+SIM_TIMEOUT_SECONDS = 24 * 3600
 
 SMTP_HOST = "smtp.soe.ucsc.edu"
 SMTP_PORT = 25
@@ -151,6 +159,41 @@ def experiment_dir(descriptor_stem: str) -> Path:
     return root / "simulations" / descriptor["experiment"]
 
 
+def sims_pending(experiment: str) -> bool:
+    """Any of this experiment's Slurm jobs still queued or running?"""
+    try:
+        names = subprocess.run(
+            ["squeue", "-u", getpass.getuser(), "-h", "-o", "%j"],
+            check=True, text=True, capture_output=True,
+        ).stdout.split()
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        log(f"WARNING: could not query squeue ({exc}); not waiting")
+        return False
+    return any(experiment in name for name in names)
+
+
+def wait_for_sims(experiment: str) -> None:
+    """`--sim` returns once Slurm has the jobs; the results land hours later.
+
+    Collecting stats before then reads a half-empty experiment dir and dies on
+    the first missing ramulator.stat.out, which is what made every sweep so far
+    record nothing.
+    """
+    deadline = time.monotonic() + SIM_TIMEOUT_SECONDS
+    waited = False
+    while sims_pending(experiment):
+        if time.monotonic() > deadline:
+            log(f"{experiment}: jobs still queued after "
+                f"{SIM_TIMEOUT_SECONDS // 3600}h; collecting what finished")
+            return
+        if not waited:
+            log(f"{experiment}: waiting for Slurm jobs to finish")
+            waited = True
+        time.sleep(POLL_SECONDS)
+    if waited:
+        log(f"{experiment}: all jobs finished")
+
+
 def run_mode(stem: str, experiment: str, *, skip_sim: bool) -> Optional[Path]:
     """Run one mode; return its aggregates.json."""
     descriptor_stem = render_descriptor(stem, experiment)
@@ -161,6 +204,7 @@ def run_mode(stem: str, experiment: str, *, skip_sim: bool) -> Optional[Path]:
             return None
         if not sci(["--sim", descriptor_stem]):
             return None
+        wait_for_sims(experiment)
         if not sci(["--collect-stats", descriptor_stem]):
             return None
 
@@ -515,12 +559,14 @@ def main() -> int:
     log(f"weekly sweep {today}: scarab={scarab_sha} infra={infra_sha}")
 
     rows: List[Dict[str, object]] = []
+    failures: List[str] = []
     for stem, label in MODES:
         experiment = f"{stem}_{suffix}"
         log(f"--- {label} ({experiment}) ---")
         aggregates_path = run_mode(stem, experiment, skip_sim=args.skip_sim)
         if aggregates_path is None:
             log(f"{label}: no results, continuing with the other modes")
+            failures.append(f"{label} ({experiment}): no results")
             continue
         metrics = derive_metrics(aggregates_path)
         for workload, values in metrics.items():
@@ -534,7 +580,19 @@ def main() -> int:
             })
 
     if not rows:
+        # Say so out loud: a silent week is indistinguishable from a healthy
+        # one, which is how the sweep sat broken without anyone noticing.
         log("ERROR: every mode failed; nothing to record")
+        body = "\n".join(
+            [f"SPEC CPU2017 weekly sweep {today} recorded nothing.",
+             f"scarab {scarab_sha}, scarab-infra {infra_sha}",
+             ""] + failures + ["", f"Log: {LOG_PATH}"]
+        )
+        print()
+        print(body)
+        if not args.dry_run and not args.no_email:
+            send_email(f"SPEC17 weekly perf sweep FAILED - {today}", body, [],
+                       org_recipients())
         return 1
 
     if args.dry_run:

--- a/scripts/weekly_perf_sweep.py
+++ b/scripts/weekly_perf_sweep.py
@@ -29,6 +29,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import traceback
 from email.message import EmailMessage
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -62,6 +63,9 @@ SMTP_HOST = "smtp.soe.ucsc.edu"
 SMTP_PORT = 25
 MAIL_FROM = "scarab-perf@soe.ucsc.edu"
 GITHUB_ORG = "litz-lab"
+# Used when the org lookup comes up empty (no gh on cron's PATH, no token, no
+# public emails). Mailing one person beats mailing nobody.
+FALLBACK_RECIPIENTS = ["hlitz@ucsc.edu"]
 
 FIELDNAMES = [
     "date",
@@ -496,12 +500,27 @@ def org_recipients() -> List[str]:
     return addresses
 
 
+def notify(subject: str, body: str, attachments: List[Path], args) -> None:
+    """Mail the lab, whatever happened.
+
+    The sweep exists to say something once a week. A week that produced no
+    mail is indistinguishable from a week nobody looked at, which is how it sat
+    broken for two runs -- so failures, crashes and skips all mail too.
+    """
+    if args.no_email or args.dry_run:
+        log(f"not mailing '{subject}' (--no-email/--dry-run)")
+        return
+    recipients = org_recipients() or FALLBACK_RECIPIENTS
+    send_email(subject, body, attachments, recipients)
+
+
 def send_email(subject: str, body: str, attachments: List[Path],
                recipients: List[str]) -> None:
     if not recipients:
         log("no recipients resolved; skipping email")
         return
 
+    delivered = 0
     for recipient in recipients:
         message = EmailMessage()
         message["From"] = MAIL_FROM
@@ -521,8 +540,14 @@ def send_email(subject: str, body: str, attachments: List[Path],
             with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=30) as smtp:
                 smtp.send_message(message)
             log(f"emailed {recipient}")
+            delivered += 1
         except Exception as exc:  # noqa: BLE001 - report and continue
             log(f"WARNING: could not email {recipient}: {exc}")
+
+    if not delivered:
+        # Nothing else can carry the news out of here; make the log say it.
+        log(f"ERROR: '{subject}' reached nobody ({len(recipients)} recipients "
+            f"tried via {SMTP_HOST}:{SMTP_PORT})")
 
 
 # ---------------------------------------------------------------------------
@@ -542,14 +567,31 @@ def main() -> int:
                         help="Override the dated experiment suffix (testing).")
     args = parser.parse_args()
 
+    today = _dt.date.today().isoformat()
+    try:
+        return run_sweep(args, today)
+    except Exception:  # noqa: BLE001 - any crash must still reach the lab
+        report = traceback.format_exc()
+        log("CRASHED:\n" + report)
+        notify(f"SPEC17 weekly perf sweep CRASHED - {today}",
+               f"The sweep raised before it could report.\n\n{report}\n"
+               f"Log: {LOG_PATH}",
+               [], args)
+        return 1
+
+
+def run_sweep(args, today: str) -> int:
     lock = LOCK_PATH.open("w")
     try:
         fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except BlockingIOError:
         log("another sweep is already running; exiting")
+        notify(f"SPEC17 weekly perf sweep SKIPPED - {today}",
+               "Another sweep still held the lock, so this run did nothing.\n"
+               f"Log: {LOG_PATH}",
+               [], args)
         return 0
 
-    today = _dt.date.today().isoformat()
     suffix = args.experiment_suffix or today.replace("-", "")
     infra_sha = git_sha(REPO_ROOT)
     scarab_sha = "skipped" if args.skip_sim else refresh_scarab()
@@ -590,9 +632,7 @@ def main() -> int:
         )
         print()
         print(body)
-        if not args.dry_run and not args.no_email:
-            send_email(f"SPEC17 weekly perf sweep FAILED - {today}", body, [],
-                       org_recipients())
+        notify(f"SPEC17 weekly perf sweep FAILED - {today}", body, [], args)
         return 1
 
     if args.dry_run:
@@ -617,9 +657,12 @@ def main() -> int:
             cwd=HISTORY_DIR, check=False)
         run(["git", "push"], cwd=HISTORY_DIR, check=False)
 
-    if not args.no_email:
-        send_email(f"SPEC17 weekly perf sweep — {today}", report, plots,
-                   org_recipients())
+    # A run where some modes died still reports, but says so in the subject.
+    if failures:
+        report += "\n\nModes that produced nothing:\n" + "\n".join(
+            f"  {f}" for f in failures) + f"\nLog: {LOG_PATH}"
+    suffix_note = " (partial)" if failures else ""
+    notify(f"SPEC17 weekly perf sweep{suffix_note} - {today}", report, plots, args)
 
     return 0
 


### PR DESCRIPTION
## Why there was no email

The sweep ran on schedule both weeks — it just recorded nothing, and the
"nothing recorded" path sends no mail, so a broken sweep looks exactly like a
quiet week. From `/soe/hlitz/logs/weekly_perf_sweep.log`, both 2026-08-16 and
2026-08-23 end in `ERROR: every mode failed; nothing to record`.

Three independent faults, all of them fatal on their own:

1. **`application_dir` does not exist.** The weekly descriptors point at
   `/soe/hlitz/applications`; the real tree is `/soe/hlitz/lab/applications`.
   All 106 memtrace jobs died before Scarab started:
   ```
   docker: Error response from daemon: invalid mount config for type "bind":
   bind source path does not exist: /soe/hlitz/applications
   ```
   (106 of 107 job logs, the 107th being the stat-collection job.)
2. **exec mode submitted nothing.** `workloads_db.json` gives a `warmup` only
   under `memtrace`, never under `exec`, so the exec descriptor's
   `"warmup": null` — "use the trace's warmup" — sent the runner into
   `workloads_data[...]["simulation"]["exec"]["warmup"]` and a
   `KeyError: 'warmup'`. Asks for `0` now.
3. **Stats were collected before the sims ran.** With `workload_manager: slurm`,
   `sci --sim` returns once the jobs are queued (7 s for 106 jobs). The sweep
   called `--collect-stats` seconds later, which read a half-empty experiment
   dir and died on the first missing `ramulator.stat.out`. It now waits for the
   experiment's jobs to leave the queue (polling `squeue` every 5 min, 24 h cap,
   then collects whatever finished).

## Also

Total failure now sends mail as well, listing which modes produced nothing and
where the log is. The point of the sweep is a weekly signal; silence should not
be one of its outputs.

## Validation

Drove `run_mode()` through the real path — the same function the sweep uses —
on a one-workload memtrace descriptor with the corrected `application_dir`:

- 3 Slurm jobs submitted, the new wait loop logged
  `waiting for Slurm jobs to finish` and then `all jobs finished` ~10 min later,
- `--collect-stats` and `--visualize` both succeeded (`collected_stats.csv`,
  `aggregates.json` written),
- `derive_metrics` returned `ipc 2.28203`, `mem_latency_cycles 304.021`,
  `offpath_cycle_pct 40.2124`, `kips 156.761`.

Before this change that same sequence failed at `--collect-stats` every time.

The failure mail was rendered with `--dry-run --skip-sim` against a suffix with
no experiments, and `sims_pending()` checked against a live queue (True for a
running experiment name, False for an unknown one).

Next Sunday's cron run is the real end-to-end test; if you'd rather not wait,
`python3 scripts/weekly_perf_sweep.py --experiment-suffix manual1` runs it now.


## Follow-up commit: mail on every exit path

The sweep's job is to say something once a week, so a silent week must mean
"nothing to say", never "the sweep broke". Four paths could still exit without
mail:

- an exception anywhere in the run (the traceback went to the log and nowhere
  else),
- the lock already being held by a previous run,
- a run where *some* modes died — it mailed, but the report never said which,
- `org_recipients()` coming back empty (no `gh` on cron's PATH, no token,
  nobody with a public email), which silently skipped the send even when there
  was a good report to deliver.

All mail now leaves through one `notify()`, which falls back to a fixed
recipient when the org lookup finds nobody. `main()` is a thin wrapper that
catches whatever `run_sweep()` throws and mails the traceback. A partial run
says `(partial)` in the subject and lists the modes that produced nothing. If
SMTP takes none of it, the log says `ERROR: '<subject>' reached nobody` instead
of a per-recipient warning.

Each path verified with `send_email`/`org_recipients` stubbed:

```
1 no-results   rc=1 subject='SPEC17 weekly perf sweep FAILED - 2026-08-24'    to=['hlitz@ucsc.edu']
2 partial      rc=0 subject='SPEC17 weekly perf sweep (partial) - 2026-08-24' to=['hlitz@ucsc.edu']
3 success      rc=0 subject='SPEC17 weekly perf sweep - 2026-08-24'           to=['hlitz@ucsc.edu']
crash          rc=1 subject='SPEC17 weekly perf sweep CRASHED - 2026-08-24'   to=['hlitz@ucsc.edu']
skipped        rc=0 subject='SPEC17 weekly perf sweep SKIPPED - 2026-08-24'   to=['hlitz@ucsc.edu']
dry-run mails: 0
```

and a dead SMTP host produces `ERROR: 'subject' reached nobody (1 recipients
tried via 127.0.0.1:1)`.

One case this cannot cover: if the process is killed outright (OOM, node
reboot) nothing can mail from inside it. Catching that needs an external
watchdog — a second cron entry that mails if no report landed by, say, Monday
noon. Say the word and I'll add it.


## Follow-up: check out a fresh scarab-infra too (2026-08-30 failure)

The 2026-08-30 sweep mailed FAILED with all three modes dying in
`--build-scarab`:

```
pin_exec.cpp:181:10: error: 'INS_HasScatteredMemoryAccess' was not declared in this scope
```

The sweep resets its *Scarab* clone to `origin/main` but ran whatever
*scarab-infra* it was started from — cron starts it in a shared working tree,
which sat on a branch predating #435 (the SDE 9.44.0 / PIN 3.31 image). So a
PIN-3.15 image was asked to build a Scarab main that needs PIN 3.31. Reproduced
exactly: that checkout resolves to `allbench_traces:6e61bf2f9b9b`
(`PIN_ROOT=/tmp_home/pin-3.15-…`), main resolves to `b8303c9d1e27` (SDE 9.44.0).

`refresh_infra()` now does for infra what `refresh_scarab()` does for Scarab:
clone/reset `/soe/hlitz/git/scarab-infra-weekly` to `origin/main` and re-exec
the sweep from it before anything else runs — the same shape as the CI job,
which checks out both repos per run. Whatever checkout cron starts only
supplies the first line of code.

Guards: `--no-self-update` runs a checkout as-is and puts a "not main" warning
at the top of its mail; the re-exec is skipped when the script on main does not
yet understand that flag, so an older main neither dies on an unknown argument
(argparse exits before the mail handler exists) nor re-execs in a loop.

`refresh_scarab()` also cleans `src/pin`: the PIN tool's `.d` files name the PIN
path of the image that built them, so after the image switch make looked for
`/tmp_home/pin-3.15-…/algorithm` and stopped. Scoped to `src/pin` so DynamoRIO
is not rebuilt every week.

### Schedule

The host is UTC and this cron build has no `CRON_TZ` (not in the binary, not in
the man page), so `0 0 * * 0` fired **Saturday 17:00 Pacific**, not Sunday
night — that is the "Aug 29, 5:02 PM" timestamp on the failure mail. Now
`0 5 * * 1`: Monday 05:00 UTC = Sunday 22:00 PDT / 21:00 PST.

### Verified

- Re-exec against a stand-in origin whose main carries this code: clone
  created, reset, `running from … at fed4e84`, sweep continues there — no loop,
  no argparse error.
- Against today's main (no flag yet): declines to re-exec, logs and mails
  "predates --no-self-update".
- After cleaning `src/pin`, `pin_exec` compiles **and links** against SDE
  9.44.0 in the current image.

### Not fixed here

`sci` names the build container `allbench_traces_<user>_scarab_build` with no
per-run suffix, so two concurrent `--build-scarab` runs by the same user
`docker rm -f` each other's container; the surviving one dies mid-build with no
error message at all. `docker events` shows the `kill`/`die`/`destroy` landing
on an in-flight build. That is what blocked my full-build verification here (a
second session was building `build_exclshim`), and it deserves its own PR —
the sim containers already carry a unique suffix.
