### PR TITLE
Make PinPlay opt-in again so live exec-driven runs work

### DIFF
--- a/common/Dockerfile.common
+++ b/common/Dockerfile.common
@@ -119,7 +119,9 @@ RUN cd $tmpdir && wget -q https://github.com/litz-lab/scarab-infra/releases/down
 # Env to build Scarab
 ENV PIN_ROOT $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit
 ENV SCARAB_ENABLE_PT_MEMTRACE 1
-ENV SCARAB_ENABLE_PINPLAY 1
+# PinPlay stays opt-in (export SCARAB_ENABLE_PINPLAY=1). It links pin_exec
+# against the SDE runtime, which only works under SDE's own launcher: run
+# live under plain `pin` it dies at OSXAVE. Replay uses sde; live exec does not.
 ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/extras/xed-intel64/lib
 ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/intel64/runtime/pincrt:$LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH $DYNAMORIO_HOME/lib64/release:$LD_LIBRARY_PATH

--- a/common/Dockerfile.oss
+++ b/common/Dockerfile.oss
@@ -61,7 +61,9 @@ RUN cd $tmpdir && wget -q https://github.com/litz-lab/scarab-infra/releases/down
 # Env to build Scarab
 ENV PIN_ROOT $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit
 ENV SCARAB_ENABLE_PT_MEMTRACE 1
-ENV SCARAB_ENABLE_PINPLAY 1
+# PinPlay stays opt-in (export SCARAB_ENABLE_PINPLAY=1). It links pin_exec
+# against the SDE runtime, which only works under SDE's own launcher: run
+# live under plain `pin` it dies at OSXAVE. Replay uses sde; live exec does not.
 ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/extras/xed-intel64/lib
 ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/intel64/runtime/pincrt:$LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH $DYNAMORIO_HOME/lib64/release:$LD_LIBRARY_PATH

--- a/common/Dockerfile.tailbench
+++ b/common/Dockerfile.tailbench
@@ -61,7 +61,9 @@ RUN cd $tmpdir && wget -q https://github.com/litz-lab/scarab-infra/releases/down
 # Env to build Scarab
 ENV PIN_ROOT $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit
 ENV SCARAB_ENABLE_PT_MEMTRACE 1
-ENV SCARAB_ENABLE_PINPLAY 1
+# PinPlay stays opt-in (export SCARAB_ENABLE_PINPLAY=1). It links pin_exec
+# against the SDE runtime, which only works under SDE's own launcher: run
+# live under plain `pin` it dies at OSXAVE. Replay uses sde; live exec does not.
 ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/extras/xed-intel64/lib
 ENV LD_LIBRARY_PATH $tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/intel64/runtime/pincrt:$LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH $DYNAMORIO_HOME/lib64/release:$LD_LIBRARY_PATH

--- a/common/scripts/user_entrypoint.sh
+++ b/common/scripts/user_entrypoint.sh
@@ -6,6 +6,11 @@ export DYNAMORIO_HOME=$tmpdir/DynamoRIO-Linux-10.0.0/
 export PIN_ROOT=$tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit
 export SCARAB_ENABLE_PT_MEMTRACE=1
 export SCARAB_ENABLE_PINPLAY=1
+# SCARAB_ENABLE_PINPLAY links pin_exec against the SDE runtime, whose init reads
+# this and aborts the run without it. The `sde` launcher would set it, but
+# scarab_launch.py runs $PIN_ROOT/pin directly. Derived from PIN_ROOT so an SDE
+# version bump needs no edit here.
+export SDE_GDB_XML="$(dirname "$PIN_ROOT")/misc/gdb-xml"
 export LD_LIBRARY_PATH=$tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/extras/xed-intel64/lib
 export LD_LIBRARY_PATH=$tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/intel64/runtime/pincrt:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$DYNAMORIO_HOME/lib64/release:$LD_LIBRARY_PATH

--- a/common/scripts/user_entrypoint.sh
+++ b/common/scripts/user_entrypoint.sh
@@ -5,11 +5,12 @@ export tmpdir="/tmp_home"
 export DYNAMORIO_HOME=$tmpdir/DynamoRIO-Linux-10.0.0/
 export PIN_ROOT=$tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit
 export SCARAB_ENABLE_PT_MEMTRACE=1
-export SCARAB_ENABLE_PINPLAY=1
-# SCARAB_ENABLE_PINPLAY links pin_exec against the SDE runtime, whose init reads
-# this and aborts the run without it. The `sde` launcher would set it, but
-# scarab_launch.py runs $PIN_ROOT/pin directly. Derived from PIN_ROOT so an SDE
-# version bump needs no edit here.
+# PinPlay is opt-in: export SCARAB_ENABLE_PINPLAY=1 for pinball replay, which
+# runs under SDE's own launcher. Enabling it here made every live exec-driven
+# run use an SDE-linked tool that cannot run under plain `pin`.
+# SDE_GDB_XML costs nothing when PinPlay is off, and sde_init() aborts without
+# it the moment anyone does opt in. Derived from PIN_ROOT so an SDE bump needs
+# no edit here.
 export SDE_GDB_XML="$(dirname "$PIN_ROOT")/misc/gdb-xml"
 export LD_LIBRARY_PATH=$tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/extras/xed-intel64/lib
 export LD_LIBRARY_PATH=$tmpdir/sde-external-9.44.0-2024-08-22-lin/pinkit/intel64/runtime/pincrt:$LD_LIBRARY_PATH


### PR DESCRIPTION
## What actually broke

#435 set `SCARAB_ENABLE_PINPLAY=1` image-wide. That makes `pin_exec` link the
SDE runtime and init through `sde_pin_init()`/`sde_init()` instead of
`PIN_Init()` (`pin_exec.cpp:308`). **That build cannot run a live program under
plain `pin`**, which is how `scarab_launch.py` launches it:

- without `SDE_GDB_XML`: aborts in init (`getenv failed for SDE_GDB_XML`),
- with it set: reaches fast-forward, then dies on
  `SDE ERROR: OSXAVE BIT IS NOT SET IN CPUID`.

SDE's own launcher sets up that CPUID emulation. PinPlay is for replaying a
pinball under `sde`, which is what #581 used it for — not for live exec.

So PinPlay goes back to **opt-in**, exactly as its makefile block documents.
`SDE_GDB_XML` is exported unconditionally: free when PinPlay is off, and
required the moment anyone opts in.

## Why the full SPEC exec suite passed and this still slipped through

Because **which tool a tree produces has been luck**. `make` has no dependency
on `SCARAB_ENABLE_PINPLAY`, so flipping it only re-links; the objects decide.
Trees carried over from before the switch kept the pre-SDE objects and quietly
stayed on the plain tool. Only a *clean* build gets the SDE one.

Every exec run on this cluster since the switch, by tool size:

| experiment | date | tool | result |
| --- | --- | --- | --- |
| exp_dseg5, dseg5base, dseg5fix | 08-25 | 9.4 MB plain | completed |
| exp_dseg5dbg, dseg5dbg2, dseg6, dseg7, exp_specvp | 08-26 | 9.4 MB plain | completed |
| exp_dseg5iso, exp_dseg5t | 08-24 | 17.1 MB SDE | no results |
| weekly_spec17_exec_opt_20260907 | 09-07 | 17.1 MB SDE | no results |

The suite that validated the `-o` knob fix ran on trees with stale objects, so
it exercised the plain tool. The weekly sweep builds from a fresh clone (and
now cleans `src/pin`), so it got the SDE tool and died — the first thing on the
cluster to do a genuinely clean exec build since #435.

## Verified

On ohm/bohr5 through `sci`, same descriptor, same node, only the tool differs:

- plain tool → exec-driven `deepsjeng_r` **finishes**: `Core 0 Finished:
  insts:10000002`, `ramulator.stat.out` 26,754 bytes.
- SDE-linked tool → `SDE ERROR: OSXAVE BIT IS NOT SET IN CPUID`, ramulator file
  0 bytes.

Isolated in the container: SDE tool without `SDE_GDB_XML` aborts in init; with
it, loads and waits for Scarab's socket.

## Corrections to what I said earlier in this thread

- I first reported OSXAVE and SIGILL as artifacts of bohr1 having no AVX-512.
  SIGILL was; **OSXAVE was not** — it reproduces on ohm.
- I then claimed the `SDE_GDB_XML` fix was verified end-to-end on ohm/bohr5.
  It was not: that run silently used the plain 9.4 MB tool, because the tree
  I had rebuilt without the flag still had non-SDE objects. The env fix is
  necessary for anyone opting into PinPlay, but it does not make live exec work.

## Follow-up worth doing (scarab side)

Give the pin tool a make dependency on `SCARAB_ENABLE_PINPLAY` so flipping it
forces a rebuild. Until then "opt-in" still means "whatever objects are lying
around", and a stale tree can hand you either tool with no warning.
