### PR TITLE
CI: run Scarab's simulation workflow instead of a copy of it

### DIFF
--- a/.github/workflows/e2e-sim.yml
+++ b/.github/workflows/e2e-sim.yml
@@ -1,5 +1,8 @@
 name: End-to-End Simulation CI
 
+# The steps live in litz-lab/scarab, so both repositories run exactly the same
+# test: a Scarab PR runs it against scarab-infra main, and this runs it against
+# Scarab main with the PR's own scarab-infra tree.
 on:
   pull_request:
     branches: [main]
@@ -9,90 +12,8 @@ on:
 
 jobs:
   e2e-simulation:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout scarab-infra
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Checkout scarab
-        uses: actions/checkout@v4
-        with:
-          repository: litz-lab/scarab
-          path: scarab
-
-      - name: Allow Git in container
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE/scarab"
-
-      - name: Generate CI descriptor
-        run: |
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          workspace = os.environ["GITHUB_WORKSPACE"]
-          with open("json/top_simpoint.json") as f:
-              d = json.load(f)
-          d["root_dir"] = workspace + "/"
-          d["scarab_path"] = workspace + "/scarab"
-          d["traces_dir"] = workspace + "/traces_top_simpoint"
-          d["application_dir"] = workspace + "/"
-          Path("json/top_simpoint_infra_ci.json").write_text(
-              json.dumps(d, indent=2, separators=(',', ':')) + "\n"
-          )
-          PY
-
-      - name: Initialize environment
-        env:
-          trace_home: ${{ github.workspace }}/traces_top_simpoint
-        run: ./sci --ci-init
-
-      - name: Locate scarabinfra conda env
-        run: |
-          python3 - <<'PY' > env_path.txt
-          import pathlib
-          from importlib.machinery import SourceFileLoader
-          import importlib.util
-
-          script_path = pathlib.Path("sci").resolve()
-          loader = SourceFileLoader("scarab_sci", str(script_path))
-          spec = importlib.util.spec_from_loader("scarab_sci", loader)
-          module = importlib.util.module_from_spec(spec)
-          loader.exec_module(module)
-          env_path, _ = module.resolve_conda_env_path()
-          print(f"SCARABINFRA_ENV={env_path}")
-          PY
-          cat env_path.txt >> "$GITHUB_ENV"
-          rm env_path.txt
-
-      - name: Build Scarab
-        env:
-          trace_home: ${{ github.workspace }}/traces_top_simpoint
-        run: ./sci --build-scarab top_simpoint_infra_ci
-
-      - name: Run simulation
-        env:
-          trace_home: ${{ github.workspace }}/traces_top_simpoint
-        run: ./sci --sim top_simpoint_infra_ci
-
-      - name: Verify simulation status
-        env:
-          trace_home: ${{ github.workspace }}/traces_top_simpoint
-        run: |
-          status_output=$(./sci --status top_simpoint_infra_ci)
-          echo "$status_output"
-          status_line=$(printf '%s\n' "$status_output" | awk -F'|' '/^this_pr[[:space:]]*\|/ {print; exit}')
-          if [ -z "$status_line" ]; then
-            echo "Missing status line for this_pr"
-            exit 1
-          fi
-          completed=$(printf '%s\n' "$status_line" | awk -F'|' '{gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2); print $2}')
-          if [ "$completed" != "1" ]; then
-            echo "Expected 1 completed simulation for this_pr, got '$completed'"
-            exit 1
-          fi
+    uses: litz-lab/scarab/.github/workflows/scarab-sim.yml@main
+    with:
+      sci_id: top_simpoint
+      infra_repository: ${{ github.repository }}
+      infra_ref: ${{ github.sha }}


### PR DESCRIPTION
`e2e-sim.yml` here is a duplicate of litz-lab/scarab's `scarab-sim.yml`: check
out both repositories, `--ci-init`, build, simulate, verify. Two copies drift,
and a change to what CI runs has to be made twice in two repositories.

This calls that workflow instead, passing this repository and sha:

```yaml
jobs:
  e2e-simulation:
    uses: litz-lab/scarab/.github/workflows/scarab-sim.yml@main
    with:
      sci_id: top_simpoint
      infra_repository: ${{ github.repository }}
      infra_ref: ${{ github.sha }}
```

so each repository tests its own merge against the other's main:

| PR in | Scarab tree | scarab-infra tree |
| --- | --- | --- |
| litz-lab/scarab | the PR merged into main (`github.sha`) | main |
| litz-lab/scarab-infra | main | the PR merged into main (`github.sha`) |

**Nothing changes about what is tested** — same descriptor, same single
simulation, and the shared workflow derives the expected completion count from
the descriptor.

Requires **litz-lab/scarab#598** first: `scarab-sim.yml`'s `Checkout Scarab`
step has no `repository:`, so called from here it would check out scarab-infra
as if it were Scarab.

#386 then adds the exec-driven simulation on top, needing no workflow edit at
all.
