### PR TITLE
sci: expire cached scarab binaries nobody has used

### DIFF
--- a/sci
+++ b/sci
@@ -4288,6 +4288,16 @@ def build_parser() -> argparse.ArgumentParser:
              "Exits non-zero on any enabled-check finding.",
     )
     parser.add_argument(
+        "--prune-builds",
+        dest="prune_builds",
+        nargs="?",
+        const=-1,
+        type=int,
+        metavar="DAYS",
+        help="Drop cached scarab binaries unused for DAYS (default 30, or "
+             "$SCI_BUILDS_MAX_AGE_DAYS). Runs automatically on --build-scarab.",
+    )
+    parser.add_argument(
         "--build-image",
         dest="build_image",
         metavar="WORKLOAD_GROUP",
@@ -4390,6 +4400,7 @@ def main() -> int:
         bool(args.build_scarab),
         bool(args.lint_scarab),
         bool(args.build_image),
+        args.prune_builds is not None,
         bool(args.list),
         bool(args.interactive),
         bool(args.trace),
@@ -4443,6 +4454,13 @@ def main() -> int:
         except StepError as exc:
             print(exc)
             return 1
+    if args.prune_builds is not None:
+        infra_utils = load_infra_utilities()
+        days = None if args.prune_builds == -1 else args.prune_builds
+        count, freed = infra_utils.prune_scarab_builds(str(REPO_ROOT), days)
+        print(f"Pruned {count} cached binaries ({freed / 1e9:.1f} GB)")
+        return 0
+
     if args.build_image:
         try:
             return run_build_image(args.build_image)

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -1033,6 +1033,72 @@ def _build_missing_scarab_version(
         raise
 
 # Wrapper function that handles rebuilding scarab if needed, and caching
+SCARAB_BUILDS_MAX_AGE_DAYS = int(os.environ.get("SCI_BUILDS_MAX_AGE_DAYS", "30"))
+
+
+def prune_scarab_builds(infra_dir, max_age_days=None, dbg_lvl=1, dry_run=False):
+    """Drop cached binaries nobody has used in max_age_days.
+
+    The cache is keyed on the scarab git hash, so every commit -- and every
+    amend during a review cycle -- mints another ~124MB entry that nothing ever
+    removes. One checkout reached 81GB in 650 binaries, inside the directory
+    that is also the docker build context.
+
+    Age is taken from mtime, which _touch_cache_hit() refreshes on reuse, so the
+    window means "unused for N days" rather than "built N days ago" -- a
+    long-lived baseline binary that gets reused stays. scarab_current* and
+    whatever they resolve to are kept whatever their age: the portable and avx
+    links legitimately point at builds many months old.
+    """
+    if max_age_days is None:
+        max_age_days = SCARAB_BUILDS_MAX_AGE_DAYS
+    if max_age_days <= 0:
+        return 0, 0
+
+    cache_dir = Path(infra_dir) / "scarab_builds"
+    if not cache_dir.is_dir():
+        return 0, 0
+
+    keep = set()
+    for link in cache_dir.glob("scarab_current*"):
+        keep.add(link.name)
+        try:
+            keep.add(link.resolve().name)
+        except OSError:
+            pass
+
+    cutoff = time.time() - max_age_days * 86400
+    freed = count = 0
+    for entry in cache_dir.iterdir():
+        if entry.name in keep or not entry.is_file() or entry.is_symlink():
+            continue
+        try:
+            st = entry.stat()
+            if st.st_mtime >= cutoff:
+                continue
+            if not dry_run:
+                entry.unlink()
+        except OSError as exc:
+            # Housekeeping must never fail a build.
+            warn(f"Could not prune {entry.name}: {exc}", dbg_lvl)
+            continue
+        freed += st.st_size
+        count += 1
+
+    if count:
+        note(f"{'Would prune' if dry_run else 'Pruned'} {count} cached scarab binaries "
+             f"unused for {max_age_days}+ days ({freed / 1e9:.1f} GB)", dbg_lvl)
+    return count, freed
+
+
+def _touch_cache_hit(path, dbg_lvl=1):
+    """Mark a cached binary as used, so prune_scarab_builds() spares it."""
+    try:
+        os.utime(path, None)
+    except OSError as exc:
+        info(f"Could not refresh mtime on {path}: {exc}", dbg_lvl)
+
+
 def rebuild_scarab(infra_dir, scarab_path, user, docker_home, docker_prefix, scarab_githash, scarab_build, stream_build=False, dbg_lvl=1):
     build_mode = scarab_build if scarab_build else "opt"
     current_cache_name = _cache_bin_name("scarab_current", build_mode)
@@ -1083,6 +1149,8 @@ def rebuild_scarab(infra_dir, scarab_path, user, docker_home, docker_prefix, sca
 
                 if diff_matches and hash_tag_matches:
                     print("Found recent Scarab binary, no build required")
+                    _touch_cache_hit(current_scarab_bin, dbg_lvl)
+                    prune_scarab_builds(infra_dir, dbg_lvl=dbg_lvl)
                     return
                 if result.returncode == 1 or not hash_tag_matches:
                     info("Cached scarab_current differs from repo binary; rebuilding.", dbg_lvl)
@@ -1240,6 +1308,7 @@ def rebuild_scarab(infra_dir, scarab_path, user, docker_home, docker_prefix, sca
         err(f"Scarab binary for current hash not found in cache after building", dbg_lvl)
         exit(1)
 
+    prune_scarab_builds(infra_dir, dbg_lvl=dbg_lvl)
     print("Scarab build successful!")
 
 # copy_scarab deprecated


### PR DESCRIPTION
`scarab_builds/` is keyed on the scarab git hash, so every commit — and every amend during a review cycle — mints another ~124MB binary, and nothing ever removed them.

My checkout had reached **81GB in 650 binaries**, oldest ten months old:

| | count | size |
| --- | --: | --: |
| scarab binaries | 650 | 81.4 GB |
| pin_exec tools | 537 | 5.1 GB |
| **older than 30 days** | **664** | **50.4 GB** |

That directory is also the docker build context (`docker build $REPO_ROOT`), which is how it turns into a job failure rather than just wasted disk: a node without the workload image falls back to building it, streams the context, and dies on the Slurm per-job memory limit — `exceeded memory limit (2130657280 > 1989148672)`. `.dockerignore` does exclude `scarab_builds/`, so that part is belt-and-braces, but an 81GB cache inside a build context is a standing hazard.

## What this does

- prunes on `--build-scarab`, on both the cache-hit and post-build paths, so it runs exactly when the cache grows
- `--prune-builds [DAYS]` for manual or cron use; `$SCI_BUILDS_MAX_AGE_DAYS` or the argument overrides the 30-day default
- **a cache hit refreshes the binary's mtime**, so the window means "unused for N days" rather than "built N days ago" — a long-lived baseline binary that gets reused is not expired out from under you
- `scarab_current*` and whatever they resolve to are kept **at any age**. This one matters: `scarab_current.opt-portable` points at an April build, so a plain mtime sweep would break it
- errors warn and continue — housekeeping must never fail a build
- `prune_scarab_builds(..., dry_run=True)` reports without deleting

## Verified

Synthetic cache with a 200-day-old symlink target, a 200-day-old orphan, and a fresh binary: dry run deletes nothing, real run removes only the orphan and spares the ancient symlink target. On the real cache, 50.1GB reclaimed (81G → 34G) with all four `scarab_current*` links still resolving.

Regeneration caveat worth stating: a pruned binary is only reproducible if its commit is still reachable. Much of what accumulates here is amend/rebase intermediates whose objects are gone, and unpinned build inputs (DynamoRIO clone, pin download, `apt install`) mean even a reachable commit rebuilds only functionally, not bit-, identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)