### PR TITLE
Weekly sweep: visible plots, no false 'not main' warning, dbg average survives a failed workload

### DIFF
--- a/scripts/weekly_perf_sweep.py
+++ b/scripts/weekly_perf_sweep.py
@@ -130,7 +130,9 @@ def infra_warning() -> str:
     head = git("rev-parse", "--short", "HEAD")
     target = git("rev-parse", "--short", "origin/main")
     behind = git("rev-list", "--count", "HEAD..origin/main")
-    dirty = git("status", "--porcelain")
+    # Tracked files only: the sweep renders a descriptor per mode into json/,
+    # so counting untracked files declared the clone "not main" every week.
+    dirty = git("status", "--porcelain", "--untracked-files=no")
     if head is None or target is None:
         return ""
     if head == target and not dirty:
@@ -176,6 +178,10 @@ def refresh_infra() -> None:
     ensure_clone(INFRA_DIR, INFRA_REMOTE)
     run(["git", "fetch", "origin", "main"], cwd=INFRA_DIR)
     run(["git", "reset", "--hard", "origin/main"], cwd=INFRA_DIR)
+    # Drop the descriptors previous runs rendered here. Only json/: the clone's
+    # scarab_builds/ cache is untracked too, and wiping it would rebuild
+    # Scarab from scratch every week.
+    run(["git", "clean", "-xfdq", "--", "json"], cwd=INFRA_DIR, check=False)
 
     script = INFRA_DIR / "scripts" / Path(__file__).name
     if not script.is_file():
@@ -343,6 +349,20 @@ def derive_metrics(aggregates_path: Path) -> Dict[str, Dict[str, Optional[float]
             "offpath_cycle_pct": offpath,
             "kips": kips,
         }
+
+    # One failed simpoint makes the aggregate's own Avg nan, which erased the
+    # whole mode from the mail and the plots -- 2026-09-07 lost memtrace/dbg to
+    # a single workload (gcc_r). Fall back to the mean of the workloads that did
+    # report. Unweighted, so it is not identical to the aggregate's Avg; it is
+    # only used when that one is unusable.
+    for metric in ("ipc", "mem_latency_cycles", "offpath_cycle_pct", "kips"):
+        current = out["Avg"].get(metric)
+        if current is not None and math.isfinite(current):
+            continue
+        values = [v[metric] for w, v in out.items()
+                  if w != "Avg" and v[metric] is not None and math.isfinite(v[metric])]
+        if values:
+            out["Avg"][metric] = sum(values) / len(values)
     return out
 
 
@@ -427,7 +447,11 @@ def make_plots(history: List[Dict[str, str]], outdir: Path) -> List[Path]:
                 xs = [d for d in dates if d in series]
                 if not xs:
                     continue
+                # Markers, not just a line: on the first run of a metric there
+                # is one date, and a one-point line draws nothing at all --
+                # which is why the 2026-09-07 plots came out blank.
                 ax.plot(xs, [series[d] for d in xs], linewidth=1.0, alpha=0.75,
+                        marker=".", markersize=4,
                         color=app_color(i), label=short_name(workload))
                 drew_anything = True
 


### PR DESCRIPTION
First real sweep produced data on 2026-09-07. Three things it got wrong.

## 1. The plots were blank

Every per-workload series is drawn as a line with no marker. One date is one
point, and a one-point line renders **nothing** — so 36 of 37 series were
invisible. Only the Average showed, because it already had `marker="o"`. That
is the single black dot on `ipc.png`.

Fixed by giving the workload lines a marker. Regenerated from the real
`history.csv`: all 36 workloads now visible in both memtrace subplots.

## 2. The mail warned the clone was "not main" when it was

```
WARNING: scarab-infra at /soe/hlitz/git/scarab-infra-weekly is not main
(checkout 32d784e, origin/main 32d784e; uncommitted changes).
```

Same sha twice — the clone *was* main. It was dirty only because the sweep
renders a descriptor per mode into its own `json/`, and the check counted
untracked files. Now it counts tracked files only, and `refresh_infra()` cleans
`json/` when resetting so last week's descriptors do not pile up. Only `json/`:
the clone's untracked `scarab_builds/` cache would go with a full clean and
Scarab would rebuild from scratch every week.

Checked against the live clone: main's version warns, this one is silent.

## 3. memtrace/dbg disappeared from the mail and the plots

`gcc_r` failed in dbg, which makes the aggregate's own `Avg` `nan` — and that
one bad cell erased the entire mode's headline and its Average line. The other
35 workloads had reported fine.

Now the average falls back to the mean of the workloads that did report
(unweighted, so only used when the aggregate's `Avg` is unusable). On the
2026-09-07 data that turns `dbg: n/a` into:

| metric | dbg | opt |
| --- | --: | --: |
| IPC | 1.8754 | 1.8615 |
| mem latency (cycles/L1 fill) | 343.11 | 342.28 |
| offpath icache | 20.42% | 23.39% |
| KIPS | 7.64 | 66.33 |

## Still broken, separately: exec/opt

Not fixed here — it needs a decision. Every exec simpoint died at startup:

```
SDE ERROR: getenv failed for SDE_GDB_XML
```

The runs launch `sde-external-9.44.0/pinkit/pin` directly, but the SDE kit
expects environment the `sde` wrapper normally sets. This is fallout from #435
(the PIN 3.15 → SDE 9.44.0 switch): exec-driven simulation has been failing on
main since then, and `--collect-stats` then aborts on the first missing
`ramulator.stat.out`, so the mode reports nothing at all. Want me to fix the
env (in the image, or in the launch path) as its own PR?
