### PR TITLE
Give each build and lint container a name of its own

### DIFF
--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -393,6 +393,46 @@ def prepare_docker_image(docker_prefix, image_tag, dbg_lvl=1):
                 exit(1)
 
 # Locally builds scarab using docker. No caching or skipping logic
+def own_container_name(base: str) -> str:
+    """A container name nobody else's run shares.
+
+    Build and lint containers used to be named just <image>_<user>_scarab_build,
+    and every run began by force-removing that name. Two builds by the same user
+    therefore destroyed each other's container, and the loser's `make` died
+    mid-compile with no error text at all -- only a truncated log.
+    """
+    return f"{base}_{os.getpid()}"
+
+
+def remove_stale_containers(base: str, dbg_lvl: int = 1) -> None:
+    """Remove leftovers of runs that were killed before their cleanup ran.
+
+    Only ones whose pid is gone: a sibling run's container must survive, which
+    is the whole point of the pid suffix.
+    """
+    try:
+        names = subprocess.run(
+            ["docker", "ps", "-a", "--filter", f"name=^{base}_[0-9]+$",
+             "--format", "{{.Names}}"],
+            check=True, capture_output=True, text=True).stdout.split()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return
+    for name in names:
+        pid = name.rsplit("_", 1)[-1]
+        if not pid.isdigit():
+            continue
+        try:
+            os.kill(int(pid), 0)
+            continue  # still running: not ours to remove
+        except PermissionError:
+            continue  # someone else's live process
+        except OSError:
+            pass
+        info(f"Removing stale container {name} (pid {pid} is gone)", dbg_lvl)
+        subprocess.run(["docker", "rm", "-f", name], check=False,
+                       capture_output=True, text=True)
+
+
 def build_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_prefix, infra_dir, dbg_lvl=1, stream_build=False):
     local_uid = os.getuid()
     local_gid = os.getgid()
@@ -401,13 +441,12 @@ def build_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_pre
 
     scarab_bin = f"{scarab_path}/src/build/{scarab_build}/scarab"
     info(f"Scarab binary at '{scarab_bin}', building it first, please wait...", dbg_lvl)
-    docker_container_name = f"{docker_prefix}_{user}_scarab_build"
-    # The container name is deterministic, so one left over from an earlier run makes
-    # this `docker run` fail with a bare exit 125 and no explanation. Clear it first:
-    # the finally below does not cover a SIGTERM'd sci (slurm timeout, CI kill, or a
-    # wrapper timeout), because Python does not unwind the stack on SIGTERM.
-    subprocess.run(["docker", "rm", "-f", f"{docker_container_name}"],
-                   check=False, capture_output=True, text=True)
+    docker_container_name = own_container_name(f"{docker_prefix}_{user}_scarab_build")
+    # A leftover of the same name makes `docker run` fail with a bare exit 125 and no
+    # explanation, and the finally below does not cover a SIGTERM'd sci (slurm timeout,
+    # CI kill, or a wrapper timeout) because Python does not unwind on SIGTERM. Clear
+    # only dead runs' containers -- never a concurrent build's.
+    remove_stale_containers(f"{docker_prefix}_{user}_scarab_build", dbg_lvl)
     try:
         subprocess.run(
                 ["docker", "run", "-e", f"user_id={local_uid}",
@@ -479,7 +518,7 @@ def lint_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_pref
     local_uid = os.getuid()
     local_gid = os.getgid()
     build_mode = scarab_build if scarab_build else "opt"
-    docker_container_name = f"{docker_prefix}_{user}_scarab_lint"
+    docker_container_name = own_container_name(f"{docker_prefix}_{user}_scarab_lint")
 
     # Keep the enabled check set narrow. Expand intentionally by editing this
     # list; every consumer of --lint-scarab picks up the change automatically.
@@ -607,10 +646,9 @@ def lint_scarab_binary(user, scarab_path, scarab_build, docker_home, docker_pref
 
     info(f"Linting scarab with image {image_ref}...", dbg_lvl)
     exception = None
-    # Same deterministic-name hazard as build_scarab_binary: clear any leftover
-    # container so a previously killed lint run does not block this one.
-    subprocess.run(["docker", "rm", "-f", f"{docker_container_name}"],
-                   check=False, capture_output=True, text=True)
+    # Same hazard as build_scarab_binary: clear leftovers of runs that died before
+    # their cleanup, but never a concurrent lint's container.
+    remove_stale_containers(f"{docker_prefix}_{user}_scarab_lint", dbg_lvl)
     try:
         subprocess.run(
             ["docker", "run",


### PR DESCRIPTION
## The bug

`build_scarab_binary` and `lint_scarab_binary` named their container after the
image and the user only:

```python
docker_container_name = f"{docker_prefix}_{user}_scarab_build"   # utilities.py:404
subprocess.run(["docker", "rm", "-f", docker_container_name], ...)  # line 409
```

The `docker rm -f` is there for a good reason — a leftover from a run that was
SIGTERM'd makes `docker run` fail with a bare exit 125 — but with a name that
carries nothing per-run, **two builds by the same user destroy each other's
container**. The loser's `make` dies mid-compile with no error text at all,
just a log that stops, and `sci` reports only "Scarab build failed".

I hit this repeatedly today while verifying #441: a second session was running
`--build-scarab build_exclshim` as the same user, and `docker events` shows the
`kill`/`die`/`destroy` landing on my in-flight build:

```
15:23:55 kill      <- while exec 1e23dff6 (my make) was running
15:23:55 exec_die  1e23dff6
15:23:55 die
15:23:55 destroy
15:23:56 create    <- the other run's fresh container
```

The damage outlives the run, too. A container killed during a link leaves a
truncated object in the archive, so a *later* build fails with something that
looks like a real compiler problem:

```
/usr/bin/ld: libdynamorio_static.a(decode_shared.c.o) in archive is not an object
```

That is how a scheduling accident turns into an afternoon of chasing a
non-existent code bug.

## The fix

Container names carry the pid of the run that owns them, and the pre-run
cleanup removes only containers whose pid is gone — never a live sibling's. Sim
containers already carry a per-simulation suffix; this brings the build and
lint paths in line.

## Verified

- **Concurrent builds coexist:** with another session's build holding the
  unsuffixed name, mine ran as `allbench_traces_hlitz_scarab_build_3619000` and
  neither disturbed the other.
- **Stale sweep is precise:** two real containers, one named for a live pid and
  one for a dead pid. Before: both present. After `remove_stale_containers`:
  only the live one remains.
- **Build works end to end:** after clearing the corrupted `build/opt` left by
  the earlier collisions, Scarab main built clean in the current image —
  132 MB binary, `Scarab build successful!`.

## Follow-up worth considering

A build killed at the wrong moment can still poison the tree for the *next*
run. The weekly sweep cleans `src/pin` (PIN objects name their image's PIN
path), but nothing detects a corrupt archive under `src/build`. Retrying a
failed build once after `rm -rf src/build/<mode>` would make that
self-healing — happy to add it if you want it.
