### PR TITLE
Weekly sweep: check out a fresh scarab-infra too, and run Sunday night

### DIFF
--- a/scripts/weekly_perf_sweep.cron
+++ b/scripts/weekly_perf_sweep.cron
@@ -4,8 +4,18 @@
 #
 # Needs the scarabinfra conda env (pandas/matplotlib) and gh on PATH; cron's
 # PATH is minimal, so both are set explicitly below.
+#
+# The host runs UTC and this cron build has no CRON_TZ, so the schedule is
+# written in UTC: Monday 05:00 UTC is Sunday 22:00 Pacific (21:00 under PST),
+# i.e. Sunday night here. The old "Sunday 00:00 UTC" fired Saturday afternoon.
+#
+# It runs from a clone of its own, reset to main first. The sweep resets its
+# Scarab clone to origin/main, and pairing that with whatever branch someone
+# left checked out in a shared working tree is how 2026-08-30 came to build a
+# PIN-3.31 Scarab inside a PIN-3.15 image. Create the clone once with:
+#   git clone git@github.com:litz-lab/scarab-infra.git /soe/hlitz/git/scarab-infra-weekly
 SHELL=/bin/bash
 PATH=/soe/hlitz/miniconda3/envs/scarabinfra/bin:/usr/local/bin:/usr/bin:/bin
 MAILTO=""
 
-0 0 * * 0 cd /soe/hlitz/git/scarab-infra && python3 scripts/weekly_perf_sweep.py >> /soe/hlitz/logs/weekly_perf_sweep.log 2>&1
+0 5 * * 1 cd /soe/hlitz/git/scarab-infra-weekly && git fetch -q origin main && git reset -q --hard origin/main && python3 scripts/weekly_perf_sweep.py >> /soe/hlitz/logs/weekly_perf_sweep.log 2>&1

--- a/scripts/weekly_perf_sweep.cron
+++ b/scripts/weekly_perf_sweep.cron
@@ -9,13 +9,13 @@
 # written in UTC: Monday 05:00 UTC is Sunday 22:00 Pacific (21:00 under PST),
 # i.e. Sunday night here. The old "Sunday 00:00 UTC" fired Saturday afternoon.
 #
-# It runs from a clone of its own, reset to main first. The sweep resets its
-# Scarab clone to origin/main, and pairing that with whatever branch someone
-# left checked out in a shared working tree is how 2026-08-30 came to build a
-# PIN-3.31 Scarab inside a PIN-3.15 image. Create the clone once with:
-#   git clone git@github.com:litz-lab/scarab-infra.git /soe/hlitz/git/scarab-infra-weekly
+# The script clones/resets both repos itself -- scarab-infra into
+# /soe/hlitz/git/scarab-infra-weekly and Scarab into /soe/hlitz/git/scarab-weekly,
+# each at origin/main -- and re-execs from the fresh infra before it does
+# anything, the same way CI checks out both. Whichever checkout cron starts it
+# from only provides that first line of code.
 SHELL=/bin/bash
 PATH=/soe/hlitz/miniconda3/envs/scarabinfra/bin:/usr/local/bin:/usr/bin:/bin
 MAILTO=""
 
-0 5 * * 1 cd /soe/hlitz/git/scarab-infra-weekly && git fetch -q origin main && git reset -q --hard origin/main && python3 scripts/weekly_perf_sweep.py >> /soe/hlitz/logs/weekly_perf_sweep.log 2>&1
+0 5 * * 1 cd /soe/hlitz/git/scarab-infra-weekly && python3 scripts/weekly_perf_sweep.py >> /soe/hlitz/logs/weekly_perf_sweep.log 2>&1

--- a/scripts/weekly_perf_sweep.py
+++ b/scripts/weekly_perf_sweep.py
@@ -42,9 +42,13 @@ MODES: List[Tuple[str, str]] = [
     ("weekly_spec17_exec_opt", "exec/opt"),
 ]
 
-# Own clone so a sweep never collides with anyone's working tree.
+# Own clones so a sweep never collides with anyone's working tree, and never
+# tests whatever branch someone happened to leave checked out.
 SCARAB_DIR = Path("/soe/hlitz/git/scarab-weekly")
 SCARAB_REMOTE = "git@github.com:litz-lab/scarab.git"
+
+INFRA_DIR = Path("/soe/hlitz/git/scarab-infra-weekly")
+INFRA_REMOTE = "git@github.com:litz-lab/scarab-infra.git"
 
 HISTORY_DIR = Path("/soe/hlitz/git/scarab_weekly")
 HISTORY_REMOTE = "git@github.com:litz-lab/scarab_weekly.git"
@@ -108,12 +112,11 @@ _INFRA_WARNING = ""
 
 
 def infra_warning() -> str:
-    """Warn when this checkout is not main, or is behind it.
+    """Warn when the checkout we ended up in is not main, or is behind it.
 
-    The sweep resets its Scarab clone to origin/main but runs whatever
-    scarab-infra it was started from. On 2026-08-30 that was a branch predating
-    the SDE/PIN-3.31 image switch, so a PIN-3.15 image tried to build a Scarab
-    main that needs PIN 3.31 and every mode died in --build-scarab.
+    Normally refresh_infra() has already re-execed us from a clean main, so
+    this is empty. It fires under --no-self-update, which is how a hand-run
+    sweep from a feature branch says so in its own mail.
     """
     run(["git", "fetch", "origin", "main"], cwd=REPO_ROOT, check=False)
 
@@ -160,6 +163,36 @@ def ensure_clone(path: Path, remote: str) -> None:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
     run(["git", "clone", remote, str(path)])
+
+
+def refresh_infra() -> None:
+    """Re-run ourselves from a fresh scarab-infra main, the way CI does.
+
+    Both repos have to be current: the images, run scripts and descriptors come
+    from infra, the simulator from Scarab. Pairing a fresh Scarab with whatever
+    infra the sweep happened to be launched from is how 2026-08-30 built a
+    PIN-3.31 Scarab inside a PIN-3.15 image and reported nothing.
+    """
+    ensure_clone(INFRA_DIR, INFRA_REMOTE)
+    run(["git", "fetch", "origin", "main"], cwd=INFRA_DIR)
+    run(["git", "reset", "--hard", "origin/main"], cwd=INFRA_DIR)
+
+    script = INFRA_DIR / "scripts" / Path(__file__).name
+    if not script.is_file():
+        log(f"WARNING: {script} missing; continuing from {REPO_ROOT}")
+        return
+    # The version on main has to understand the flag that stops it re-execing
+    # in turn; without that check an older one either dies on an unknown
+    # argument (no mail, argparse exits before our handler) or loops forever.
+    if "--no-self-update" not in script.read_text(encoding="utf-8", errors="replace"):
+        log(f"WARNING: {script} predates --no-self-update; "
+            f"continuing from {REPO_ROOT}")
+        return
+    log(f"running from {INFRA_DIR} at {git_sha(INFRA_DIR)}")
+    # exec, not import: the descriptors, sci and run scripts of this run must
+    # all come from the tree we just reset.
+    os.execv(sys.executable,
+             [sys.executable, str(script), "--no-self-update", *sys.argv[1:]])
 
 
 def refresh_scarab() -> str:
@@ -612,9 +645,14 @@ def main() -> int:
     parser.add_argument("--no-push", action="store_true")
     parser.add_argument("--experiment-suffix", default=None,
                         help="Override the dated experiment suffix (testing).")
+    parser.add_argument("--no-self-update", action="store_true",
+                        help="Run this checkout as-is instead of re-execing "
+                             "from a fresh scarab-infra main.")
     args = parser.parse_args()
 
     today = _dt.date.today().isoformat()
+    if not args.no_self_update and not args.dry_run:
+        refresh_infra()  # never returns: re-execs from INFRA_DIR
     try:
         return run_sweep(args, today)
     except Exception:  # noqa: BLE001 - any crash must still reach the lab

--- a/scripts/weekly_perf_sweep.py
+++ b/scripts/weekly_perf_sweep.py
@@ -102,6 +102,46 @@ def run(cmd: List[str], *, cwd: Optional[Path] = None, check: bool = True,
     )
 
 
+# Set once per run; prepended to every mail so a stale checkout is never a
+# silent explanation for a weird result.
+_INFRA_WARNING = ""
+
+
+def infra_warning() -> str:
+    """Warn when this checkout is not main, or is behind it.
+
+    The sweep resets its Scarab clone to origin/main but runs whatever
+    scarab-infra it was started from. On 2026-08-30 that was a branch predating
+    the SDE/PIN-3.31 image switch, so a PIN-3.15 image tried to build a Scarab
+    main that needs PIN 3.31 and every mode died in --build-scarab.
+    """
+    run(["git", "fetch", "origin", "main"], cwd=REPO_ROOT, check=False)
+
+    def git(*args: str) -> Optional[str]:
+        try:
+            return subprocess.run(["git", *args], cwd=str(REPO_ROOT), check=True,
+                                  text=True, capture_output=True).stdout.strip()
+        except subprocess.CalledProcessError:
+            return None
+
+    head = git("rev-parse", "--short", "HEAD")
+    target = git("rev-parse", "--short", "origin/main")
+    behind = git("rev-list", "--count", "HEAD..origin/main")
+    dirty = git("status", "--porcelain")
+    if head is None or target is None:
+        return ""
+    if head == target and not dirty:
+        return ""
+    detail = [f"checkout {head}, origin/main {target}"]
+    if behind and behind != "0":
+        detail.append(f"{behind} commits behind")
+    if dirty:
+        detail.append("uncommitted changes")
+    return (f"WARNING: scarab-infra at {REPO_ROOT} is not main ("
+            + "; ".join(detail) + ").\n"
+            "The images and run scripts under test are not the ones on main.")
+
+
 def git_sha(repo: Path) -> str:
     try:
         out = subprocess.run(["git", "rev-parse", "--short", "HEAD"], cwd=str(repo),
@@ -127,6 +167,11 @@ def refresh_scarab() -> str:
     run(["git", "fetch", "origin", "main"], cwd=SCARAB_DIR)
     # Reset, not pull: a stray local commit must not change what we measure.
     run(["git", "reset", "--hard", "origin/main"], cwd=SCARAB_DIR)
+    # And clean the PIN tool: its objects keep .d files naming the PIN path of
+    # the image that built them, so a container upgrade turns into "No rule to
+    # make target /tmp_home/pin-3.15-.../algorithm" until they are gone. Only
+    # src/pin -- wiping the whole tree would rebuild DynamoRIO every week.
+    run(["git", "clean", "-xfd", "--", "src/pin"], cwd=SCARAB_DIR, check=False)
     run(["git", "submodule", "update", "--init", "--recursive"], cwd=SCARAB_DIR, check=False)
     return git_sha(SCARAB_DIR)
 
@@ -510,6 +555,8 @@ def notify(subject: str, body: str, attachments: List[Path], args) -> None:
     if args.no_email or args.dry_run:
         log(f"not mailing '{subject}' (--no-email/--dry-run)")
         return
+    if _INFRA_WARNING:
+        body = f"{_INFRA_WARNING}\n\n{body}"
     recipients = org_recipients() or FALLBACK_RECIPIENTS
     send_email(subject, body, attachments, recipients)
 
@@ -581,6 +628,11 @@ def main() -> int:
 
 
 def run_sweep(args, today: str) -> int:
+    global _INFRA_WARNING
+    _INFRA_WARNING = infra_warning()
+    if _INFRA_WARNING:
+        log(_INFRA_WARNING)
+
     lock = LOCK_PATH.open("w")
     try:
         fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)


### PR DESCRIPTION
Follow-up to #437, rebased on current main.

## Why the 2026-08-30 sweep mailed FAILED

All three modes died in `--build-scarab`:

```
pin_exec.cpp:181:10: error: 'INS_HasScatteredMemoryAccess' was not declared in this scope
```

The sweep resets its *Scarab* clone to `origin/main` but ran whatever
*scarab-infra* it was started from — cron starts it in a shared working tree,
which sat on a branch predating #435 (the SDE 9.44.0 / PIN 3.31 image). A
PIN-3.15 image was asked to build a Scarab main that needs PIN 3.31. Reproduced
exactly: that checkout resolves to `allbench_traces:6e61bf2f9b9b`
(`PIN_ROOT=/tmp_home/pin-3.15-…`); main resolves to `b8303c9d1e27` (SDE 9.44.0).

## Check out both repos, like CI

`refresh_infra()` does for infra what `refresh_scarab()` already does for
Scarab: clone/reset `/soe/hlitz/git/scarab-infra-weekly` to `origin/main` and
re-exec the sweep from it before anything else runs. Whatever checkout cron
starts only supplies that first line of code; the descriptors, `sci`, run
scripts and image tag all come from the fresh main — the same shape as the CI
job, which checks out both repos per run.

Guards, because re-execing into code you have not read is how you get a loop or
a silent death:

- `--no-self-update` runs a checkout as-is, and its mail carries a "not main"
  warning naming the sha and how far behind it is.
- The re-exec is skipped when the script on main does not yet understand that
  flag — otherwise an older main dies on an unknown argument (argparse exits
  before the crash-mail handler exists) or re-execs forever.

`refresh_scarab()` also cleans `src/pin`: the PIN tool's `.d` files name the PIN
path of the image that built them, so after an image switch make looks for
`/tmp_home/pin-3.15-…/algorithm` and stops. Scoped to `src/pin` so DynamoRIO is
not rebuilt every week.

## Schedule

The host is UTC and this cron build has no `CRON_TZ` (absent from the binary
and the man page), so `0 0 * * 0` fired **Saturday 17:00 Pacific** — that is
the "Aug 29, 5:02 PM" timestamp on the failure mail, not Sunday night. Now
`0 5 * * 1`: Monday 05:00 UTC = Sunday 22:00 PDT / 21:00 PST. The cron line
also drops its `cd`-and-git preamble, since the script does the checkout now.

## Verified

- Re-exec against a stand-in origin carrying this code: clone created, reset,
  `running from … at fed4e84`, sweep continues there — no loop, no argparse
  error.
- Against a main without the flag: declines to re-exec, logs and mails
  `predates --no-self-update`.
- Mail paths still fire after the rebase: FAILED, (partial), success, CRASHED,
  SKIPPED, and nothing under `--dry-run`.
- After cleaning `src/pin`, `pin_exec` compiles and links against SDE 9.44.0 in
  the current image.

## Not fixed here

`sci` names the build container `allbench_traces_<user>_scarab_build`
(`utilities.py:404`) with no per-run suffix, and every build starts with
`docker rm -f` on that name. Two concurrent `--build-scarab` runs by the same
user therefore destroy each other's container, and the loser dies mid-build
with no error text at all — just a truncated log. `docker events` shows the
`kill`/`die`/`destroy` landing on an in-flight build. The sim containers
already carry a unique suffix; the build container should too. Worth its own PR.
